### PR TITLE
Add PR submission reminder to coding task system prompt

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -547,6 +547,9 @@ func (e *Executor) buildPrompt(task *db.Task, attachmentPaths []string) string {
 - Implement the solution
 - Write tests if applicable
 - Commit your changes with clear messages
+- Submit a pull request when your work is complete
+
+IMPORTANT: Your objective is to submit a PR to complete this task. Always remember to create and submit a pull request as the final step of your work. This is how you signal that the implementation is ready for review and merging.
 
 When finished, provide a summary of what you did:
 - List files changed/created


### PR DESCRIPTION
## Summary
This PR adds a clear reminder to the coding task system prompt that instructs Claude to submit a pull request when finishing work on a task.

## Changes Made
- Modified `internal/executor/executor.go` to include PR submission instructions in the coding task prompt
- Added a new instruction item: "Submit a pull request when your work is complete"
- Added an IMPORTANT note emphasizing that PR submission is the objective and final step

## Why This Change?
Previously, Claude might complete implementation work but forget to create a PR. This explicit reminder ensures that:
1. Claude always remembers PR submission as part of task completion
2. The PR creation is clearly positioned as the objective/goal
3. Task workflow is more consistent and automated

## Test Plan
- [x] Code compiles successfully with `go build`
- [x] Changes are isolated to system prompt generation
- The updated prompt will be used for all future coding tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)