### PR TITLE
feat: remove kill command functionality

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -278,39 +278,6 @@ Use --hard to kill all tmux sessions for a complete reset.`,
 	}
 	claudesCmd.AddCommand(claudesListCmd)
 
-	claudesKillCmd := &cobra.Command{
-		Use:   "kill <task-id>",
-		Short: "Kill a Claude session by task ID",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			var taskID int
-			if _, err := fmt.Sscanf(args[0], "%d", &taskID); err != nil {
-				fmt.Fprintln(os.Stderr, errorStyle.Render("Invalid task ID: "+args[0]))
-				os.Exit(1)
-			}
-			if err := killClaudeSession(taskID); err != nil {
-				fmt.Fprintln(os.Stderr, errorStyle.Render(err.Error()))
-				os.Exit(1)
-			}
-			fmt.Println(successStyle.Render(fmt.Sprintf("Killed session for task %d", taskID)))
-		},
-	}
-	claudesCmd.AddCommand(claudesKillCmd)
-
-	claudesKillallCmd := &cobra.Command{
-		Use:   "killall",
-		Short: "Kill all Claude sessions",
-		Run: func(cmd *cobra.Command, args []string) {
-			count := killAllClaudeSessions()
-			if count == 0 {
-				fmt.Println(dimStyle.Render("No Claude sessions running"))
-			} else {
-				fmt.Println(successStyle.Render(fmt.Sprintf("Killed %d session(s)", count)))
-			}
-		},
-	}
-	claudesCmd.AddCommand(claudesKillallCmd)
-
 	rootCmd.AddCommand(claudesCmd)
 
 	// Delete subcommand - delete a task, kill its Claude session, and remove worktree
@@ -2080,18 +2047,6 @@ func killClaudeSession(taskID int) error {
 	}
 
 	return nil
-}
-
-// killAllClaudeSessions kills all task-* tmux windows in task-daemon.
-func killAllClaudeSessions() int {
-	sessions := getClaudeSessions()
-	count := 0
-	for _, s := range sessions {
-		if err := killClaudeSession(s.taskID); err == nil {
-			count++
-		}
-	}
-	return count
 }
 
 // deleteTask deletes a task, its Claude session, and its worktree.

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -956,15 +956,7 @@ func (m *DetailModel) renderHelp() string {
 		}{"x", "execute"})
 	}
 
-	hasSession := m.hasActiveTmuxSession()
 	hasPanes := m.claudePaneID != "" || m.workdirPaneID != ""
-	// Show kill option if there's an active tmux session
-	if hasSession {
-		keys = append(keys, struct {
-			key  string
-			desc string
-		}{"k", "kill"})
-	}
 
 	keys = append(keys, struct {
 		key  string


### PR DESCRIPTION
## Summary
- Removes the non-functional `kill` and `killall` CLI commands from `task claudes`
- Removes the 'k' keybinding for kill in the TUI
- Removes the kill confirmation dialog and all related state/functions

Users can simply use Ctrl+C to terminate Claude sessions, making the kill command redundant.

## Test plan
- [x] Build succeeds (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Verify 'k' key no longer triggers kill dialog in TUI
- [ ] Verify `task claudes kill` and `task claudes killall` commands are removed


🤖 Generated with [Claude Code](https://claude.com/claude-code)