### PR TITLE
Add labels to tmux panes for better navigation

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -924,11 +924,21 @@ func execInTmux() error {
 	osexec.Command("tmux", "set-option", "-t", "task-ui", "status-left", " ").Run()
 	osexec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " Ctrl+B ↑↓ switch panes ").Run()
 
+	// Enable pane border labels
+	osexec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-status", "top").Run()
+	osexec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-format", " #{pane_title} ").Run()
+	osexec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
+	osexec.Command("tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
+
 	// Split pane vertically - Claude runs in the bottom pane (40% height)
 	// The -c flag sets the working directory for the new pane
 	// Launch Claude with copilot system prompt and permissions
 	claudeCmd := buildCopilotClaudeCommand()
 	osexec.Command("tmux", "split-window", "-t", "task-ui", "-v", "-l", "40%", "-c", cwd, claudeCmd).Run()
+
+	// Set pane titles for labels
+	osexec.Command("tmux", "select-pane", "-t", "task-ui:.0", "-T", "Tasks").Run()
+	osexec.Command("tmux", "select-pane", "-t", "task-ui:.1", "-T", "Copilot").Run()
 
 	// Select the top pane (task TUI) so it has focus when we attach
 	osexec.Command("tmux", "select-pane", "-t", "task-ui:.0").Run()


### PR DESCRIPTION
## Summary
- Add pane border labels to display pane names at the top of each pane
- Label the main view panes as "Tasks" (top) and "Copilot" (bottom)
- Label the task detail view panes as "Details" (top), "Claude" (bottom-left), and "Shell" (bottom-right)
- Ensure labels are properly reset when switching between main view and task detail view

## Implementation Details
The implementation adds tmux pane titles using `select-pane -T` and enables pane border status display with `pane-border-status top`. This provides clear visual indicators of each pane's purpose:

**Main View:**
- Tasks: The kanban board showing all tasks
- Copilot: App-wide Claude assistant for task management

**Task Detail View:**
- Details: Task metadata and logs (15% height)
- Claude: Task-specific Claude session (42% width)
- Shell: Working directory shell (42% width)

## Test plan
- [x] Build succeeds without errors
- [ ] Start the app and verify "Tasks" and "Copilot" labels appear in main view
- [ ] Enter a task detail view and verify "Details", "Claude", and "Shell" labels appear
- [ ] Exit task detail view and verify labels reset back to "Tasks" and "Copilot"
- [ ] Verify pane border styling is consistent and visually clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)