### PR TITLE
Replace 'none' project with 'personal' default project

### DIFF
--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -51,3 +51,50 @@ func TestTimestampLocalization(t *testing.T) {
 		t.Errorf("CreatedAt %v is not within expected range of now %v", retrieved.CreatedAt.Time, now)
 	}
 }
+
+func TestPersonalProjectCreation(t *testing.T) {
+	// Create temporary database
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+	defer os.Remove(dbPath)
+
+	// Verify 'personal' project was created
+	personal, err := db.GetProjectByName("personal")
+	if err != nil {
+		t.Fatalf("failed to get personal project: %v", err)
+	}
+	if personal == nil {
+		t.Fatal("personal project was not created")
+	}
+	if personal.Name != "personal" {
+		t.Errorf("expected project name 'personal', got '%s'", personal.Name)
+	}
+
+	// Verify that creating a task with empty project defaults to 'personal'
+	task := &Task{
+		Title:    "Test Task",
+		Body:     "Test body",
+		Status:   StatusBacklog,
+		Type:     TypeCode,
+		Project:  "", // Empty project
+		Priority: "normal",
+	}
+	if err := db.CreateTask(task); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	// Retrieve the task and verify it has 'personal' project
+	retrieved, err := db.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+	if retrieved.Project != "personal" {
+		t.Errorf("expected task project 'personal', got '%s'", retrieved.Project)
+	}
+}

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -48,6 +48,11 @@ const (
 
 // CreateTask creates a new task.
 func (db *DB) CreateTask(t *Task) error {
+	// Default to 'personal' project if not specified
+	if t.Project == "" {
+		t.Project = "personal"
+	}
+
 	result, err := db.Exec(`
 		INSERT INTO tasks (title, body, status, type, project, priority)
 		VALUES (?, ?, ?, ?, ?, ?)

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -68,7 +68,7 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 	}
 
 	// Load projects
-	m.projects = []string{""}
+	m.projects = []string{}
 	if database != nil {
 		if projs, err := database.ListProjects(); err == nil {
 			for _, p := range projs {
@@ -77,7 +77,16 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 		}
 	}
 
-	// Detect default project from working directory
+	// Default to 'personal' project
+	m.project = "personal"
+	for i, p := range m.projects {
+		if p == "personal" {
+			m.projectIdx = i
+			break
+		}
+	}
+
+	// Detect project from working directory (overrides default)
 	if workingDir != "" && database != nil {
 		if proj, err := database.GetProjectByPath(workingDir); err == nil && proj != nil {
 			m.project = proj.Name


### PR DESCRIPTION
## Summary
- Eliminates the 'none' project concept where tasks had no project assignment
- Every task now requires a project, with 'personal' as the default
- The 'personal' project has a dedicated git-backed worktree directory for artifacts

## Changes
- **Database Migration**: Automatically creates 'personal' project on startup, migrates existing tasks with empty project
- **Git Repository**: Initializes `~/.local/share/task/personal/` as a git repo with main branch
- **Task Creation**: Defaults to 'personal' project when none specified
- **UI Form**: Removes empty project option, defaults to 'personal' (can be overridden by working directory detection)
- **Executor**: Enforces project requirement, no longer creates arbitrary per-task directories
- **Tests**: Added `TestPersonalProjectCreation` to verify functionality

## Test plan
- [x] All database tests pass including new `TestPersonalProjectCreation` test
- [x] All CLI tests pass
- [x] Personal project directory is created and initialized as git repo
- [x] Existing tasks with empty project are migrated to 'personal'
- [x] New tasks default to 'personal' project
- [x] Binary builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)