### PR TITLE
feat: add distinct colors to project labels

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -295,6 +295,9 @@ func NewAppModel(database *db.DB, exec *executor.Executor, workingDir string) *A
 	// Load saved theme from database
 	LoadThemeFromDB(database.GetSetting)
 
+	// Load project colors into cache
+	LoadProjectColors(database)
+
 	// Start with zero size - will be set by WindowSizeMsg
 	kanban := NewKanbanBoard(0, 0)
 

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -548,6 +548,11 @@ func (m *SettingsModel) saveProject() (*SettingsModel, tea.Cmd) {
 		return m, nil
 	}
 
+	// Update the project color cache
+	if m.editProject.Color != "" {
+		SetProjectColor(m.editProject.Name, m.editProject.Color)
+	}
+
 	m.editingProject = false
 	m.editProject = nil
 	m.err = nil


### PR DESCRIPTION
## Summary
- Add color column to projects table for storing hex colors
- Create project color cache with thread-safe access for UI rendering
- Auto-assign distinct colors from a palette of 8 visually distinct colors to projects on migration
- Load project colors on app startup and update cache on save

## Test plan
- [x] Run `go test ./...` - all tests pass
- [x] Build successfully with `go build ./...`
- [ ] Manually verify projects display with distinct colors on the kanban board
- [ ] Verify new projects get assigned colors automatically
- [ ] Verify colors persist across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)