### PR TITLE
feat: use GitHub API to detect merged PRs for task auto-close

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1887,7 +1887,8 @@ func (e *Executor) checkMergedBranches() {
 }
 
 // isBranchMerged checks if a task's branch has been merged into the default branch.
-// Uses git commands to detect merged branches. All commands have timeouts to prevent blocking.
+// First checks GitHub API for PR merge status (most reliable), then falls back to git commands.
+// All commands have timeouts to prevent blocking.
 func (e *Executor) isBranchMerged(task *db.Task) bool {
 	projectDir := e.getProjectDir(task.Project)
 	if projectDir == "" {
@@ -1898,6 +1899,16 @@ func (e *Executor) isBranchMerged(task *db.Task) bool {
 	gitDir := filepath.Join(projectDir, ".git")
 	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
 		return false
+	}
+
+	// First, check GitHub API for PR merge status (most reliable method)
+	// This directly tells us if the PR was merged, regardless of branch deletion
+	if e.prCache != nil && task.BranchName != "" {
+		prInfo := e.prCache.GetPRForBranch(projectDir, task.BranchName)
+		if prInfo != nil && prInfo.State == github.PRStateMerged {
+			e.logger.Debug("PR detected as merged via GitHub API", "branch", task.BranchName, "pr", prInfo.Number)
+			return true
+		}
 	}
 
 	// Get the default branch


### PR DESCRIPTION
## Summary
- Enhanced `isBranchMerged()` to first check the GitHub API for PR merge status before falling back to git commands
- This ensures more reliable detection of merged PRs, especially when branches are auto-deleted after merge
- The existing git-based detection remains as a fallback

## Test plan
- [x] Verified all tests pass (`go test ./...`)
- [x] Verified the code compiles (`go build ./...`)
- [ ] Manual testing: merge a PR and verify the task is auto-closed within 30 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)