### PR TITLE
Fix kanban column header width alignment

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -228,8 +228,9 @@ func (k *KanbanBoard) View() string {
 		isSelectedCol := colIdx == k.selectedCol
 
 		// Colored header bar at top of column
+		// Width is colWidth + 2 to match the column's total width (content + left/right borders)
 		headerBarStyle := lipgloss.NewStyle().
-			Width(colWidth).
+			Width(colWidth + 2).
 			Background(col.Color).
 			Foreground(lipgloss.Color("#000000")).
 			Bold(true).


### PR DESCRIPTION
## Summary
- Fixed kanban column layout misalignment where headers were narrower than column content
- The header bar width was `colWidth` but columns have borders adding 2 characters, making total width `colWidth + 2`
- Updated header width to `colWidth + 2` to match column total width

## Test plan
- [x] Build passes
- [x] Kanban tests pass
- [ ] Visually verify columns are properly aligned in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)