### PR TITLE
feat: add scheduled and recurring tasks

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -205,6 +205,10 @@ func (db *DB) migrate() error {
 		`ALTER TABLE tasks ADD COLUMN worktree_path TEXT DEFAULT ''`,
 		`ALTER TABLE tasks ADD COLUMN branch_name TEXT DEFAULT ''`,
 		`ALTER TABLE tasks ADD COLUMN port INTEGER DEFAULT 0`,
+		// Scheduled task columns
+		`ALTER TABLE tasks ADD COLUMN scheduled_at DATETIME`,   // When to next run (null = not scheduled)
+		`ALTER TABLE tasks ADD COLUMN recurrence TEXT DEFAULT ''`, // Recurrence pattern (empty = one-time)
+		`ALTER TABLE tasks ADD COLUMN last_run_at DATETIME`,    // When last executed (for recurring tasks)
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -845,6 +845,20 @@ func (m *DetailModel) renderHeader() string {
 		meta.WriteString(prDesc)
 	}
 
+	// Schedule info
+	if t.IsScheduled() {
+		meta.WriteString("  ")
+		scheduleStyle := lipgloss.NewStyle().
+			Padding(0, 1).
+			Background(lipgloss.Color("214")). // Orange
+			Foreground(lipgloss.Color("#000000"))
+		scheduleText := "⏰ " + formatScheduleTime(t.ScheduledAt.Time)
+		if t.IsRecurring() {
+			scheduleText += " (" + t.Recurrence + ")"
+		}
+		meta.WriteString(scheduleStyle.Render(scheduleText))
+	}
+
 	// Tmux hint if session is active
 	if m.claudePaneID != "" {
 		meta.WriteString("  ")

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/github"
@@ -440,6 +441,17 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool) 
 		b.WriteString(PRStatusBadge(prInfo))
 	}
 
+	// Schedule indicator
+	if task.IsScheduled() {
+		scheduleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // Orange for schedule
+		scheduleText := formatScheduleTime(task.ScheduledAt.Time)
+		if task.IsRecurring() {
+			scheduleText = task.Recurrence[0:1] + ":" + scheduleText // e.g., "h:2:30pm" for hourly
+		}
+		b.WriteString(" ")
+		b.WriteString(scheduleStyle.Render("⏰" + scheduleText))
+	}
+
 	// Title (truncate if needed)
 	title := task.Title
 	maxTitleLen := width - 4
@@ -567,4 +579,45 @@ func (k *KanbanBoard) HandleClick(x, y int) *db.Task {
 	k.selectedRow = taskIdx
 
 	return col.Tasks[taskIdx]
+}
+
+// formatScheduleTime formats a scheduled time for display.
+func formatScheduleTime(t time.Time) string {
+	now := time.Now()
+	diff := t.Sub(now)
+
+	// If in the past
+	if diff < 0 {
+		return "overdue"
+	}
+
+	// If less than an hour away
+	if diff < time.Hour {
+		mins := int(diff.Minutes())
+		if mins <= 0 {
+			return "now"
+		}
+		return fmt.Sprintf("%dm", mins)
+	}
+
+	// If less than 24 hours away
+	if diff < 24*time.Hour {
+		hours := int(diff.Hours())
+		return fmt.Sprintf("%dh", hours)
+	}
+
+	// If today or tomorrow
+	if t.Day() == now.Day() && t.Month() == now.Month() && t.Year() == now.Year() {
+		return t.Format("3:04pm")
+	}
+	tomorrow := now.AddDate(0, 0, 1)
+	if t.Day() == tomorrow.Day() && t.Month() == tomorrow.Month() && t.Year() == tomorrow.Year() {
+		return "tmrw " + t.Format("3pm")
+	}
+
+	// Otherwise show date
+	if t.Year() == now.Year() {
+		return t.Format("Jan 2")
+	}
+	return t.Format("Jan 2 '06")
 }


### PR DESCRIPTION
## Summary
- Add support for scheduling tasks to run at specific times
- Add recurring task patterns: hourly, daily, weekly, monthly
- Recurring tasks preserve context by reusing the same worktree and Claude instance
- If a recurring task is still running when next recurrence is due, it's skipped

## Features

### Scheduling
- New Schedule field in task form accepts natural language: `1h`, `2h30m`, `tomorrow 9am`, `2024-01-15 14:00`
- New Recurrence selector: none, hourly, daily, weekly, monthly

### UI
- Schedule indicator (⏰) shown on task cards in kanban board
- Schedule badge shown in task detail header with countdown/time

### Executor
- Polls for due scheduled tasks every 10 seconds
- Automatically queues tasks when their scheduled time arrives
- After recurring task completes, resets to backlog for next scheduled run

## Test plan
- [x] Create a task with schedule "1h" - verify scheduled_at is set 1 hour in future
- [x] Create a recurring hourly task - verify it queues when due
- [x] Verify recurring task resets to backlog after completion
- [x] Verify if task is still running, next recurrence is skipped
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)