### PR TITLE
Add mouse click support for task cards in kanban board

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -399,7 +399,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.MouseMsg:
-		// Handle notification click on dashboard
+		// Handle mouse clicks on dashboard view
 		if m.currentView == ViewDashboard && msg.Action == tea.MouseActionRelease && msg.Button == tea.MouseButtonLeft {
 			// Check if notification banner is visible and click is on it (row 0)
 			if m.notification != "" && time.Now().Before(m.notifyUntil) && m.notificationTaskID > 0 {
@@ -407,6 +407,10 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// Click on notification banner - open task detail view
 					return m, m.loadTask(m.notificationTaskID)
 				}
+			}
+			// Check if clicking on a task card
+			if task := m.kanban.HandleClick(msg.X, msg.Y); task != nil {
+				return m, m.loadTask(task.ID)
 			}
 		}
 

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -463,3 +463,76 @@ func (k *KanbanBoard) FocusColumn(colIdx int) {
 func (k *KanbanBoard) ColumnCount() int {
 	return len(k.columns)
 }
+
+// HandleClick handles a mouse click at the given coordinates.
+// Returns the clicked task if a task card was clicked, nil otherwise.
+// Also updates the selection to the clicked task.
+func (k *KanbanBoard) HandleClick(x, y int) *db.Task {
+	if k.width < 40 || k.height < 10 {
+		return nil
+	}
+
+	// Calculate column layout (same as View())
+	numCols := len(k.columns)
+	availableWidth := k.width - (numCols * 2) - (numCols - 1)
+	colWidth := availableWidth / numCols
+	if colWidth < 20 {
+		colWidth = 20
+	}
+
+	// Each column has: 1 border + colWidth content + 1 border = colWidth + 2
+	// Columns are joined with no gap between them in lipgloss.JoinHorizontal
+	colTotalWidth := colWidth + 2
+
+	// Determine which column was clicked
+	colIdx := x / colTotalWidth
+	if colIdx >= numCols {
+		colIdx = numCols - 1
+	}
+	if colIdx < 0 {
+		return nil
+	}
+
+	// Check if click is within column bounds (not on border)
+	colStartX := colIdx * colTotalWidth
+	relX := x - colStartX
+	if relX < 1 || relX > colWidth {
+		// Clicked on border
+		return nil
+	}
+
+	// Calculate Y position within column
+	// Column structure: 1 border line, then header (2 lines with margin), then task cards
+	// Border is 1 line at top
+	headerLines := 3 // Header text + margin
+	taskCardHeight := 3
+
+	// relY is position within the column content (after top border)
+	relY := y - 1 // -1 for top border
+
+	// Skip header area
+	taskAreaY := relY - headerLines
+	if taskAreaY < 0 {
+		// Clicked on header
+		return nil
+	}
+
+	// Calculate which task was clicked
+	col := k.columns[colIdx]
+	colHeight := k.height - 2
+	maxTasks := (colHeight - 4) / taskCardHeight
+	if maxTasks < 1 {
+		maxTasks = 1
+	}
+
+	taskIdx := taskAreaY / taskCardHeight
+	if taskIdx >= len(col.Tasks) || taskIdx >= maxTasks {
+		return nil
+	}
+
+	// Update selection
+	k.selectedCol = colIdx
+	k.selectedRow = taskIdx
+
+	return col.Tasks[taskIdx]
+}

--- a/internal/ui/kanban_test.go
+++ b/internal/ui/kanban_test.go
@@ -47,3 +47,145 @@ func TestKanbanBoard_ColumnCount(t *testing.T) {
 		t.Errorf("ColumnCount() = %d, want 4", got)
 	}
 }
+
+func TestKanbanBoard_HandleClick(t *testing.T) {
+	board := NewKanbanBoard(100, 50)
+
+	// Set up some tasks in different columns
+	tasks := []*db.Task{
+		{ID: 1, Title: "Backlog Task 1", Status: db.StatusBacklog},
+		{ID: 2, Title: "Backlog Task 2", Status: db.StatusBacklog},
+		{ID: 3, Title: "In Progress Task", Status: db.StatusQueued},
+		{ID: 4, Title: "Blocked Task", Status: db.StatusBlocked},
+		{ID: 5, Title: "Done Task", Status: db.StatusDone},
+	}
+	board.SetTasks(tasks)
+
+	// Calculate column width for test assertions
+	// 4 columns, width 100, accounting for borders and gaps
+	numCols := 4
+	availableWidth := 100 - (numCols * 2) - (numCols - 1)
+	colWidth := availableWidth / numCols
+	colTotalWidth := colWidth + 2
+
+	tests := []struct {
+		name       string
+		x          int
+		y          int
+		wantTaskID int64
+		wantNil    bool
+	}{
+		{
+			name:       "click on first task in backlog column",
+			x:          colTotalWidth/2,           // Middle of first column
+			y:          5,                          // After header (1 border + 3 header = 4, so y=5 is first task)
+			wantTaskID: 1,
+		},
+		{
+			name:       "click on second task in backlog column",
+			x:          colTotalWidth/2,           // Middle of first column
+			y:          8,                          // Second task (card height = 3)
+			wantTaskID: 2,
+		},
+		{
+			name:       "click on task in second column (in progress)",
+			x:          colTotalWidth + colTotalWidth/2, // Middle of second column
+			y:          5,
+			wantTaskID: 3,
+		},
+		{
+			name:       "click on task in third column (blocked)",
+			x:          2*colTotalWidth + colTotalWidth/2, // Middle of third column
+			y:          5,
+			wantTaskID: 4,
+		},
+		{
+			name:       "click on task in fourth column (done)",
+			x:          3*colTotalWidth + colTotalWidth/2, // Middle of fourth column
+			y:          5,
+			wantTaskID: 5,
+		},
+		{
+			name:    "click on header area returns nil",
+			x:       colTotalWidth / 2,
+			y:       2, // Header area
+			wantNil: true,
+		},
+		{
+			name:    "click below tasks returns nil",
+			x:       colTotalWidth / 2,
+			y:       45, // Way below tasks
+			wantNil: true,
+		},
+		{
+			name:    "terminal too small returns nil",
+			x:       5,
+			y:       5,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset board size for most tests
+			if tt.name == "terminal too small returns nil" {
+				board.SetSize(30, 5) // Too small
+			} else {
+				board.SetSize(100, 50)
+			}
+
+			task := board.HandleClick(tt.x, tt.y)
+
+			if tt.wantNil {
+				if task != nil {
+					t.Errorf("HandleClick(%d, %d) = task %d, want nil", tt.x, tt.y, task.ID)
+				}
+			} else {
+				if task == nil {
+					t.Errorf("HandleClick(%d, %d) = nil, want task %d", tt.x, tt.y, tt.wantTaskID)
+				} else if task.ID != tt.wantTaskID {
+					t.Errorf("HandleClick(%d, %d) = task %d, want task %d", tt.x, tt.y, task.ID, tt.wantTaskID)
+				}
+			}
+		})
+	}
+}
+
+func TestKanbanBoard_HandleClickUpdatesSelection(t *testing.T) {
+	board := NewKanbanBoard(100, 50)
+
+	tasks := []*db.Task{
+		{ID: 1, Title: "Task 1", Status: db.StatusBacklog},
+		{ID: 2, Title: "Task 2", Status: db.StatusQueued},
+	}
+	board.SetTasks(tasks)
+
+	// Click on task in second column
+	numCols := 4
+	availableWidth := 100 - (numCols * 2) - (numCols - 1)
+	colWidth := availableWidth / numCols
+	colTotalWidth := colWidth + 2
+
+	x := colTotalWidth + colTotalWidth/2 // Middle of second column
+	y := 5                                // First task position
+
+	task := board.HandleClick(x, y)
+
+	if task == nil {
+		t.Fatal("HandleClick returned nil, expected task")
+	}
+
+	// Verify selection was updated
+	if board.selectedCol != 1 {
+		t.Errorf("selectedCol = %d, want 1", board.selectedCol)
+	}
+	if board.selectedRow != 0 {
+		t.Errorf("selectedRow = %d, want 0", board.selectedRow)
+	}
+
+	// Verify SelectedTask returns the same task
+	selectedTask := board.SelectedTask()
+	if selectedTask == nil || selectedTask.ID != task.ID {
+		t.Errorf("SelectedTask() = %v, want task %d", selectedTask, task.ID)
+	}
+}


### PR DESCRIPTION
## Summary
- Users can now click on task cards in the kanban board to open the task detail view
- Adds `HandleClick` method to KanbanBoard for detecting clicked tasks based on coordinates
- Handles `tea.MouseMsg` events in the app to trigger task loading on click

## Test plan
- [x] Added unit tests for click position detection across all columns
- [x] Tests verify clicking on headers/empty areas returns nil
- [x] Tests verify selection state is updated on click
- [ ] Manual testing: click on tasks in each column to verify detail view opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)