### PR TITLE
Add visual indicators for draggable pane borders

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -416,6 +416,9 @@ func (m *DetailModel) joinTmuxPanes() {
 	exec.Command("tmux", "set-option", "-t", "task-ui", "status-right-length", "60").Run()
 
 	// Style pane borders - active pane gets theme color outline
+	// Use heavy border lines to make them more visible and indicate they're draggable
+	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-lines", "heavy").Run()
+	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-indicators", "arrows").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
 
@@ -451,6 +454,8 @@ func (m *DetailModel) breakTmuxPanes() {
 
 	// Reset status bar and pane styling
 	exec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " ").Run()
+	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-lines", "single").Run()
+	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-indicators", "off").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
 
@@ -516,6 +521,8 @@ func (m *DetailModel) killTmuxSession() {
 
 	// Reset pane styling first
 	exec.Command("tmux", "set-option", "-t", "task-ui", "status-right", " ").Run()
+	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-lines", "single").Run()
+	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-indicators", "off").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	exec.Command("tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
 


### PR DESCRIPTION
## Summary
- Added `pane-border-lines: heavy` to make pane borders thicker and more visible
- Added `pane-border-indicators: arrows` to show arrows on the active pane border, making it clear the borders are interactive
- Reset border styling back to defaults when panes are closed

These changes help users discover that they can drag pane borders to resize, improving the UX for the split-pane layout.

## Test plan
- [ ] Open a task detail view that has joined panes (Claude + Shell)
- [ ] Verify the pane borders appear thicker with heavy styling
- [ ] Verify arrow indicators appear on the active pane border
- [ ] Drag a pane border to resize and confirm it works as expected
- [ ] Close/hide the panes and verify borders reset to normal styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)