### PR TITLE
fix: improve scheduled task label format

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -852,7 +852,11 @@ func (m *DetailModel) renderHeader() string {
 			Padding(0, 1).
 			Background(lipgloss.Color("214")). // Orange
 			Foreground(lipgloss.Color("#000000"))
-		scheduleText := "⏰ " + formatScheduleTime(t.ScheduledAt.Time)
+		icon := "⏰"
+		if t.IsRecurring() {
+			icon = "🔁"
+		}
+		scheduleText := icon + " " + formatScheduleTime(t.ScheduledAt.Time)
 		if t.IsRecurring() {
 			scheduleText += " (" + t.Recurrence + ")"
 		}

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -652,11 +652,12 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool) 
 	if task.IsScheduled() {
 		scheduleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // Orange for schedule
 		scheduleText := formatScheduleTime(task.ScheduledAt.Time)
+		icon := "⏰"
 		if task.IsRecurring() {
-			scheduleText = task.Recurrence[0:1] + ":" + scheduleText // e.g., "h:2:30pm" for hourly
+			icon = "🔁" // Use repeat icon to indicate recurring task
 		}
 		b.WriteString(" ")
-		b.WriteString(scheduleStyle.Render("⏰" + scheduleText))
+		b.WriteString(scheduleStyle.Render(icon + scheduleText))
 	}
 
 	// Title (truncate if needed)


### PR DESCRIPTION
## Summary
- Changed the scheduled task label from confusing format like `d:6h` to use distinct icons
- One-time scheduled tasks show: `⏰6h`
- Recurring tasks show: `🔁6h`
- Detail view also updated for consistency, showing `🔁 6h (daily)` for recurring tasks

## Test plan
- [ ] Create a one-time scheduled task and verify it shows `⏰` icon
- [ ] Create a recurring task and verify it shows `🔁` icon  
- [ ] Open detail view for recurring task and verify it shows `🔁` icon with recurrence info

🤖 Generated with [Claude Code](https://claude.com/claude-code)