### PR TITLE
Fix task panes visibility when leaving task detail view

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -977,6 +977,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		task := m.selectedTask
 		if task.Status == db.StatusBlocked || task.Status == db.StatusDone ||
 			task.Status == db.StatusBacklog {
+			// Clean up panes before leaving detail view
+			if m.detailView != nil {
+				m.detailView.Cleanup()
+			}
 			m.retryView = NewRetryModel(task, m.db, m.width, m.height)
 			m.previousView = m.currentView
 			m.currentView = ViewRetry
@@ -988,6 +992,9 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.selectedTask.Status = db.StatusDone
 		if m.detailView != nil {
 			m.detailView.UpdateTask(m.selectedTask)
+			// Clean up panes before leaving detail view
+			m.detailView.Cleanup()
+			m.detailView = nil
 		}
 		// Update task in the list and kanban
 		m.updateTaskInList(m.selectedTask)
@@ -1023,6 +1030,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.openTaskDir(m.selectedTask)
 	}
 	if key.Matches(keyMsg, m.keys.Files) && m.selectedTask != nil {
+		// Clean up panes before leaving detail view
+		if m.detailView != nil {
+			m.detailView.Cleanup()
+		}
 		m.attachmentsView = NewAttachmentsModel(m.selectedTask, m.db, m.width, m.height)
 		m.previousView = m.currentView
 		m.currentView = ViewAttachments


### PR DESCRIPTION
## Summary
- Clean up tmux panes (Claude and shell panes) when navigating away from the task detail view
- Previously, panes would remain visible when opening retry dialog, attachments view, or closing a task
- Now panes are properly hidden when leaving detail view through any navigation path

## Test plan
- [ ] Open a task with an active tmux session (panes visible)
- [ ] Press `r` to open retry dialog - verify panes disappear
- [ ] Go back to task detail, press `f` for attachments - verify panes disappear
- [ ] Go back to task detail, press `c` to close task - verify panes disappear
- [ ] Verify `q/esc` still works correctly to hide panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)