### PR TITLE
Remove interrupt command and 'i' key shortcut

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,6 @@ Any state → closed (manual)
 | `c` | Close selected task |
 | `d` | Delete selected task |
 | `w` | Watch current execution |
-| `i` | Interrupt execution |
 | `/` | Filter tasks |
 | `m` | Project memories |
 | `s` | Settings |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ ssh -p 2222 your-server
 | `a` | Attach to tmux session |
 | `o` | Open task's working directory |
 | `f` | View/manage attachments |
-| `i` | Interrupt execution |
 | `/` | Filter tasks |
 | `m` | Project memories |
 | `s` | Settings |

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2,36 +2,22 @@ package ui
 
 import (
 	"testing"
-
-	"github.com/bborn/workflow/internal/db"
 )
 
-func TestInterruptKeyEnabled(t *testing.T) {
-	// Create a test database
-	database, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("failed to create test db: %v", err)
-	}
-	defer database.Close()
-
-	// Create app model with nil executor (we'll test the keys directly)
+func TestDefaultKeyMap(t *testing.T) {
+	// Verify DefaultKeyMap creates valid key bindings
 	keys := DefaultKeyMap()
 
-	// By default, the interrupt key should be enabled
-	if !keys.Interrupt.Enabled() {
-		t.Error("interrupt key should be enabled by default")
+	// Check that some key bindings are properly defined
+	if keys.Enter.Help().Key != "enter" {
+		t.Error("Enter key should have help text 'enter'")
 	}
 
-	// After disabling, it should be disabled
-	keys.Interrupt.SetEnabled(false)
-	if keys.Interrupt.Enabled() {
-		t.Error("interrupt key should be disabled after SetEnabled(false)")
+	if keys.Quit.Help().Key != "ctrl+c" {
+		t.Error("Quit key should have help text 'ctrl+c'")
 	}
 
-	// Re-enable
-	keys.Interrupt.SetEnabled(true)
-	if !keys.Interrupt.Enabled() {
-		t.Error("interrupt key should be enabled after SetEnabled(true)")
+	if keys.New.Help().Key != "n" {
+		t.Error("New key should have help text 'n'")
 	}
 }
-

--- a/internal/ui/watch.go
+++ b/internal/ui/watch.go
@@ -15,19 +15,18 @@ import (
 
 // WatchModel represents the task watch view.
 type WatchModel struct {
-	database    *db.DB
-	executor    *executor.Executor
-	taskID      int64
-	task        *db.Task
-	logs        []*db.TaskLog
-	lastLogID   int64
-	viewport    viewport.Model
-	spinner     spinner.Model
-	width       int
-	height      int
-	ready       bool
-	logCh       chan *db.TaskLog
-	interrupted bool
+	database  *db.DB
+	executor  *executor.Executor
+	taskID    int64
+	task      *db.Task
+	logs      []*db.TaskLog
+	lastLogID int64
+	viewport  viewport.Model
+	spinner   spinner.Model
+	width     int
+	height    int
+	ready     bool
+	logCh     chan *db.TaskLog
 }
 
 // NewWatchModel creates a new watch model.
@@ -107,13 +106,6 @@ func (m *WatchModel) Update(msg tea.Msg) (*WatchModel, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		// Handle interrupt key
-		if msg.String() == "i" {
-			m.executor.Interrupt(m.taskID)
-			m.interrupted = true
-			return m, nil
-		}
-
 		var cmd tea.Cmd
 		m.viewport, cmd = m.viewport.Update(msg)
 		cmds = append(cmds, cmd)
@@ -190,7 +182,6 @@ func (m *WatchModel) renderHelp() string {
 		desc string
 	}{
 		{"↑/↓", "scroll"},
-		{"i", "interrupt"},
 		{"q/esc", "back"},
 	}
 


### PR DESCRIPTION
## Summary
- Removes the interrupt command (`i` key shortcut) from the application
- Cleans up all related code including key bindings, handlers, and helper functions
- Updates documentation in README.md and AGENTS.md

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Verify 'i' key no longer triggers any action in dashboard view
- [ ] Verify 'i' key no longer triggers any action in detail view
- [ ] Verify watch view no longer shows 'i' in help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)