### PR TITLE
fix: ring terminal bell properly inside TUI by writing to /dev/tty

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -452,12 +452,12 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// Task just became blocked - ring bell and show notification
 					m.notification = fmt.Sprintf("⚠ Task #%d needs input: %s", t.ID, t.Title)
 					m.notifyUntil = time.Now().Add(10 * time.Second)
-					fmt.Print("\a") // Ring terminal bell
+					RingBell() // Ring terminal bell (writes to /dev/tty to bypass TUI)
 				} else if t.Status == db.StatusDone && db.IsInProgress(prevStatus) {
 					// Task completed - ring bell and show notification
 					m.notification = fmt.Sprintf("✓ Task #%d complete: %s", t.ID, t.Title)
 					m.notifyUntil = time.Now().Add(5 * time.Second)
-					fmt.Print("\a") // Ring terminal bell
+					RingBell() // Ring terminal bell (writes to /dev/tty to bypass TUI)
 				}
 			}
 			m.prevStatuses[t.ID] = t.Status
@@ -567,11 +567,11 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						if event.Task.Status == db.StatusBlocked {
 							m.notification = fmt.Sprintf("⚠ Task #%d needs input: %s", event.TaskID, event.Task.Title)
 							m.notifyUntil = time.Now().Add(10 * time.Second)
-							fmt.Print("\a") // Ring terminal bell
+							RingBell() // Ring terminal bell (writes to /dev/tty to bypass TUI)
 						} else if event.Task.Status == db.StatusDone && db.IsInProgress(prevStatus) {
 							m.notification = fmt.Sprintf("✓ Task #%d complete: %s", event.TaskID, event.Task.Title)
 							m.notifyUntil = time.Now().Add(5 * time.Second)
-							fmt.Print("\a") // Ring terminal bell
+							RingBell() // Ring terminal bell (writes to /dev/tty to bypass TUI)
 						} else if db.IsInProgress(event.Task.Status) {
 							m.notification = fmt.Sprintf("▶ Task #%d started: %s", event.TaskID, event.Task.Title)
 							m.notifyUntil = time.Now().Add(3 * time.Second)

--- a/internal/ui/bell.go
+++ b/internal/ui/bell.go
@@ -1,0 +1,23 @@
+package ui
+
+import (
+	"os"
+)
+
+// RingBell sends the BEL character (\a) to the terminal to trigger an audible bell.
+// It writes directly to /dev/tty to bypass any stdout buffering that might occur
+// when running inside a TUI framework like Bubble Tea.
+func RingBell() {
+	// Open /dev/tty directly to write to the actual terminal
+	// This bypasses Bubble Tea's alternate screen buffer and stdout capture
+	tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		// Fallback to stderr if /dev/tty is not available
+		// (stderr is less likely to be captured than stdout)
+		os.Stderr.WriteString("\a")
+		return
+	}
+	defer tty.Close()
+
+	tty.WriteString("\a")
+}


### PR DESCRIPTION
## Summary
- Creates a `RingBell()` utility function that writes the BEL character (`\a`) directly to `/dev/tty`
- Updates task status change notifications to use the new function instead of `fmt.Print("\a")`
- This bypasses Bubble Tea's alternate screen buffer, ensuring the bell reaches the actual terminal

## Problem
When a task moved to "blocked" state (needing user input), the terminal bell was working in iTerm but not inside the tasks TUI app. This was because `fmt.Print("\a")` writes to stdout, which gets captured by Bubble Tea's output handling.

## Solution
By writing directly to `/dev/tty`, we bypass any stdout buffering or capture that the TUI framework might be doing. Falls back to stderr if `/dev/tty` is unavailable.

## Test plan
- [x] Build compiles without errors
- [x] All existing tests pass
- [ ] Manual test: Run task app, queue a task that asks for input, verify bell rings

🤖 Generated with [Claude Code](https://claude.com/claude-code)