### PR TITLE
feat: allow users to change task status at any time

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -848,10 +848,6 @@ func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keys.ChangeStatus):
 		if task := m.kanban.SelectedTask(); task != nil {
-			// Don't allow changing status if task is currently processing
-			if task.Status == db.StatusProcessing {
-				return m, nil
-			}
 			return m.showChangeStatus(task)
 		}
 
@@ -964,10 +960,6 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.editTaskForm.Init()
 	}
 	if key.Matches(keyMsg, m.keys.ChangeStatus) && m.selectedTask != nil {
-		// Don't allow changing status if task is currently processing
-		if m.selectedTask.Status == db.StatusProcessing {
-			return m, nil
-		}
 		return m.showChangeStatus(m.selectedTask)
 	}
 
@@ -1317,8 +1309,7 @@ func (m *AppModel) showChangeStatus(task *db.Task) (tea.Model, tea.Cmd) {
 	m.pendingChangeStatusTask = task
 	m.changeStatusValue = task.Status
 
-	// Build status options - exclude processing (can't manually set to processing)
-	// and exclude the current status
+	// Build status options - exclude the current status
 	statusOptions := []huh.Option[string]{}
 	allStatuses := []struct {
 		value string
@@ -1326,6 +1317,7 @@ func (m *AppModel) showChangeStatus(task *db.Task) (tea.Model, tea.Cmd) {
 	}{
 		{db.StatusBacklog, "◦ Backlog"},
 		{db.StatusQueued, "▶ Queued"},
+		{db.StatusProcessing, "▶ Processing"},
 		{db.StatusBlocked, "⚠ Blocked"},
 		{db.StatusDone, "✓ Done"},
 	}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1017,13 +1017,11 @@ func (m *DetailModel) renderHelp() string {
 		}{"r", "retry"})
 	}
 
-	// Only show status change when task is not currently processing
-	if !isProcessing {
-		keys = append(keys, struct {
-			key  string
-			desc string
-		}{"S", "status"})
-	}
+	// Always show status change option
+	keys = append(keys, struct {
+		key  string
+		desc string
+	}{"S", "status"})
 
 	// Show Tab shortcut when panes are visible
 	if hasPanes && os.Getenv("TMUX") != "" {


### PR DESCRIPTION
## Summary
- Users can now change task status even when a task is in "processing" state
- The status (S) shortcut is now always visible in the help bar
- "Processing" is now available as a status option in the change status modal

## Changes Made
- Removed status change restrictions from dashboard view (internal/ui/app.go:851-854)
- Removed status change restrictions from detail view (internal/ui/app.go:967-970)
- Updated help bar to always show status shortcut (internal/ui/detail.go:1020-1026)
- Added StatusProcessing to available status options in the change status modal (internal/ui/app.go:1320)

## Motivation
Previously, users were blocked from changing a task's status when it was in the "processing" state. This limitation prevented users from having full control over their tasks. With this change, users have complete freedom to move tasks into any status they want, regardless of the current state.

## Test plan
- [x] Build succeeds without errors
- [x] Code changes verified through git diff
- [ ] Manual testing: Start a task (status becomes "processing")
- [ ] Manual testing: Press 'S' to change status - modal should appear
- [ ] Manual testing: Verify "Processing" appears as an option in the modal
- [ ] Manual testing: Change status to any other state successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)