### PR TITLE
fix: handle scroll offset when clicking tasks in kanban board

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -557,8 +557,29 @@ func (k *KanbanBoard) HandleClick(x, y int) *db.Task {
 		maxTasks = 1
 	}
 
-	taskIdx := taskAreaY / taskCardHeight
-	if taskIdx >= len(col.Tasks) || taskIdx >= maxTasks {
+	// Get scroll offset for this column
+	scrollOffset := 0
+	if colIdx < len(k.scrollOffsets) {
+		scrollOffset = k.scrollOffsets[colIdx]
+	}
+
+	// Account for scroll indicator line when scrolled
+	if scrollOffset > 0 {
+		taskAreaY -= 1 // Subtract 1 for the "↑ N more" indicator line
+		if taskAreaY < 0 {
+			// Clicked on scroll indicator
+			return nil
+		}
+	}
+
+	visibleTaskIdx := taskAreaY / taskCardHeight
+	if visibleTaskIdx >= maxTasks {
+		return nil
+	}
+
+	// Convert visible index to actual task index
+	taskIdx := scrollOffset + visibleTaskIdx
+	if taskIdx >= len(col.Tasks) {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- Fixed the `HandleClick` function in the kanban board that wasn't accounting for scroll offset when determining which task was clicked
- This caused clicks to select the wrong task or return nil when the column was scrolled, preventing users from clicking on the first visible task

## Test plan
- [x] Ran existing tests - all pass including `TestKanbanBoard_HandleClick`
- [ ] Manual testing: Click on tasks in a scrolled kanban column to verify correct task is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)