### PR TITLE
fix: make Command+P task switcher work in all views

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -414,6 +414,14 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
+		// Command palette works from any view
+		if key.Matches(msg, m.keys.CommandPalette) {
+			m.commandPaletteView = NewCommandPaletteModel(m.db, m.tasks, m.width, m.height)
+			m.previousView = m.currentView
+			m.currentView = ViewCommandPalette
+			return m, m.commandPaletteView.Init()
+		}
+
 		// Route to current view
 		switch m.currentView {
 		case ViewDashboard:
@@ -976,12 +984,6 @@ func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.previousView = m.currentView
 		m.currentView = ViewMemories
 		return m, nil
-
-	case key.Matches(msg, m.keys.CommandPalette):
-		m.commandPaletteView = NewCommandPaletteModel(m.db, m.tasks, m.width, m.height)
-		m.previousView = m.currentView
-		m.currentView = ViewCommandPalette
-		return m, m.commandPaletteView.Init()
 
 	case key.Matches(msg, m.keys.Refresh):
 		m.loading = true


### PR DESCRIPTION
## Summary
- Move Command+P keyboard shortcut from view-specific `updateDashboard()` to global keyboard handler in `Update()`
- This allows the task switcher to be opened from any view (Detail, Memories, Attachments, etc.)
- Previously only worked in the Dashboard/Kanban view

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [ ] Manual testing: Press Command+P (or `p` or Ctrl+P) from:
  - Dashboard view (Kanban)
  - Detail view
  - Memories view
  - Attachments view
- [ ] Verify task selection navigates correctly from each view

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)