### PR TITLE
fix: sort closed tasks by completion date

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -145,7 +145,10 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 		query += " AND status != 'done'"
 	}
 
-	query += " ORDER BY created_at DESC"
+	// Sort done/blocked tasks by completed_at (most recently closed first),
+	// other tasks by created_at (newest first).
+	// Use id DESC as secondary sort for consistent ordering when timestamps are equal.
+	query += " ORDER BY CASE WHEN status IN ('done', 'blocked') THEN completed_at ELSE created_at END DESC, id DESC"
 
 	if opts.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", opts.Limit)


### PR DESCRIPTION
## Summary
- Closed tasks (done/blocked) now sort by `completed_at` DESC instead of `created_at` DESC
- Most recently closed tasks appear first in the Done column
- Added `id DESC` as secondary sort for consistent ordering when timestamps are equal
- Added test to verify closed tasks sorting behavior

## Test plan
- [x] Added `TestListTasksClosedSortedByCompletedAt` test
- [x] All existing tests pass
- [ ] Manual verification: close multiple tasks and verify they appear in order of closing time in the Done column

🤖 Generated with [Claude Code](https://claude.com/claude-code)