### PR TITLE
feat: personal project first and remember last task type per project

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -187,6 +187,9 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 		}
 	}
 
+	// Load last used task type for the selected project
+	m.loadLastTaskTypeForProject()
+
 	// Title input
 	m.titleInput = textinput.New()
 	m.titleInput.Placeholder = "What needs to be done?"
@@ -287,6 +290,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.focused == FieldProject {
 				m.projectIdx = (m.projectIdx - 1 + len(m.projects)) % len(m.projects)
 				m.project = m.projects[m.projectIdx]
+				m.loadLastTaskTypeForProject()
 				return m, nil
 			}
 			if m.focused == FieldType {
@@ -299,6 +303,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.focused == FieldProject {
 				m.projectIdx = (m.projectIdx + 1) % len(m.projects)
 				m.project = m.projects[m.projectIdx]
+				m.loadLastTaskTypeForProject()
 				return m, nil
 			}
 			if m.focused == FieldType {
@@ -340,6 +345,7 @@ func (m *FormModel) selectByPrefix(prefix string) {
 			if strings.HasPrefix(strings.ToLower(p), prefix) {
 				m.projectIdx = i
 				m.project = p
+				m.loadLastTaskTypeForProject()
 				return
 			}
 		}
@@ -354,6 +360,27 @@ func (m *FormModel) selectByPrefix(prefix string) {
 				m.taskType = t
 				return
 			}
+		}
+	}
+}
+
+// loadLastTaskTypeForProject loads and sets the last used task type for the current project.
+func (m *FormModel) loadLastTaskTypeForProject() {
+	if m.db == nil || m.project == "" {
+		return
+	}
+
+	lastType, err := m.db.GetLastTaskTypeForProject(m.project)
+	if err != nil || lastType == "" {
+		return
+	}
+
+	// Find the type in the list and set it
+	for i, t := range m.types {
+		if t == lastType {
+			m.typeIdx = i
+			m.taskType = t
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Personal project always appears first in the projects list (sorted before all other projects)
- Default to personal project unless running inside a directory matching another project's path
- Remember and restore the last used task type when switching between projects
- Automatically save last used task type when creating a task

## Test plan
- [x] Verified personal project appears first in list when multiple projects exist
- [x] Verified project defaults to personal when no matching path found
- [x] Verified project defaults to matched project when running from its directory
- [x] Verified last task type is saved when creating tasks
- [x] Verified last task type is restored when switching projects
- [x] Added unit tests for all new functionality
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)