### PR TITLE
Fix Kanban column headers being cut off at top

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -278,8 +278,9 @@ func (k *KanbanBoard) View() string {
 		colWidth = 20
 	}
 
-	// Calculate available height for tasks (subtract 1 for header bar)
-	colHeight := k.height - 1
+	// Calculate available height for tasks
+	// Subtract 2: 1 for header bar + 1 for bottom border of column
+	colHeight := k.height - 2
 
 	// Build columns
 	var columnViews []string


### PR DESCRIPTION
## Summary
- Fixed column height calculation that was causing kanban column headers to be cut off at the top
- The calculation now correctly accounts for both the header bar (1 row) and bottom border (1 row)

## Problem
The column height was calculated as `k.height - 1` to account for the header bar, but the column container also has a bottom border which adds 1 row. This resulted in:
- Header bar: 1 line
- Column body: k.height - 1
- Bottom border: 1 line  
- Total: k.height + 1 (1 row taller than available space)

## Solution
Changed the calculation from `k.height - 1` to `k.height - 2` to account for both the header bar and the bottom border.

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Visual verification of kanban headers appearing correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)