### PR TITLE
fix: show S (status) shortcut in task detail view help bar

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -975,6 +975,14 @@ func (m *DetailModel) renderHelp() string {
 		}{"r", "retry"})
 	}
 
+	// Only show status change when task is not currently processing
+	if !isProcessing {
+		keys = append(keys, struct {
+			key  string
+			desc string
+		}{"S", "status"})
+	}
+
 	// Show Tab shortcut when panes are visible
 	if hasPanes && os.Getenv("TMUX") != "" {
 		keys = append(keys, struct {


### PR DESCRIPTION
## Summary
- The status change shortcut (Shift+S) was implemented in the detail view but not shown in the help bar
- This adds the "S status" help text to the detail view, with the same conditional logic as other shortcuts (only shown when task is not currently processing)

Fixes #267

## Test plan
- [x] Open a task in detail view
- [x] Verify "S status" appears in the help bar when task is not processing
- [x] Press Shift+S to confirm the status change modal opens
- [x] Verify the shortcut is hidden when task is processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)