### PR TITLE
Add PR status display for tasks with associated pull requests

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -1,0 +1,282 @@
+// Package github provides GitHub integration for querying PR status.
+package github
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// PRState represents the state of a pull request.
+type PRState string
+
+const (
+	PRStateOpen   PRState = "OPEN"
+	PRStateClosed PRState = "CLOSED"
+	PRStateMerged PRState = "MERGED"
+	PRStateDraft  PRState = "DRAFT"
+)
+
+// CheckState represents the state of CI checks.
+type CheckState string
+
+const (
+	CheckStatePending CheckState = "PENDING"
+	CheckStatePassing CheckState = "SUCCESS"
+	CheckStateFailing CheckState = "FAILURE"
+	CheckStateNone    CheckState = ""
+)
+
+// PRInfo contains information about a pull request.
+type PRInfo struct {
+	Number     int        `json:"number"`
+	URL        string     `json:"url"`
+	State      PRState    `json:"state"`
+	IsDraft    bool       `json:"isDraft"`
+	Title      string     `json:"title"`
+	CheckState CheckState `json:"checkState"`
+	Mergeable  string     `json:"mergeable"` // "MERGEABLE", "CONFLICTING", "UNKNOWN"
+	UpdatedAt  time.Time  `json:"updatedAt"`
+}
+
+// ghPRResponse is the JSON response from gh pr view.
+type ghPRResponse struct {
+	Number              int    `json:"number"`
+	URL                 string `json:"url"`
+	State               string `json:"state"`
+	IsDraft             bool   `json:"isDraft"`
+	Title               string `json:"title"`
+	MergeStateStatus    string `json:"mergeStateStatus"`
+	StatusCheckRollup   []ghCheck `json:"statusCheckRollup"`
+	UpdatedAt           string `json:"updatedAt"`
+}
+
+type ghCheck struct {
+	State      string `json:"state"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+// PRCache caches PR information to avoid repeated API calls.
+type PRCache struct {
+	mu    sync.RWMutex
+	cache map[string]*cacheEntry
+}
+
+type cacheEntry struct {
+	info      *PRInfo
+	fetchedAt time.Time
+}
+
+const cacheTTL = 30 * time.Second
+
+// NewPRCache creates a new PR cache.
+func NewPRCache() *PRCache {
+	return &PRCache{
+		cache: make(map[string]*cacheEntry),
+	}
+}
+
+// GetPRForBranch queries GitHub for a PR associated with the given branch.
+// Uses caching to avoid repeated API calls.
+// Returns nil if no PR exists or gh CLI is not available.
+func (c *PRCache) GetPRForBranch(repoDir, branchName string) *PRInfo {
+	if branchName == "" {
+		return nil
+	}
+
+	cacheKey := repoDir + ":" + branchName
+
+	// Check cache first
+	c.mu.RLock()
+	entry, ok := c.cache[cacheKey]
+	c.mu.RUnlock()
+
+	if ok && time.Since(entry.fetchedAt) < cacheTTL {
+		return entry.info
+	}
+
+	// Fetch from GitHub
+	info := fetchPRInfo(repoDir, branchName)
+
+	// Update cache
+	c.mu.Lock()
+	c.cache[cacheKey] = &cacheEntry{
+		info:      info,
+		fetchedAt: time.Now(),
+	}
+	c.mu.Unlock()
+
+	return info
+}
+
+// InvalidateCache clears the cache for a specific branch.
+func (c *PRCache) InvalidateCache(repoDir, branchName string) {
+	cacheKey := repoDir + ":" + branchName
+	c.mu.Lock()
+	delete(c.cache, cacheKey)
+	c.mu.Unlock()
+}
+
+// fetchPRInfo queries GitHub for PR information using gh CLI.
+func fetchPRInfo(repoDir, branchName string) *PRInfo {
+	// Check if gh CLI is available
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil
+	}
+
+	// Query for PR associated with this branch
+	// gh pr view <branch> --json number,url,state,isDraft,title,mergeStateStatus,statusCheckRollup,updatedAt
+	cmd := exec.Command("gh", "pr", "view", branchName,
+		"--json", "number,url,state,isDraft,title,mergeStateStatus,statusCheckRollup,updatedAt")
+	cmd.Dir = repoDir
+
+	output, err := cmd.Output()
+	if err != nil {
+		// No PR exists for this branch or other error
+		return nil
+	}
+
+	var resp ghPRResponse
+	if err := json.Unmarshal(output, &resp); err != nil {
+		return nil
+	}
+
+	// Parse the response
+	info := &PRInfo{
+		Number:    resp.Number,
+		URL:       resp.URL,
+		Title:     resp.Title,
+		IsDraft:   resp.IsDraft,
+		Mergeable: resp.MergeStateStatus,
+	}
+
+	// Parse state
+	switch strings.ToUpper(resp.State) {
+	case "OPEN":
+		if resp.IsDraft {
+			info.State = PRStateDraft
+		} else {
+			info.State = PRStateOpen
+		}
+	case "CLOSED":
+		info.State = PRStateClosed
+	case "MERGED":
+		info.State = PRStateMerged
+	default:
+		info.State = PRStateOpen
+	}
+
+	// Parse check state from statusCheckRollup
+	info.CheckState = parseCheckState(resp.StatusCheckRollup)
+
+	// Parse updated time
+	if t, err := time.Parse(time.RFC3339, resp.UpdatedAt); err == nil {
+		info.UpdatedAt = t
+	}
+
+	return info
+}
+
+// parseCheckState determines the overall check state from individual checks.
+func parseCheckState(checks []ghCheck) CheckState {
+	if len(checks) == 0 {
+		return CheckStateNone
+	}
+
+	hasFailure := false
+	hasPending := false
+
+	for _, check := range checks {
+		// For status checks, look at state
+		// For check runs, look at conclusion
+		conclusion := strings.ToUpper(check.Conclusion)
+		state := strings.ToUpper(check.State)
+		status := strings.ToUpper(check.Status)
+
+		// Check if pending
+		if status == "QUEUED" || status == "IN_PROGRESS" || status == "PENDING" ||
+			state == "PENDING" || state == "EXPECTED" {
+			hasPending = true
+			continue
+		}
+
+		// Check if failed
+		if conclusion == "FAILURE" || conclusion == "ERROR" || conclusion == "TIMED_OUT" ||
+			conclusion == "CANCELLED" || state == "FAILURE" || state == "ERROR" {
+			hasFailure = true
+		}
+	}
+
+	if hasFailure {
+		return CheckStateFailing
+	}
+	if hasPending {
+		return CheckStatePending
+	}
+	return CheckStatePassing
+}
+
+// StatusIcon returns a unicode icon representing the PR state.
+func (p *PRInfo) StatusIcon() string {
+	if p == nil {
+		return ""
+	}
+
+	switch p.State {
+	case PRStateMerged:
+		return "M" // Merged
+	case PRStateClosed:
+		return "X" // Closed
+	case PRStateDraft:
+		return "D" // Draft
+	case PRStateOpen:
+		switch p.CheckState {
+		case CheckStatePassing:
+			return "P" // PR open, checks passing
+		case CheckStateFailing:
+			return "F" // PR open, checks failing
+		case CheckStatePending:
+			return "R" // PR open, checks running
+		default:
+			return "O" // PR open, no checks
+		}
+	}
+	return ""
+}
+
+// StatusDescription returns a human-readable description.
+func (p *PRInfo) StatusDescription() string {
+	if p == nil {
+		return ""
+	}
+
+	switch p.State {
+	case PRStateMerged:
+		return "Merged"
+	case PRStateClosed:
+		return "Closed"
+	case PRStateDraft:
+		return "Draft PR"
+	case PRStateOpen:
+		switch p.CheckState {
+		case CheckStatePassing:
+			if p.Mergeable == "MERGEABLE" {
+				return "Ready to merge"
+			}
+			if p.Mergeable == "CONFLICTING" {
+				return "Has conflicts"
+			}
+			return "Checks passing"
+		case CheckStateFailing:
+			return "Checks failing"
+		case CheckStatePending:
+			return "Checks running"
+		default:
+			return "Open PR"
+		}
+	}
+	return ""
+}

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -1,0 +1,266 @@
+package github
+
+import (
+	"testing"
+)
+
+func TestPRStateConstants(t *testing.T) {
+	// Verify state constants are defined
+	states := []PRState{PRStateOpen, PRStateClosed, PRStateMerged, PRStateDraft}
+	for _, s := range states {
+		if s == "" {
+			t.Errorf("PR state constant should not be empty")
+		}
+	}
+}
+
+func TestCheckStateConstants(t *testing.T) {
+	// Verify check state constants
+	states := []CheckState{CheckStatePending, CheckStatePassing, CheckStateFailing, CheckStateNone}
+	// CheckStateNone is intentionally empty
+	if CheckStatePending == "" {
+		t.Errorf("CheckStatePending should not be empty")
+	}
+	if CheckStatePassing == "" {
+		t.Errorf("CheckStatePassing should not be empty")
+	}
+	if CheckStateFailing == "" {
+		t.Errorf("CheckStateFailing should not be empty")
+	}
+	if CheckStateNone != "" {
+		t.Errorf("CheckStateNone should be empty")
+	}
+	_ = states
+}
+
+func TestNewPRCache(t *testing.T) {
+	cache := NewPRCache()
+	if cache == nil {
+		t.Fatal("NewPRCache returned nil")
+	}
+	if cache.cache == nil {
+		t.Error("cache map should be initialized")
+	}
+}
+
+func TestPRCacheGetMissingBranch(t *testing.T) {
+	cache := NewPRCache()
+
+	// Empty branch name should return nil
+	info := cache.GetPRForBranch("/some/repo", "")
+	if info != nil {
+		t.Error("empty branch name should return nil")
+	}
+}
+
+func TestPRInfoStatusIcon(t *testing.T) {
+	tests := []struct {
+		name     string
+		prInfo   *PRInfo
+		expected string
+	}{
+		{
+			name:     "nil PR",
+			prInfo:   nil,
+			expected: "",
+		},
+		{
+			name:     "merged PR",
+			prInfo:   &PRInfo{State: PRStateMerged},
+			expected: "M",
+		},
+		{
+			name:     "closed PR",
+			prInfo:   &PRInfo{State: PRStateClosed},
+			expected: "X",
+		},
+		{
+			name:     "draft PR",
+			prInfo:   &PRInfo{State: PRStateDraft},
+			expected: "D",
+		},
+		{
+			name:     "open PR with passing checks",
+			prInfo:   &PRInfo{State: PRStateOpen, CheckState: CheckStatePassing},
+			expected: "P",
+		},
+		{
+			name:     "open PR with failing checks",
+			prInfo:   &PRInfo{State: PRStateOpen, CheckState: CheckStateFailing},
+			expected: "F",
+		},
+		{
+			name:     "open PR with pending checks",
+			prInfo:   &PRInfo{State: PRStateOpen, CheckState: CheckStatePending},
+			expected: "R",
+		},
+		{
+			name:     "open PR with no checks",
+			prInfo:   &PRInfo{State: PRStateOpen, CheckState: CheckStateNone},
+			expected: "O",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.prInfo.StatusIcon()
+			if got != tt.expected {
+				t.Errorf("StatusIcon() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPRInfoStatusDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		prInfo   *PRInfo
+		expected string
+	}{
+		{
+			name:     "nil PR",
+			prInfo:   nil,
+			expected: "",
+		},
+		{
+			name:     "merged PR",
+			prInfo:   &PRInfo{State: PRStateMerged},
+			expected: "Merged",
+		},
+		{
+			name:     "closed PR",
+			prInfo:   &PRInfo{State: PRStateClosed},
+			expected: "Closed",
+		},
+		{
+			name:     "draft PR",
+			prInfo:   &PRInfo{State: PRStateDraft},
+			expected: "Draft PR",
+		},
+		{
+			name:     "open PR ready to merge",
+			prInfo:   &PRInfo{State: PRStateOpen, CheckState: CheckStatePassing, Mergeable: "MERGEABLE"},
+			expected: "Ready to merge",
+		},
+		{
+			name:     "open PR with conflicts",
+			prInfo:   &PRInfo{State: PRStateOpen, CheckState: CheckStatePassing, Mergeable: "CONFLICTING"},
+			expected: "Has conflicts",
+		},
+		{
+			name:     "open PR with failing checks",
+			prInfo:   &PRInfo{State: PRStateOpen, CheckState: CheckStateFailing},
+			expected: "Checks failing",
+		},
+		{
+			name:     "open PR with pending checks",
+			prInfo:   &PRInfo{State: PRStateOpen, CheckState: CheckStatePending},
+			expected: "Checks running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.prInfo.StatusDescription()
+			if got != tt.expected {
+				t.Errorf("StatusDescription() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseCheckState(t *testing.T) {
+	tests := []struct {
+		name     string
+		checks   []ghCheck
+		expected CheckState
+	}{
+		{
+			name:     "no checks",
+			checks:   nil,
+			expected: CheckStateNone,
+		},
+		{
+			name:     "empty checks",
+			checks:   []ghCheck{},
+			expected: CheckStateNone,
+		},
+		{
+			name: "all passing",
+			checks: []ghCheck{
+				{Conclusion: "SUCCESS"},
+				{Conclusion: "SUCCESS"},
+			},
+			expected: CheckStatePassing,
+		},
+		{
+			name: "one failing",
+			checks: []ghCheck{
+				{Conclusion: "SUCCESS"},
+				{Conclusion: "FAILURE"},
+			},
+			expected: CheckStateFailing,
+		},
+		{
+			name: "one pending",
+			checks: []ghCheck{
+				{Conclusion: "SUCCESS"},
+				{Status: "IN_PROGRESS"},
+			},
+			expected: CheckStatePending,
+		},
+		{
+			name: "pending and failing - failure wins",
+			checks: []ghCheck{
+				{Status: "IN_PROGRESS"},
+				{Conclusion: "FAILURE"},
+			},
+			expected: CheckStateFailing,
+		},
+		{
+			name: "error state",
+			checks: []ghCheck{
+				{Conclusion: "ERROR"},
+			},
+			expected: CheckStateFailing,
+		},
+		{
+			name: "timed out",
+			checks: []ghCheck{
+				{Conclusion: "TIMED_OUT"},
+			},
+			expected: CheckStateFailing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCheckState(tt.checks)
+			if got != tt.expected {
+				t.Errorf("parseCheckState() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPRCacheInvalidate(t *testing.T) {
+	cache := NewPRCache()
+
+	// Add an entry manually
+	cache.cache["test:branch"] = &cacheEntry{
+		info: &PRInfo{Number: 1},
+	}
+
+	// Verify it exists
+	if len(cache.cache) != 1 {
+		t.Error("cache should have 1 entry")
+	}
+
+	// Invalidate it
+	cache.InvalidateCache("test", "branch")
+
+	// Verify it's gone
+	if len(cache.cache) != 0 {
+		t.Error("cache should be empty after invalidation")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/executor"
+	"github.com/bborn/workflow/internal/github"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -223,6 +224,9 @@ type AppModel struct {
 	watcher   *fsnotify.Watcher
 	dbChangeCh chan struct{}
 
+	// PR status cache
+	prCache *github.PRCache
+
 	// Number filter for quick task ID jump
 	numberFilter string
 
@@ -312,6 +316,7 @@ func NewAppModel(database *db.DB, exec *executor.Executor, workingDir string) *A
 		prevStatuses: make(map[int64]string),
 		watcher:      watcher,
 		dbChangeCh:   dbChangeCh,
+		prCache:      github.NewPRCache(),
 	}
 }
 
@@ -427,7 +432,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			m.prevStatuses[t.ID] = t.Status
-			
+
 			// Update detail view if showing this task
 			if m.selectedTask != nil && m.selectedTask.ID == t.ID {
 				m.selectedTask = t
@@ -439,6 +444,9 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.kanban.SetTasks(m.tasks)
 
+		// Fetch PR info for tasks with branches
+		cmds = append(cmds, m.fetchAllPRInfo()...)
+
 	case taskLoadedMsg:
 		if msg.err == nil {
 			m.selectedTask = msg.task
@@ -449,8 +457,22 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if tickerCmd := m.detailView.StartTmuxTicker(); tickerCmd != nil {
 				cmds = append(cmds, tickerCmd)
 			}
+			// Fetch PR info for the task
+			if prCmd := m.fetchPRInfo(msg.task); prCmd != nil {
+				cmds = append(cmds, prCmd)
+			}
 		} else {
 			m.err = msg.err
+		}
+
+	case prInfoMsg:
+		// Update PR info in kanban and detail view
+		if msg.info != nil {
+			m.kanban.SetPRInfo(msg.taskID, msg.info)
+			// Update detail view if showing this task
+			if m.detailView != nil && m.selectedTask != nil && m.selectedTask.ID == msg.taskID {
+				m.detailView.SetPRInfo(msg.info)
+			}
 		}
 
 	case taskCreatedMsg:
@@ -1285,6 +1307,11 @@ type tickMsg time.Time
 
 type dbChangeMsg struct{}
 
+type prInfoMsg struct {
+	taskID int64
+	info   *github.PRInfo
+}
+
 func (m *AppModel) loadTasks() tea.Cmd {
 	return func() tea.Msg {
 		tasks, err := m.db.ListTasks(db.ListTasksOptions{Limit: 50, IncludeClosed: true})
@@ -1518,6 +1545,42 @@ func (m *AppModel) tick() tea.Cmd {
 	return tea.Tick(1*time.Second, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
+}
+
+// fetchPRInfo fetches PR info for a single task.
+func (m *AppModel) fetchPRInfo(task *db.Task) tea.Cmd {
+	if task.BranchName == "" || m.prCache == nil {
+		return nil
+	}
+
+	// Get the worktree or project directory for gh CLI
+	repoDir := task.WorktreePath
+	if repoDir == "" {
+		repoDir = m.executor.GetProjectDir(task.Project)
+	}
+	if repoDir == "" {
+		return nil
+	}
+
+	prCache := m.prCache
+	taskID := task.ID
+	branchName := task.BranchName
+
+	return func() tea.Msg {
+		info := prCache.GetPRForBranch(repoDir, branchName)
+		return prInfoMsg{taskID: taskID, info: info}
+	}
+}
+
+// fetchAllPRInfo returns commands to fetch PR info for all tasks with branches.
+func (m *AppModel) fetchAllPRInfo() []tea.Cmd {
+	var cmds []tea.Cmd
+	for _, task := range m.tasks {
+		if cmd := m.fetchPRInfo(task); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return cmds
 }
 
 // startDatabaseWatcher starts watching the database file for changes.

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/github"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -27,6 +28,7 @@ type KanbanBoard struct {
 	allTasks      []*db.Task // All tasks for filtering
 	filteredTasks []*db.Task // Tasks after applying text filter
 	textFilter    string     // Current text filter
+	prInfo        map[int64]*github.PRInfo // PR info by task ID
 }
 
 // NewKanbanBoard creates a new kanban board.
@@ -35,6 +37,7 @@ func NewKanbanBoard(width, height int) *KanbanBoard {
 		columns: makeKanbanColumns(),
 		width:   width,
 		height:  height,
+		prInfo:  make(map[int64]*github.PRInfo),
 	}
 }
 
@@ -62,6 +65,22 @@ func (k *KanbanBoard) RefreshTheme() {
 func (k *KanbanBoard) SetTasks(tasks []*db.Task) {
 	k.allTasks = tasks
 	k.applyFilter()
+}
+
+// SetPRInfo updates the PR info for a task.
+func (k *KanbanBoard) SetPRInfo(taskID int64, info *github.PRInfo) {
+	if k.prInfo == nil {
+		k.prInfo = make(map[int64]*github.PRInfo)
+	}
+	k.prInfo[taskID] = info
+}
+
+// GetPRInfo returns the PR info for a task.
+func (k *KanbanBoard) GetPRInfo(taskID int64) *github.PRInfo {
+	if k.prInfo == nil {
+		return nil
+	}
+	return k.prInfo[taskID]
 }
 
 // applyFilter filters tasks and distributes them to columns.
@@ -318,6 +337,12 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool) 
 		}
 		b.WriteString(" ")
 		b.WriteString(projectStyle.Render("[" + shortProject + "]"))
+	}
+
+	// PR status indicator
+	if prInfo := k.prInfo[task.ID]; prInfo != nil {
+		b.WriteString(" ")
+		b.WriteString(PRStatusBadge(prInfo))
 	}
 
 	// Title (truncate if needed)


### PR DESCRIPTION
- Create new internal/github package to query PR status via gh CLI
- Add PRCache for efficient PR info retrieval with 30s TTL
- Display PR status badge on kanban cards (M=merged, D=draft, P=passing, etc)
- Show PR status and link in task detail view header
- Fetch PR info asynchronously when tasks load to avoid blocking UI

PR status indicators:
- M (purple): Merged
- X (red): Closed
- D (gray): Draft
- R (green): Ready to merge (checks passing, mergeable)
- P (green): Checks passing
- F (red): Checks failing
- W (yellow): Checks running/pending
- C (red): Has conflicts
- O (green): Open, no checks