### PR TITLE
Remove copilot pane tmux resize

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -922,7 +922,7 @@ func execInTmux() error {
 	osexec.Command("tmux", "set-option", "-t", "task-ui", "status", "on").Run()
 	osexec.Command("tmux", "set-option", "-t", "task-ui", "status-style", "bg=#1e293b,fg=#94a3b8").Run()
 	osexec.Command("tmux", "set-option", "-t", "task-ui", "status-left", " ").Run()
-	osexec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " Ctrl+B ↑↓ switch panes ").Run()
+	osexec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " ").Run()
 
 	// Enable pane border labels
 	osexec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-status", "top").Run()
@@ -930,18 +930,8 @@ func execInTmux() error {
 	osexec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	osexec.Command("tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
 
-	// Split pane vertically - Claude runs in the bottom pane (40% height)
-	// The -c flag sets the working directory for the new pane
-	// Launch Claude with copilot system prompt and permissions
-	claudeCmd := buildCopilotClaudeCommand()
-	osexec.Command("tmux", "split-window", "-t", "task-ui", "-v", "-l", "40%", "-c", cwd, claudeCmd).Run()
-
-	// Set pane titles for labels
+	// Set pane title for the task TUI
 	osexec.Command("tmux", "select-pane", "-t", "task-ui:.0", "-T", "Tasks").Run()
-	osexec.Command("tmux", "select-pane", "-t", "task-ui:.1", "-T", "Copilot").Run()
-
-	// Select the top pane (task TUI) so it has focus when we attach
-	osexec.Command("tmux", "select-pane", "-t", "task-ui:.0").Run()
 
 	// Now attach to the session
 	cmd := osexec.Command("tmux", "attach-session", "-t", "task-ui")

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -343,8 +343,6 @@ func (m *AppModel) Init() tea.Cmd {
 	// Enable mouse support for click-to-focus on tmux panes
 	if os.Getenv("TMUX") != "" {
 		osExec.Command("tmux", "set-option", "-t", "task-ui", "mouse", "on").Run()
-		// Resize task-ui pane to take 85% of window height (copilot gets 15%)
-		osExec.Command("tmux", "resize-pane", "-y", "85%").Run()
 	}
 
 	return tea.Batch(m.loadTasks(), m.waitForTaskEvent(), m.waitForDBChange(), m.tick())

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -273,13 +273,12 @@ func (m *DetailModel) getWorkdir() string {
 // breakTmuxPanes breaks both joined panes - kills workdir, returns Claude to task-daemon.
 func (m *DetailModel) breakTmuxPanes() {
 	// Reset status bar and pane styling
-	exec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " Ctrl+B ↑↓ switch panes ").Run()
+	exec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " ").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
 
-	// Reset pane titles back to main view labels
+	// Reset pane title back to main view label
 	exec.Command("tmux", "select-pane", "-t", "task-ui:.0", "-T", "Tasks").Run()
-	exec.Command("tmux", "select-pane", "-t", "task-ui:.1", "-T", "Copilot").Run()
 
 	// Kill the workdir pane first (it's not from task-daemon, just a shell we created)
 	if m.workdirPaneID != "" {
@@ -319,13 +318,12 @@ func (m *DetailModel) killTmuxSession() {
 	m.database.AppendTaskLog(m.task.ID, "user", "→ [Kill] Session terminated")
 
 	// Reset pane styling first
-	exec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " Ctrl+B ↑↓ switch panes ").Run()
+	exec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " ").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
 
-	// Reset pane titles back to main view labels
+	// Reset pane title back to main view label
 	exec.Command("tmux", "select-pane", "-t", "task-ui:.0", "-T", "Tasks").Run()
-	exec.Command("tmux", "select-pane", "-t", "task-ui:.1", "-T", "Copilot").Run()
 
 	// Kill the workdir pane first (it's a separate pane we created)
 	if m.workdirPaneID != "" {


### PR DESCRIPTION
## Summary
- Remove the tmux pane resize that allocated 85% of window height to task-ui (leaving 15% for the copilot pane)
- The copilot pane is no longer needed

## Test plan
- Build the project to ensure compilation succeeds
- Run the task-ui to verify the layout works correctly without the copilot pane resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)