### PR TITLE
feat: add #<id> shortcut to jump directly to a task

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -233,6 +233,10 @@ type AppModel struct {
 	// Number filter for quick task ID jump
 	numberFilter string
 
+	// Shortcut mode for #<id> direct task jump
+	shortcutMode   bool
+	shortcutBuffer string
+
 	// Text filter input
 	filterInput  textinput.Model
 	filtering    bool
@@ -731,6 +735,12 @@ func (m *AppModel) viewDashboard() string {
 		headerParts = append(headerParts, statusBar)
 	}
 
+	// Shortcut mode display (#<id> jump)
+	if m.shortcutMode {
+		shortcutStyle := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
+		headerParts = append(headerParts, shortcutStyle.Render(fmt.Sprintf("Jump to: #%s_", m.shortcutBuffer)))
+	}
+
 	// Filter display
 	if m.filtering {
 		filterStyle := lipgloss.NewStyle().Foreground(ColorSecondary)
@@ -792,8 +802,51 @@ func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Handle number filter input
 	keyStr := msg.String()
+
+	// Handle shortcut mode (#<id> to jump directly to task)
+	if m.shortcutMode {
+		// Accumulate digits
+		if len(keyStr) == 1 && keyStr[0] >= '0' && keyStr[0] <= '9' {
+			m.shortcutBuffer += keyStr
+			return m, nil
+		}
+		// Backspace removes last digit
+		if keyStr == "backspace" && m.shortcutBuffer != "" {
+			m.shortcutBuffer = m.shortcutBuffer[:len(m.shortcutBuffer)-1]
+			return m, nil
+		}
+		// Enter confirms and loads the task
+		if keyStr == "enter" && m.shortcutBuffer != "" {
+			var taskID int64
+			if _, err := fmt.Sscanf(m.shortcutBuffer, "%d", &taskID); err == nil {
+				m.shortcutMode = false
+				m.shortcutBuffer = ""
+				return m, m.loadTask(taskID)
+			}
+		}
+		// Escape cancels shortcut mode
+		if keyStr == "esc" {
+			m.shortcutMode = false
+			m.shortcutBuffer = ""
+			return m, nil
+		}
+		// Any other key cancels shortcut mode
+		m.shortcutMode = false
+		m.shortcutBuffer = ""
+		// Fall through to normal key handling
+	}
+
+	// Start shortcut mode with '#'
+	if keyStr == "#" {
+		m.shortcutMode = true
+		m.shortcutBuffer = ""
+		m.numberFilter = "" // Clear any existing number filter
+		m.kanban.ApplyNumberFilter("")
+		return m, nil
+	}
+
+	// Handle number filter input
 	if len(keyStr) == 1 && keyStr[0] >= '0' && keyStr[0] <= '9' {
 		m.numberFilter += keyStr
 		m.kanban.ApplyNumberFilter(m.numberFilter)


### PR DESCRIPTION
## Summary
- Add the ability to type `#206` to open task 206 directly from the dashboard
- Press `#` to enter shortcut mode, type task ID, press Enter to jump
- Visual feedback shows "Jump to: #<digits>_" in the header while typing
- Escape or non-digit keys cancel shortcut mode

## Test plan
- [x] Build compiles successfully
- [x] All existing tests pass
- [ ] Manual test: Press `#`, type a task ID, press Enter - should open that task
- [ ] Manual test: Press `#`, type digits, press Esc - should cancel and return to normal mode
- [ ] Manual test: Press `#`, type digits, press a letter - should cancel and process the letter normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)