### PR TITLE
Fix kanban columns to display more tasks (v2)

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -199,7 +199,7 @@ func (k *KanbanBoard) ensureSelectedVisible() {
 
 	// Calculate how many tasks fit in the visible area
 	colHeight := k.height
-	cardHeight := 4
+	cardHeight := 3 // Most cards are 3 lines (2 content + 1 border)
 	maxVisible := (colHeight - 3) / cardHeight // -3 for header bar and minimal padding
 	if maxVisible < 1 {
 		maxVisible = 1
@@ -299,9 +299,10 @@ func (k *KanbanBoard) View() string {
 		headerText := fmt.Sprintf("%s %s (%d)", col.Icon, col.Title, len(col.Tasks))
 		headerBar := headerBarStyle.Render(headerText)
 
-		// Task cards - calculate how many fit (each card is ~3 lines with margin)
-		cardHeight := 4 // Increased for better spacing
-		maxTasks := (colHeight - 3) / cardHeight // -3 for header bar and minimal padding
+		// Task cards - calculate how many fit
+		// Non-selected cards: 2 lines content + 1 line border = 3 lines
+		cardHeight := 3
+		maxTasks := (colHeight - 3) / cardHeight // -3 for scroll indicators and padding
 		if maxTasks < 1 {
 			maxTasks = 1
 		}


### PR DESCRIPTION
## Summary
- Changed `cardHeight` from 4 to 3 in `View()` and `ensureSelectedVisible()`
- Non-selected task cards are 3 lines (2 content + 1 border), not 4
- This matches the existing `HandleClick()` code which already used `taskCardHeight := 3`

## What's different from the reverted PR
This is a **minimal fix** that only changes the `cardHeight` constant. The previous PR modified `colHeight` which affected the column box dimensions and broke the headers. This PR does not touch `colHeight` at all.

## Expected result
~33% more tasks displayed per column without affecting the column header layout.

## Test plan
- [x] Run `go test ./internal/ui/...` - all tests pass
- [x] Run `go build ./...` - builds successfully  
- [ ] Manual testing: verify columns display more tasks and headers are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)