### PR TITLE
feat: add Command+P task switcher for fast navigation

### DIFF
--- a/internal/ui/command_palette.go
+++ b/internal/ui/command_palette.go
@@ -1,0 +1,372 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// CommandPaletteModel represents the Command+P task switcher.
+type CommandPaletteModel struct {
+	db            *db.DB
+	allTasks      []*db.Task
+	filteredTasks []*db.Task
+	projects      []*db.Project
+	searchInput   textinput.Model
+	selectedIndex int
+	width         int
+	height        int
+	maxVisible    int
+
+	// Result
+	selectedTask *db.Task
+	cancelled    bool
+}
+
+// NewCommandPaletteModel creates a new command palette model.
+func NewCommandPaletteModel(database *db.DB, tasks []*db.Task, width, height int) *CommandPaletteModel {
+	searchInput := textinput.New()
+	searchInput.Placeholder = "Search tasks by title, ID, or project..."
+	searchInput.Focus()
+	searchInput.CharLimit = 100
+	searchInput.Width = min(60, width-10)
+
+	// Load projects for project-based filtering
+	projects, _ := database.ListProjects()
+
+	m := &CommandPaletteModel{
+		db:          database,
+		allTasks:    tasks,
+		projects:    projects,
+		searchInput: searchInput,
+		width:       width,
+		height:      height,
+		maxVisible:  10,
+	}
+	m.filterTasks()
+	return m
+}
+
+// Init initializes the command palette.
+func (m *CommandPaletteModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+// Update handles messages.
+func (m *CommandPaletteModel) Update(msg tea.Msg) (*CommandPaletteModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			m.cancelled = true
+			return m, nil
+		case "enter":
+			if len(m.filteredTasks) > 0 && m.selectedIndex < len(m.filteredTasks) {
+				m.selectedTask = m.filteredTasks[m.selectedIndex]
+			}
+			return m, nil
+		case "up", "ctrl+p", "ctrl+k":
+			if m.selectedIndex > 0 {
+				m.selectedIndex--
+			} else if len(m.filteredTasks) > 0 {
+				// Wrap to bottom
+				m.selectedIndex = len(m.filteredTasks) - 1
+			}
+			return m, nil
+		case "down", "ctrl+n", "ctrl+j":
+			if m.selectedIndex < len(m.filteredTasks)-1 {
+				m.selectedIndex++
+			} else {
+				// Wrap to top
+				m.selectedIndex = 0
+			}
+			return m, nil
+		case "pgup":
+			m.selectedIndex -= m.maxVisible
+			if m.selectedIndex < 0 {
+				m.selectedIndex = 0
+			}
+			return m, nil
+		case "pgdown":
+			m.selectedIndex += m.maxVisible
+			if m.selectedIndex >= len(m.filteredTasks) {
+				m.selectedIndex = len(m.filteredTasks) - 1
+			}
+			if m.selectedIndex < 0 {
+				m.selectedIndex = 0
+			}
+			return m, nil
+		}
+
+		// Update search input
+		var cmd tea.Cmd
+		m.searchInput, cmd = m.searchInput.Update(msg)
+		m.filterTasks()
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+// filterTasks filters tasks based on the search query.
+func (m *CommandPaletteModel) filterTasks() {
+	query := strings.ToLower(strings.TrimSpace(m.searchInput.Value()))
+
+	if query == "" {
+		m.filteredTasks = m.allTasks
+	} else {
+		m.filteredTasks = nil
+		for _, task := range m.allTasks {
+			if m.matchesQuery(task, query) {
+				m.filteredTasks = append(m.filteredTasks, task)
+			}
+		}
+	}
+
+	// Clamp selected index
+	if m.selectedIndex >= len(m.filteredTasks) {
+		m.selectedIndex = max(0, len(m.filteredTasks)-1)
+	}
+}
+
+// matchesQuery checks if a task matches the search query.
+func (m *CommandPaletteModel) matchesQuery(task *db.Task, query string) bool {
+	// Check task ID
+	if strings.Contains(fmt.Sprintf("%d", task.ID), query) {
+		return true
+	}
+	// Check task ID with # prefix
+	if strings.HasPrefix(query, "#") {
+		idQuery := strings.TrimPrefix(query, "#")
+		if strings.Contains(fmt.Sprintf("%d", task.ID), idQuery) {
+			return true
+		}
+	}
+	// Check title
+	if strings.Contains(strings.ToLower(task.Title), query) {
+		return true
+	}
+	// Check project
+	if strings.Contains(strings.ToLower(task.Project), query) {
+		return true
+	}
+	// Check status
+	if strings.Contains(strings.ToLower(task.Status), query) {
+		return true
+	}
+	// Fuzzy match: check if all characters in query appear in order in title
+	if fuzzyMatch(strings.ToLower(task.Title), query) {
+		return true
+	}
+	return false
+}
+
+// fuzzyMatch performs a simple fuzzy match - all characters in pattern appear in order in str.
+func fuzzyMatch(str, pattern string) bool {
+	if len(pattern) == 0 {
+		return true
+	}
+	if len(str) == 0 {
+		return false
+	}
+
+	patternIdx := 0
+	for i := 0; i < len(str) && patternIdx < len(pattern); i++ {
+		if str[i] == pattern[patternIdx] {
+			patternIdx++
+		}
+	}
+	return patternIdx == len(pattern)
+}
+
+// View renders the command palette.
+func (m *CommandPaletteModel) View() string {
+	// Modal dimensions
+	modalWidth := min(80, m.width-4)
+
+	// Header
+	header := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ColorPrimary).
+		MarginBottom(1).
+		Render("Go to Task")
+
+	// Search input
+	inputStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorSecondary).
+		Padding(0, 1).
+		Width(modalWidth - 6)
+	searchBox := inputStyle.Render(m.searchInput.View())
+
+	// Task list
+	var taskList strings.Builder
+	if len(m.filteredTasks) == 0 {
+		emptyStyle := lipgloss.NewStyle().
+			Foreground(ColorMuted).
+			Italic(true).
+			Padding(1, 0)
+		taskList.WriteString(emptyStyle.Render("No tasks found"))
+	} else {
+		// Calculate visible range (for scrolling)
+		start := 0
+		end := len(m.filteredTasks)
+		if end > m.maxVisible {
+			// Center the selected item when possible
+			halfVisible := m.maxVisible / 2
+			start = m.selectedIndex - halfVisible
+			if start < 0 {
+				start = 0
+			}
+			end = start + m.maxVisible
+			if end > len(m.filteredTasks) {
+				end = len(m.filteredTasks)
+				start = end - m.maxVisible
+				if start < 0 {
+					start = 0
+				}
+			}
+		}
+
+		// Show scroll indicator at top
+		if start > 0 {
+			scrollUp := lipgloss.NewStyle().
+				Foreground(ColorMuted).
+				Italic(true).
+				Render(fmt.Sprintf("  ... %d more above", start))
+			taskList.WriteString(scrollUp + "\n")
+		}
+
+		// Render visible tasks
+		for i := start; i < end; i++ {
+			task := m.filteredTasks[i]
+			isSelected := i == m.selectedIndex
+
+			taskList.WriteString(m.renderTaskItem(task, isSelected, modalWidth-6))
+			if i < end-1 {
+				taskList.WriteString("\n")
+			}
+		}
+
+		// Show scroll indicator at bottom
+		remaining := len(m.filteredTasks) - end
+		if remaining > 0 {
+			scrollDown := lipgloss.NewStyle().
+				Foreground(ColorMuted).
+				Italic(true).
+				Render(fmt.Sprintf("\n  ... %d more below", remaining))
+			taskList.WriteString(scrollDown)
+		}
+	}
+
+	// Help text
+	helpStyle := lipgloss.NewStyle().
+		Foreground(ColorMuted).
+		MarginTop(1)
+	help := helpStyle.Render("Enter: select  Esc: cancel  ↑/↓: navigate")
+
+	// Combine all parts
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		searchBox,
+		"",
+		taskList.String(),
+		help,
+	)
+
+	// Modal box
+	modalBox := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary).
+		Padding(1, 2).
+		Width(modalWidth)
+
+	modalContent := modalBox.Render(content)
+
+	// Center on screen
+	return lipgloss.NewStyle().
+		Width(m.width).
+		Height(m.height).
+		Align(lipgloss.Center, lipgloss.Center).
+		Render(modalContent)
+}
+
+// renderTaskItem renders a single task in the list.
+func (m *CommandPaletteModel) renderTaskItem(task *db.Task, isSelected bool, width int) string {
+	// Status icon
+	statusIcon := StatusIcon(task.Status)
+	statusColor := StatusColor(task.Status)
+
+	// Build the line
+	var line strings.Builder
+
+	// Selection indicator
+	if isSelected {
+		line.WriteString(lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true).Render("> "))
+	} else {
+		line.WriteString("  ")
+	}
+
+	// Status
+	line.WriteString(lipgloss.NewStyle().Foreground(statusColor).Render(statusIcon))
+	line.WriteString(" ")
+
+	// Task ID
+	idStyle := lipgloss.NewStyle().Foreground(ColorMuted)
+	line.WriteString(idStyle.Render(fmt.Sprintf("#%-4d", task.ID)))
+	line.WriteString(" ")
+
+	// Project tag
+	if task.Project != "" {
+		projectStyle := lipgloss.NewStyle().Foreground(ProjectColor(task.Project))
+		shortProject := task.Project
+		switch task.Project {
+		case "offerlab":
+			shortProject = "ol"
+		case "influencekit":
+			shortProject = "ik"
+		}
+		line.WriteString(projectStyle.Render("[" + shortProject + "]"))
+		line.WriteString(" ")
+	}
+
+	// Title (truncate if needed)
+	title := task.Title
+	currentLen := lipgloss.Width(line.String())
+	maxTitleLen := width - currentLen - 2
+	if maxTitleLen < 10 {
+		maxTitleLen = 10
+	}
+	if len(title) > maxTitleLen {
+		title = title[:maxTitleLen-1] + "..."
+	}
+
+	titleStyle := lipgloss.NewStyle()
+	if isSelected {
+		titleStyle = titleStyle.Bold(true).Foreground(ColorPrimary)
+	}
+	line.WriteString(titleStyle.Render(title))
+
+	return line.String()
+}
+
+// SelectedTask returns the selected task, or nil if cancelled.
+func (m *CommandPaletteModel) SelectedTask() *db.Task {
+	return m.selectedTask
+}
+
+// IsCancelled returns true if the user cancelled the palette.
+func (m *CommandPaletteModel) IsCancelled() bool {
+	return m.cancelled
+}
+
+// SetSize updates the command palette dimensions.
+func (m *CommandPaletteModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	m.searchInput.Width = min(60, width-10)
+}

--- a/internal/ui/command_palette_test.go
+++ b/internal/ui/command_palette_test.go
@@ -1,0 +1,111 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func TestFuzzyMatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		str     string
+		pattern string
+		want    bool
+	}{
+		{"empty pattern", "hello world", "", true},
+		{"empty string", "", "abc", false},
+		{"exact match", "hello", "hello", true},
+		{"substring at start", "hello", "hel", true},
+		{"substring in middle", "hello", "ell", true},
+		{"non-contiguous chars", "hello world", "hwd", true},
+		{"non-contiguous chars complex", "implement feature", "ipf", true},
+		{"no match", "hello", "xyz", false},
+		{"pattern longer than string", "hi", "hello", false},
+		{"case sensitive no match", "Hello", "hello", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fuzzyMatch(tt.str, tt.pattern)
+			if got != tt.want {
+				t.Errorf("fuzzyMatch(%q, %q) = %v, want %v", tt.str, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandPaletteFiltering(t *testing.T) {
+	tasks := []*db.Task{
+		{ID: 1, Title: "Implement login feature", Project: "webapp", Status: db.StatusBacklog},
+		{ID: 2, Title: "Fix bug in dashboard", Project: "webapp", Status: db.StatusProcessing},
+		{ID: 3, Title: "Add unit tests", Project: "api", Status: db.StatusDone},
+		{ID: 42, Title: "Command palette", Project: "workflow", Status: db.StatusQueued},
+	}
+
+	tests := []struct {
+		name     string
+		query    string
+		expected int // number of expected results
+	}{
+		{"empty query shows all", "", 4},
+		{"filter by ID", "42", 1},
+		{"filter by ID with hash", "#42", 1},
+		{"filter by title word", "bug", 1},
+		{"filter by project", "webapp", 2},
+		{"filter by status", "done", 1},
+		{"fuzzy match", "ilf", 1}, // "Implement login feature"
+		{"no results", "nonexistent", 0},
+		{"partial ID match", "4", 1}, // matches only ID 42 (contains "4")
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a minimal command palette model for testing
+			m := &CommandPaletteModel{
+				allTasks: tasks,
+			}
+			m.searchInput.SetValue(tt.query)
+			m.filterTasks()
+
+			if len(m.filteredTasks) != tt.expected {
+				t.Errorf("query %q: got %d results, want %d", tt.query, len(m.filteredTasks), tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchesQuery(t *testing.T) {
+	task := &db.Task{
+		ID:      123,
+		Title:   "Implement search feature",
+		Project: "myproject",
+		Status:  db.StatusBacklog,
+	}
+
+	m := &CommandPaletteModel{}
+
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"match by ID", "123", true},
+		{"match by ID with hash", "#123", true},
+		{"partial ID", "12", true},
+		{"match by title", "search", true},
+		{"match by project", "myproject", true},
+		{"match by status", "backlog", true},
+		{"fuzzy match title", "isf", true}, // "Implement search feature"
+		{"no match", "xyz", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := m.matchesQuery(task, tt.query)
+			if got != tt.want {
+				t.Errorf("matchesQuery(%+v, %q) = %v, want %v", task, tt.query, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a VS Code-style command palette (`Ctrl+P` / `p`) for quickly jumping to any task
- Implements fuzzy search by task title, ID (with or without #), project, or status
- Provides keyboard navigation with up/down arrows, Enter to select, Esc to cancel
- Includes centered modal overlay that integrates with existing theme

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual testing: Press `p` or `Ctrl+P` on dashboard to open palette
- [ ] Manual testing: Type to filter tasks by title/ID/project
- [ ] Manual testing: Navigate with arrow keys, select with Enter
- [ ] Manual testing: Press Esc to close without selecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)