### PR TITLE
Add confirmation dialog for project deletion

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -802,6 +802,26 @@ func (db *DB) DeleteProject(id int64) error {
 	return nil
 }
 
+// CountTasksByProject returns the number of tasks associated with a project name.
+func (db *DB) CountTasksByProject(projectName string) (int, error) {
+	var count int
+	err := db.QueryRow("SELECT COUNT(*) FROM tasks WHERE project = ?", projectName).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count tasks: %w", err)
+	}
+	return count, nil
+}
+
+// CountMemoriesByProject returns the number of memories associated with a project name.
+func (db *DB) CountMemoriesByProject(projectName string) (int, error) {
+	var count int
+	err := db.QueryRow("SELECT COUNT(*) FROM project_memories WHERE project = ?", projectName).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count memories: %w", err)
+	}
+	return count, nil
+}
+
 // ListProjects returns all projects, with "personal" always first.
 func (db *DB) ListProjects() ([]*Project, error) {
 	rows, err := db.Query(`

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -1574,3 +1574,126 @@ func TestCreateTaskDefaultsToPersonal(t *testing.T) {
 		t.Errorf("expected project 'personal', got '%s'", retrieved.Project)
 	}
 }
+
+func TestCountTasksByProject(t *testing.T) {
+	// Create temporary database
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+	defer os.Remove(dbPath)
+
+	// Create a test project
+	project := &Project{
+		Name: "test-project",
+		Path: tmpDir,
+	}
+	if err := db.CreateProject(project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	// Initially no tasks for project
+	count, err := db.CountTasksByProject("test-project")
+	if err != nil {
+		t.Fatalf("failed to count tasks: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 tasks, got %d", count)
+	}
+
+	// Create tasks for the project
+	for i := 0; i < 3; i++ {
+		task := &Task{
+			Title:   "Test Task",
+			Status:  StatusBacklog,
+			Type:    TypeCode,
+			Project: "test-project",
+		}
+		if err := db.CreateTask(task); err != nil {
+			t.Fatalf("failed to create task: %v", err)
+		}
+	}
+
+	// Count should now be 3
+	count, err = db.CountTasksByProject("test-project")
+	if err != nil {
+		t.Fatalf("failed to count tasks: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 tasks, got %d", count)
+	}
+
+	// Count for non-existent project should be 0
+	count, err = db.CountTasksByProject("nonexistent-project")
+	if err != nil {
+		t.Fatalf("failed to count tasks: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 tasks for nonexistent project, got %d", count)
+	}
+}
+
+func TestCountMemoriesByProject(t *testing.T) {
+	// Create temporary database
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+	defer os.Remove(dbPath)
+
+	// Create a test project
+	project := &Project{
+		Name: "test-project",
+		Path: tmpDir,
+	}
+	if err := db.CreateProject(project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	// Initially no memories for project
+	count, err := db.CountMemoriesByProject("test-project")
+	if err != nil {
+		t.Fatalf("failed to count memories: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 memories, got %d", count)
+	}
+
+	// Create memories for the project
+	for i := 0; i < 2; i++ {
+		memory := &ProjectMemory{
+			Project:  "test-project",
+			Category: MemoryCategoryGeneral,
+			Content:  "Test memory content",
+		}
+		if err := db.CreateMemory(memory); err != nil {
+			t.Fatalf("failed to create memory: %v", err)
+		}
+	}
+
+	// Count should now be 2
+	count, err = db.CountMemoriesByProject("test-project")
+	if err != nil {
+		t.Fatalf("failed to count memories: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 memories, got %d", count)
+	}
+
+	// Count for non-existent project should be 0
+	count, err = db.CountMemoriesByProject("nonexistent-project")
+	if err != nil {
+		t.Fatalf("failed to count memories: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 memories for nonexistent project, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary
- Added confirmation dialog when deleting a project in Settings
- Shows count of tasks and memories that will become orphaned
- Prevents accidental deletion of projects with associated data
- Added helper methods `CountTasksByProject` and `CountMemoriesByProject` to the database layer

## Test plan
- [ ] Navigate to Settings (press 's' from dashboard)
- [ ] Select a project and press 'd' to delete
- [ ] Verify confirmation dialog appears with project name
- [ ] Verify dialog shows count of orphaned tasks/memories (if any)
- [ ] Verify pressing Esc cancels the deletion
- [ ] Verify confirming "Delete" actually deletes the project
- [ ] Verify attempting to delete "personal" project shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)