### PR TITLE
Make attachments accessible to task's Claude

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -494,7 +494,7 @@ func (e *Executor) getAttachmentsSection(taskID int64, paths []string) string {
 	for _, p := range paths {
 		section.WriteString(fmt.Sprintf("- %s\n", p))
 	}
-	section.WriteString("\nYou can view these files using the View tool.\n\n")
+	section.WriteString("\nYou can read these files using the Read tool.\n\n")
 	return section.String()
 }
 


### PR DESCRIPTION
## Summary
- Fix attachment prompt to reference "Read tool" instead of "View tool" (Claude Code uses Read, not View)
- When retrying a task with attachments while the Claude session is alive, write attachment files to `.task-attachments` directory and include paths in feedback sent to Claude
- Add tests for attachment functionality

## Test plan
- [x] Verify tests pass (`go test ./internal/executor/...`)
- [ ] Create a task with attachments and verify Claude can read them
- [ ] Add attachments during a retry and verify Claude receives the file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)