### PR TITLE
fix: allow tab navigation out of instructions textarea in settings forms

### DIFF
--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -336,13 +336,7 @@ func (m *SettingsModel) updateProjectForm(msg tea.KeyMsg) (*SettingsModel, tea.C
 		m.editProject = nil
 		return m, nil
 	case "tab":
-		// Tab moves forward through fields (unless in textarea)
-		if m.projectFormFocus == 3 {
-			// In instructions textarea, tab inserts tab character
-			var cmd tea.Cmd
-			m.instructionsInput, cmd = m.instructionsInput.Update(msg)
-			return m, cmd
-		}
+		// Tab moves forward through fields
 		m.projectFormFocus = (m.projectFormFocus + 1) % 4
 		m.updateProjectFormFocus()
 		if m.projectFormFocus == 1 {
@@ -451,13 +445,7 @@ func (m *SettingsModel) updateTaskTypeForm(msg tea.KeyMsg) (*SettingsModel, tea.
 		m.editTaskType = nil
 		return m, nil
 	case "tab":
-		// Tab moves forward through fields (unless in textarea)
-		if m.typeFormFocus == 2 {
-			// In instructions textarea, tab inserts tab character
-			var cmd tea.Cmd
-			m.typeInstructionsInput, cmd = m.typeInstructionsInput.Update(msg)
-			return m, cmd
-		}
+		// Tab moves forward through fields
 		m.typeFormFocus = (m.typeFormFocus + 1) % 3
 		m.updateTaskTypeFormFocus()
 		if m.typeFormFocus == 2 {


### PR DESCRIPTION
## Summary
- Fixed tab navigation in the Project editing form - users can now tab out of the instructions textarea field
- Fixed the same issue in the Task Type editing form

Previously, pressing Tab while in the instructions textarea would insert a tab character instead of moving to the next form field, making it impossible to navigate out of the field using keyboard alone.

## Test plan
- [ ] Open Settings and edit a project
- [ ] Tab through the form fields (Name → Path → Aliases → Instructions → Name)
- [ ] Verify Tab works to move forward from the Instructions field
- [ ] Open Settings and edit a task type
- [ ] Verify Tab works to navigate through all fields including out of Instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)