### PR TITLE
feat: improve task details labeling with task number and position

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -465,6 +465,9 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.executor.ResumeTask(msg.task.ID)
 			}
 			m.detailView = NewDetailModel(msg.task, m.db, m.executor, m.width, m.height)
+			// Set task position in column for display
+			pos, total := m.kanban.GetTaskPosition()
+			m.detailView.SetPosition(pos, total)
 			m.previousView = m.currentView
 			m.currentView = ViewDetail
 			// Start tmux output ticker if session is active

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -757,6 +757,19 @@ func (k *KanbanBoard) ColumnCount() int {
 	return len(k.columns)
 }
 
+// GetTaskPosition returns the position of the currently selected task in its column.
+// Returns (position, total) where position is 1-indexed, or (0, 0) if no task is selected.
+func (k *KanbanBoard) GetTaskPosition() (int, int) {
+	if k.selectedCol < 0 || k.selectedCol >= len(k.columns) {
+		return 0, 0
+	}
+	col := k.columns[k.selectedCol]
+	if len(col.Tasks) == 0 || k.selectedRow < 0 || k.selectedRow >= len(col.Tasks) {
+		return 0, 0
+	}
+	return k.selectedRow + 1, len(col.Tasks) // 1-indexed position
+}
+
 // HandleClick handles a mouse click at the given coordinates.
 // Returns the clicked task if a task card was clicked, nil otherwise.
 // Also updates the selection to the clicked task.


### PR DESCRIPTION
## Summary
- Replace 'Details' panel label with 'Task X' showing the task number
- Add position indicator (e.g. 1/12) showing task's position in the kanban column
- Update tmux pane title to show task number and position (useful for navigation context)

## Test plan
- [ ] Open a task from the kanban board
- [ ] Verify the header shows "Task X (N/M)" format where N is position, M is total
- [ ] Verify the tmux pane title shows "Task X (N/M)" format
- [ ] Navigate with arrow keys and verify position updates correctly
- [ ] Verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)