### PR TITLE
Prevent deletion of the personal project

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -528,7 +528,19 @@ func (db *DB) UpdateProject(p *Project) error {
 
 // DeleteProject deletes a project.
 func (db *DB) DeleteProject(id int64) error {
-	_, err := db.Exec("DELETE FROM projects WHERE id = ?", id)
+	// Get the project name to check if it's the personal project
+	var name string
+	err := db.QueryRow("SELECT name FROM projects WHERE id = ?", id).Scan(&name)
+	if err != nil {
+		return fmt.Errorf("get project: %w", err)
+	}
+
+	// Prevent deletion of the personal project
+	if name == "personal" {
+		return fmt.Errorf("cannot delete the personal project")
+	}
+
+	_, err = db.Exec("DELETE FROM projects WHERE id = ?", id)
 	if err != nil {
 		return fmt.Errorf("delete project: %w", err)
 	}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -192,10 +192,15 @@ func (m *SettingsModel) Update(msg tea.Msg) (*SettingsModel, tea.Cmd) {
 		case "d":
 			// Delete selected project (only in projects section)
 			if m.section == 1 && len(m.projects) > 0 && m.selected < len(m.projects) {
-				m.db.DeleteProject(m.projects[m.selected].ID)
-				m.loadSettings()
-				if m.selected >= len(m.projects) && m.selected > 0 {
-					m.selected--
+				err := m.db.DeleteProject(m.projects[m.selected].ID)
+				if err != nil {
+					m.err = err
+				} else {
+					m.err = nil
+					m.loadSettings()
+					if m.selected >= len(m.projects) && m.selected > 0 {
+						m.selected--
+					}
 				}
 			}
 		case "p":


### PR DESCRIPTION
## Summary
- Added protection to prevent users from deleting the "personal" project
- The personal project is the default project automatically created during database initialization
- Attempting to delete it now shows a clear error message to the user

## Changes
- **Database layer**: Modified `DeleteProject()` in `internal/db/tasks.go` to check if the project name is "personal" and return an error if deletion is attempted
- **UI layer**: Updated settings view in `internal/ui/settings.go` to properly handle and display deletion errors to users
- **Tests**: Added comprehensive test `TestDeletePersonalProject()` in `internal/db/tasks_test.go` to verify the protection works correctly

## Test plan
- [x] Run `go test ./internal/db` - all tests pass including new test
- [x] Run `go build ./...` - project builds successfully
- [x] Verify personal project cannot be deleted (returns error)
- [x] Verify other projects can still be deleted normally
- [ ] Manual UI testing: Try to delete personal project in settings and verify error is displayed
- [ ] Manual UI testing: Verify deletion of other projects still works

## Additional Notes
This fix ensures the personal project, which serves as the default workspace for tasks, cannot be accidentally deleted by users. The protection is implemented at the database layer for maximum safety.

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)