### PR TITLE
Remove priority field from tasks

### DIFF
--- a/cmd/task/cli_test.go
+++ b/cmd/task/cli_test.go
@@ -29,34 +29,31 @@ func TestCLICreateTask(t *testing.T) {
 		{
 			name: "basic task",
 			task: &db.Task{
-				Title:    "Test task",
-				Body:     "",
-				Status:   db.StatusBacklog,
-				Type:     db.TypeCode,
-				Project:  "",
-				Priority: "normal",
+				Title:   "Test task",
+				Body:    "",
+				Status:  db.StatusBacklog,
+				Type:    db.TypeCode,
+				Project: "",
 			},
 		},
 		{
 			name: "task with all fields",
 			task: &db.Task{
-				Title:    "Full task",
-				Body:     "This is the body",
-				Status:   db.StatusBacklog,
-				Type:     db.TypeWriting,
-				Project:  "myproject",
-				Priority: "high",
+				Title:   "Full task",
+				Body:    "This is the body",
+				Status:  db.StatusBacklog,
+				Type:    db.TypeWriting,
+				Project: "myproject",
 			},
 		},
 		{
 			name: "queued task",
 			task: &db.Task{
-				Title:    "Queued task",
-				Body:     "",
-				Status:   db.StatusQueued,
-				Type:     db.TypeCode,
-				Project:  "",
-				Priority: "normal",
+				Title:   "Queued task",
+				Body:    "",
+				Status:  db.StatusQueued,
+				Type:    db.TypeCode,
+				Project: "",
 			},
 		},
 	}
@@ -102,9 +99,9 @@ func TestCLIListTasks(t *testing.T) {
 
 	// Create some tasks
 	tasks := []*db.Task{
-		{Title: "Task 1", Status: db.StatusBacklog, Type: db.TypeCode, Priority: "normal"},
-		{Title: "Task 2", Status: db.StatusQueued, Type: db.TypeCode, Priority: "high"},
-		{Title: "Task 3", Status: db.StatusDone, Type: db.TypeWriting, Priority: "low", Project: "proj1"},
+		{Title: "Task 1", Status: db.StatusBacklog, Type: db.TypeCode},
+		{Title: "Task 2", Status: db.StatusQueued, Type: db.TypeCode},
+		{Title: "Task 3", Status: db.StatusDone, Type: db.TypeWriting, Project: "proj1"},
 	}
 	for _, task := range tasks {
 		if err := database.CreateTask(task); err != nil {
@@ -163,11 +160,10 @@ func TestCLIUpdateTask(t *testing.T) {
 
 	// Create a task
 	task := &db.Task{
-		Title:    "Original title",
-		Body:     "Original body",
-		Status:   db.StatusBacklog,
-		Type:     db.TypeCode,
-		Priority: "normal",
+		Title:  "Original title",
+		Body:   "Original body",
+		Status: db.StatusBacklog,
+		Type:   db.TypeCode,
 	}
 	if err := database.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
@@ -176,7 +172,6 @@ func TestCLIUpdateTask(t *testing.T) {
 	// Update the task
 	task.Title = "Updated title"
 	task.Body = "Updated body"
-	task.Priority = "high"
 	if err := database.UpdateTask(task); err != nil {
 		t.Fatalf("UpdateTask() error = %v", err)
 	}
@@ -191,9 +186,6 @@ func TestCLIUpdateTask(t *testing.T) {
 	}
 	if fetched.Body != "Updated body" {
 		t.Errorf("Body = %v, want 'Updated body'", fetched.Body)
-	}
-	if fetched.Priority != "high" {
-		t.Errorf("Priority = %v, want 'high'", fetched.Priority)
 	}
 }
 
@@ -211,10 +203,9 @@ func TestCLIExecuteTask(t *testing.T) {
 
 	// Create a backlog task
 	task := &db.Task{
-		Title:    "Task to execute",
-		Status:   db.StatusBacklog,
-		Type:     db.TypeCode,
-		Priority: "normal",
+		Title:  "Task to execute",
+		Status: db.StatusBacklog,
+		Type:   db.TypeCode,
 	}
 	if err := database.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
@@ -249,10 +240,9 @@ func TestCLICloseTask(t *testing.T) {
 
 	// Create and queue a task
 	task := &db.Task{
-		Title:    "Task to close",
-		Status:   db.StatusProcessing,
-		Type:     db.TypeCode,
-		Priority: "normal",
+		Title:  "Task to close",
+		Status: db.StatusProcessing,
+		Type:   db.TypeCode,
 	}
 	if err := database.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
@@ -290,10 +280,9 @@ func TestCLIDeleteTask(t *testing.T) {
 
 	// Create a task
 	task := &db.Task{
-		Title:    "Task to delete",
-		Status:   db.StatusBacklog,
-		Type:     db.TypeCode,
-		Priority: "normal",
+		Title:  "Task to delete",
+		Status: db.StatusBacklog,
+		Type:   db.TypeCode,
 	}
 	if err := database.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
@@ -328,10 +317,9 @@ func TestCLIRetryTask(t *testing.T) {
 
 	// Create a blocked task
 	task := &db.Task{
-		Title:    "Blocked task",
-		Status:   db.StatusBlocked,
-		Type:     db.TypeCode,
-		Priority: "normal",
+		Title:  "Blocked task",
+		Status: db.StatusBlocked,
+		Type:   db.TypeCode,
 	}
 	if err := database.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
@@ -375,24 +363,6 @@ func TestTaskTypeValidation(t *testing.T) {
 	for _, typ := range invalidTypes {
 		if typ == db.TypeCode || typ == db.TypeWriting || typ == db.TypeThinking {
 			t.Errorf("type %q should be invalid", typ)
-		}
-	}
-}
-
-// TestPriorityValidation tests priority validation
-func TestPriorityValidation(t *testing.T) {
-	validPriorities := []string{"low", "normal", "high"}
-	invalidPriorities := []string{"invalid", "urgent", ""}
-
-	for _, p := range validPriorities {
-		if p != "low" && p != "normal" && p != "high" {
-			t.Errorf("priority %q should be valid", p)
-		}
-	}
-
-	for _, p := range invalidPriorities {
-		if p == "low" || p == "normal" || p == "high" {
-			t.Errorf("priority %q should be invalid", p)
 		}
 	}
 }

--- a/internal/db/memories_test.go
+++ b/internal/db/memories_test.go
@@ -237,11 +237,10 @@ func TestMemoryWithSourceTask(t *testing.T) {
 	// Create a task first
 	task := &Task{
 		Title:    "Source Task",
-		Body:     "Task body",
-		Status:   StatusBacklog,
-		Type:     TypeCode,
-		Project:  "testproject",
-		Priority: "normal",
+		Body:    "Task body",
+		Status:  StatusBacklog,
+		Type:    TypeCode,
+		Project: "testproject",
 	}
 	if err := db.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -111,7 +111,6 @@ func (db *DB) migrate() error {
 			status TEXT DEFAULT 'backlog',
 			type TEXT DEFAULT '',
 			project TEXT DEFAULT '',
-			priority TEXT DEFAULT 'normal',
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			started_at DATETIME,
@@ -210,6 +209,9 @@ func (db *DB) migrate() error {
 
 	// Migrate tasks with empty project to 'personal'
 	db.Exec(`UPDATE tasks SET project = 'personal' WHERE project = ''`)
+
+	// Drop priority column if it exists (SQLite 3.35.0+ supports DROP COLUMN)
+	db.Exec(`ALTER TABLE tasks DROP COLUMN priority`)
 
 	return nil
 }

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -26,8 +26,7 @@ func TestTimestampLocalization(t *testing.T) {
 		Status:   StatusBacklog,
 		Type:     TypeCode,
 		Project:  "test",
-		Priority: "normal",
-	}
+			}
 	if err := db.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
 	}
@@ -83,8 +82,7 @@ func TestPersonalProjectCreation(t *testing.T) {
 		Status:   StatusBacklog,
 		Type:     TypeCode,
 		Project:  "", // Empty project
-		Priority: "normal",
-	}
+			}
 	if err := db.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
 	}

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -25,8 +25,7 @@ func TestGetLastQuestion(t *testing.T) {
 		Status:   StatusBacklog,
 		Type:     TypeCode,
 		Project:  "test",
-		Priority: "normal",
-	}
+			}
 	if err := db.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
 	}
@@ -86,8 +85,7 @@ func TestTaskLogsWithQuestion(t *testing.T) {
 		Status:   StatusBacklog,
 		Type:     TypeCode,
 		Project:  "test",
-		Priority: "normal",
-	}
+			}
 	if err := db.CreateTask(task); err != nil {
 		t.Fatalf("failed to create task: %v", err)
 	}
@@ -139,27 +137,23 @@ func TestGetTasksWithBranches(t *testing.T) {
 		Title:    "Task without branch",
 		Status:   StatusBacklog,
 		Type:     TypeCode,
-		Priority: "normal",
-	}
+			}
 	taskWithBranch := &Task{
 		Title:      "Task with branch",
 		Status:     StatusBlocked,
 		Type:       TypeCode,
-		Priority:   "normal",
 		BranchName: "task/1-task-with-branch",
 	}
 	taskDoneWithBranch := &Task{
 		Title:      "Done task with branch",
 		Status:     StatusDone,
 		Type:       TypeCode,
-		Priority:   "normal",
 		BranchName: "task/2-done-task",
 	}
 	taskProcessingWithBranch := &Task{
 		Title:      "Processing task with branch",
 		Status:     StatusProcessing,
 		Type:       TypeCode,
-		Priority:   "normal",
 		BranchName: "task/3-processing-task",
 	}
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -69,7 +69,6 @@ func (r *Runner) Run(event string, task *db.Task, message string) {
 		fmt.Sprintf("TASK_STATUS=%s", task.Status),
 		fmt.Sprintf("TASK_PROJECT=%s", task.Project),
 		fmt.Sprintf("TASK_TYPE=%s", task.Type),
-		fmt.Sprintf("TASK_PRIORITY=%s", task.Priority),
 		fmt.Sprintf("TASK_MESSAGE=%s", message),
 		fmt.Sprintf("TASK_EVENT=%s", event),
 	)

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -430,12 +430,6 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool) 
 	b.WriteString(" ")
 	b.WriteString(Dim.Render(fmt.Sprintf("#%d", task.ID)))
 
-	// Priority indicator
-	if task.Priority == "high" {
-		b.WriteString(" ")
-		b.WriteString(PriorityHigh.Render())
-	}
-
 	// Project tag
 	if task.Project != "" {
 		projectStyle := lipgloss.NewStyle().Foreground(ProjectColor(task.Project))

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -54,11 +54,6 @@ var (
 			Foreground(ColorBlocked).
 			SetString("!")
 
-	// Priority
-	PriorityHigh = lipgloss.NewStyle().
-			Foreground(ColorError).
-			SetString("↑")
-
 	// Box styles
 	Box = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -303,11 +303,6 @@ func refreshStyles() {
 		Foreground(ColorBlocked).
 		SetString("!")
 
-	// Update priority
-	PriorityHigh = lipgloss.NewStyle().
-		Foreground(ColorError).
-		SetString("↑")
-
 	// Update box styles
 	Box = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).


### PR DESCRIPTION
## Summary
- Removed the `priority` field from tasks as it was not being actively used
- Simplified queue ordering to use creation time instead of priority-based sorting
- Removed all priority-related UI components, CLI flags, and test cases

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] Database migration drops priority column for existing databases
- [x] CLI commands work without priority flags
- [x] UI form no longer shows priority selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)