### PR TITLE
Allow task editing from detail view

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -460,6 +460,7 @@ func (m *DetailModel) renderHelp() string {
 		key  string
 		desc string
 	}{
+		{"e", "edit"},
 		{"r", "retry"},
 		{"c", "close"},
 		{"d", "delete"},


### PR DESCRIPTION
## Summary
- Add ability to edit existing tasks by pressing `e` in the task detail view
- Opens a pre-populated form with the task's current title, body, project, type, and priority
- On save, updates the task while preserving ID, status, worktree, branch, and timestamps

## Test plan
- [ ] Open a task in the detail view
- [ ] Press `e` to open the edit form
- [ ] Verify form is pre-populated with current task data
- [ ] Edit fields and submit with `Ctrl+S`
- [ ] Verify task is updated and detail view reflects changes
- [ ] Test canceling with `Esc` returns to detail view without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)