### PR TITLE
Fix kanban column content to use full available height

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -198,9 +198,10 @@ func (k *KanbanBoard) ensureSelectedVisible() {
 	}
 
 	// Calculate how many tasks fit in the visible area
-	colHeight := k.height
+	// Subtract 1 for header bar, then 2 for column borders
+	colHeight := k.height - 1
 	cardHeight := 4
-	maxVisible := (colHeight - 3) / cardHeight // -3 for header bar and minimal padding
+	maxVisible := (colHeight - 2) / cardHeight
 	if maxVisible < 1 {
 		maxVisible = 1
 	}
@@ -279,8 +280,8 @@ func (k *KanbanBoard) View() string {
 	}
 
 	// Calculate available height for tasks
-	// Subtract 2: 1 for header bar + 1 for bottom border of column
-	colHeight := k.height - 2
+	// Subtract 1 for header bar (which is rendered separately above the column)
+	colHeight := k.height - 1
 
 	// Build columns
 	var columnViews []string
@@ -299,9 +300,10 @@ func (k *KanbanBoard) View() string {
 		headerText := fmt.Sprintf("%s %s (%d)", col.Icon, col.Title, len(col.Tasks))
 		headerBar := headerBarStyle.Render(headerText)
 
-		// Task cards - calculate how many fit (each card is ~3 lines with margin)
-		cardHeight := 4 // Increased for better spacing
-		maxTasks := (colHeight - 3) / cardHeight // -3 for header bar and minimal padding
+		// Task cards - calculate how many fit (each card is ~3-4 lines)
+		cardHeight := 4
+		// Subtract 2 for top/bottom column borders, then divide by card height
+		maxTasks := (colHeight - 2) / cardHeight
 		if maxTasks < 1 {
 			maxTasks = 1
 		}
@@ -590,8 +592,9 @@ func (k *KanbanBoard) HandleClick(x, y int) *db.Task {
 
 	// Calculate which task was clicked
 	col := k.columns[colIdx]
-	colHeight := k.height
-	maxTasks := (colHeight - 3) / taskCardHeight // -3 for header bar and minimal padding
+	// Subtract 1 for header bar, then 2 for column borders
+	colHeight := k.height - 1
+	maxTasks := (colHeight - 2) / taskCardHeight
 	if maxTasks < 1 {
 		maxTasks = 1
 	}


### PR DESCRIPTION
## Summary
- Fixed height calculation in kanban columns that was over-subtracting available space
- Columns now display more tasks by using the full available terminal height
- Applied consistent height calculation across `View()`, `ensureSelectedVisible()`, and `HandleClick()` methods

## Test plan
- [x] Run `go test ./internal/ui/...` - all tests pass
- [x] Run `go build ./...` - builds successfully
- [ ] Manual testing: verify columns now use full height and display more tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)