### PR TITLE
Fix Kanban column headers being cut off

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -293,8 +293,7 @@ func (k *KanbanBoard) View() string {
 			Background(col.Color).
 			Foreground(lipgloss.Color("#000000")).
 			Bold(true).
-			Align(lipgloss.Center).
-			Padding(0, 1)
+			Align(lipgloss.Center)
 
 		headerText := fmt.Sprintf("%s %s (%d)", col.Icon, col.Title, len(col.Tasks))
 		headerBar := headerBarStyle.Render(headerText)


### PR DESCRIPTION
## Summary
- Fixed Kanban column headers being cut off by removing horizontal padding from the header style

## Problem
The column headers were being truncated because the `headerBarStyle` had both:
- A fixed width of `colWidth + 2` (to match column borders)
- Horizontal padding of `Padding(0, 1)` (1 character on each side)

The padding consumed 2 characters from within the fixed width, leaving insufficient space for longer header text like "▶ In Progress (3)".

## Solution
Removed the `Padding(0, 1)` call from the header bar style in `internal/ui/kanban.go:297`. This allows the full `colWidth + 2` width to be used for header text while maintaining proper alignment with the column borders.

## Changes
- `internal/ui/kanban.go`: Removed `.Padding(0, 1)` from `headerBarStyle`

## Testing
- Built the application successfully with `go build ./cmd/task`
- The fix ensures header text has the full available width without being cut off

🤖 Generated with [Claude Code](https://claude.com/claude-code)