### PR TITLE
feat: add arrow key shortcuts to navigate tasks in detail view

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1003,6 +1003,36 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.showChangeStatus(m.selectedTask)
 	}
 
+	// Arrow key navigation to prev/next task in the same column
+	if key.Matches(keyMsg, m.keys.Up) {
+		// Clean up current detail view before switching
+		if m.detailView != nil {
+			m.detailView.Cleanup()
+			m.detailView = nil
+		}
+		// Move selection up in the kanban
+		m.kanban.MoveUp()
+		// Load the new task
+		if task := m.kanban.SelectedTask(); task != nil {
+			return m, m.loadTask(task.ID)
+		}
+		return m, nil
+	}
+	if key.Matches(keyMsg, m.keys.Down) {
+		// Clean up current detail view before switching
+		if m.detailView != nil {
+			m.detailView.Cleanup()
+			m.detailView = nil
+		}
+		// Move selection down in the kanban
+		m.kanban.MoveDown()
+		// Load the new task
+		if task := m.kanban.SelectedTask(); task != nil {
+			return m, m.loadTask(task.ID)
+		}
+		return m, nil
+	}
+
 	if m.detailView != nil {
 		var cmd tea.Cmd
 		m.detailView, cmd = m.detailView.Update(msg)

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -944,7 +944,7 @@ func (m *DetailModel) renderHelp() string {
 		key  string
 		desc string
 	}{
-		{"↑/↓", "scroll"},
+		{"↑/↓", "prev/next task"},
 	}
 
 	// Only show execute when task is not currently processing


### PR DESCRIPTION
## Summary
- When viewing task details, pressing ↑/↓ arrow keys (or j/k) navigates to the previous/next task in the same kanban column
- Updates the help bar to show "↑/↓ prev/next task" instead of "↑/↓ scroll"
- Properly cleans up tmux panes before switching to the new task

## Test plan
- [ ] Open a task from a kanban column with multiple tasks
- [ ] Press ↑ or k to navigate to the previous task in the column
- [ ] Press ↓ or j to navigate to the next task in the column
- [ ] Verify the detail view updates to show the new task
- [ ] Verify navigation wraps around (at the bottom, pressing ↓ goes to the top)
- [ ] Verify tmux panes are properly cleaned up and recreated when switching tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)