### PR TITLE
feat: Add magic paste functionality for task titles

### DIFF
--- a/internal/ui/form_magic_paste_test.go
+++ b/internal/ui/form_magic_paste_test.go
@@ -1,0 +1,196 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestFormModel_MagicPaste_GitHubPR(t *testing.T) {
+	// Create a form model
+	form := NewFormModel(nil, 100, 30, "")
+
+	// Simulate pasting a GitHub PR URL into the title field
+	pasteMsg := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("https://github.com/owner/repo/pull/123"),
+		Paste: true,
+	}
+
+	// Process the paste
+	_, _ = form.Update(pasteMsg)
+
+	// Verify the title was set correctly
+	expectedTitle := "repo #123"
+	if form.titleInput.Value() != expectedTitle {
+		t.Errorf("Expected title %q, got %q", expectedTitle, form.titleInput.Value())
+	}
+
+	// Verify PR URL and number were extracted
+	expectedPRURL := "https://github.com/owner/repo/pull/123"
+	if form.prURL != expectedPRURL {
+		t.Errorf("Expected PRURL %q, got %q", expectedPRURL, form.prURL)
+	}
+
+	expectedPRNumber := 123
+	if form.prNumber != expectedPRNumber {
+		t.Errorf("Expected PRNumber %d, got %d", expectedPRNumber, form.prNumber)
+	}
+}
+
+func TestFormModel_MagicPaste_GitHubIssue(t *testing.T) {
+	// Create a form model
+	form := NewFormModel(nil, 100, 30, "")
+
+	// Simulate pasting a GitHub Issue URL into the title field
+	pasteMsg := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("https://github.com/owner/repo/issues/42"),
+		Paste: true,
+	}
+
+	// Process the paste
+	_, _ = form.Update(pasteMsg)
+
+	// Verify the title was set correctly
+	expectedTitle := "repo #42"
+	if form.titleInput.Value() != expectedTitle {
+		t.Errorf("Expected title %q, got %q", expectedTitle, form.titleInput.Value())
+	}
+
+	// GitHub issues don't populate PR fields
+	if form.prURL != "" {
+		t.Errorf("Expected empty PRURL for issue, got %q", form.prURL)
+	}
+
+	if form.prNumber != 0 {
+		t.Errorf("Expected PRNumber 0 for issue, got %d", form.prNumber)
+	}
+}
+
+func TestFormModel_MagicPaste_Linear(t *testing.T) {
+	// Create a form model
+	form := NewFormModel(nil, 100, 30, "")
+
+	// Simulate pasting a Linear URL into the title field
+	pasteMsg := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("https://linear.app/myteam/issue/PROJ-456/fix-the-bug"),
+		Paste: true,
+	}
+
+	// Process the paste
+	_, _ = form.Update(pasteMsg)
+
+	// Verify the title was set correctly
+	expectedTitle := "PROJ-456"
+	if form.titleInput.Value() != expectedTitle {
+		t.Errorf("Expected title %q, got %q", expectedTitle, form.titleInput.Value())
+	}
+
+	// Linear issues don't populate PR fields
+	if form.prURL != "" {
+		t.Errorf("Expected empty PRURL for Linear issue, got %q", form.prURL)
+	}
+
+	if form.prNumber != 0 {
+		t.Errorf("Expected PRNumber 0 for Linear issue, got %d", form.prNumber)
+	}
+}
+
+func TestFormModel_MagicPaste_RegularText(t *testing.T) {
+	// Create a form model
+	form := NewFormModel(nil, 100, 30, "")
+
+	// Set an initial value
+	form.titleInput.SetValue("Initial ")
+
+	// Simulate pasting regular text (not a URL)
+	pasteMsg := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("some regular text"),
+		Paste: true,
+	}
+
+	// Process the paste
+	_, _ = form.Update(pasteMsg)
+
+	// Verify the text was appended (not replaced)
+	expectedTitle := "Initial some regular text"
+	if form.titleInput.Value() != expectedTitle {
+		t.Errorf("Expected title %q, got %q", expectedTitle, form.titleInput.Value())
+	}
+
+	// PR fields should remain empty
+	if form.prURL != "" {
+		t.Errorf("Expected empty PRURL, got %q", form.prURL)
+	}
+
+	if form.prNumber != 0 {
+		t.Errorf("Expected PRNumber 0, got %d", form.prNumber)
+	}
+}
+
+func TestFormModel_MagicPaste_OnlyWorksInTitleField(t *testing.T) {
+	// Create a form model
+	form := NewFormModel(nil, 100, 30, "")
+
+	// Focus on body field
+	form.focused = FieldBody
+
+	// Simulate pasting a GitHub PR URL into the body field
+	pasteMsg := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("https://github.com/owner/repo/pull/999"),
+		Paste: true,
+	}
+
+	// Process the paste
+	_, _ = form.Update(pasteMsg)
+
+	// Verify magic paste did NOT happen - the URL should be pasted as-is
+	expectedBody := "https://github.com/owner/repo/pull/999"
+	if form.bodyInput.Value() != expectedBody {
+		t.Errorf("Expected body %q, got %q", expectedBody, form.bodyInput.Value())
+	}
+
+	// PR fields should remain empty
+	if form.prURL != "" {
+		t.Errorf("Expected empty PRURL when pasting into body, got %q", form.prURL)
+	}
+
+	if form.prNumber != 0 {
+		t.Errorf("Expected PRNumber 0 when pasting into body, got %d", form.prNumber)
+	}
+
+	// Title should remain empty
+	if form.titleInput.Value() != "" {
+		t.Errorf("Expected empty title, got %q", form.titleInput.Value())
+	}
+}
+
+func TestFormModel_GetDBTask_IncludesPRInfo(t *testing.T) {
+	// Create a form model
+	form := NewFormModel(nil, 100, 30, "")
+
+	// Set PR info via magic paste
+	form.titleInput.SetValue("repo #123")
+	form.prURL = "https://github.com/owner/repo/pull/123"
+	form.prNumber = 123
+
+	// Get the DB task
+	task := form.GetDBTask()
+
+	// Verify PR info is included
+	if task.PRURL != "https://github.com/owner/repo/pull/123" {
+		t.Errorf("Expected task.PRURL %q, got %q", "https://github.com/owner/repo/pull/123", task.PRURL)
+	}
+
+	if task.PRNumber != 123 {
+		t.Errorf("Expected task.PRNumber %d, got %d", 123, task.PRNumber)
+	}
+
+	if task.Title != "repo #123" {
+		t.Errorf("Expected task.Title %q, got %q", "repo #123", task.Title)
+	}
+}

--- a/internal/ui/url_parser.go
+++ b/internal/ui/url_parser.go
@@ -1,0 +1,105 @@
+package ui
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ParsedURL contains information extracted from a pasted URL
+type ParsedURL struct {
+	OriginalURL string
+	Type        string // "github_pr", "github_issue", "linear"
+	Title       string // Extracted or generated title
+	PRURL       string // For GitHub PRs
+	PRNumber    int    // For GitHub PRs
+	IssueNumber int    // For GitHub issues or Linear issues
+	IssueID     string // For Linear (e.g., "PROJ-123")
+}
+
+var (
+	// GitHub PR URL: https://github.com/owner/repo/pull/123
+	githubPRRegex = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$`)
+
+	// GitHub Issue URL: https://github.com/owner/repo/issues/123
+	githubIssueRegex = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)(?:[/?#].*)?$`)
+
+	// Linear URL: https://linear.app/team/issue/PROJ-123/issue-title
+	linearRegex = regexp.MustCompile(`^https?://linear\.app/([^/]+)/issue/([A-Z]+-\d+)(?:/.*)?$`)
+)
+
+// ParseURL attempts to parse a pasted string and extract structured information
+// Returns nil if the string is not a recognized URL pattern
+func ParseURL(input string) *ParsedURL {
+	input = strings.TrimSpace(input)
+
+	// Try GitHub PR
+	if matches := githubPRRegex.FindStringSubmatch(input); matches != nil {
+		owner := matches[1]
+		repo := matches[2]
+		prNumber, _ := strconv.Atoi(matches[3])
+
+		return &ParsedURL{
+			OriginalURL: input,
+			Type:        "github_pr",
+			Title:       formatGitHubPRTitle(owner, repo, prNumber),
+			PRURL:       normalizeGitHubURL(input),
+			PRNumber:    prNumber,
+		}
+	}
+
+	// Try GitHub Issue
+	if matches := githubIssueRegex.FindStringSubmatch(input); matches != nil {
+		owner := matches[1]
+		repo := matches[2]
+		issueNumber, _ := strconv.Atoi(matches[3])
+
+		return &ParsedURL{
+			OriginalURL: input,
+			Type:        "github_issue",
+			Title:       formatGitHubIssueTitle(owner, repo, issueNumber),
+			IssueNumber: issueNumber,
+		}
+	}
+
+	// Try Linear
+	if matches := linearRegex.FindStringSubmatch(input); matches != nil {
+		team := matches[1]
+		issueID := matches[2]
+
+		return &ParsedURL{
+			OriginalURL: input,
+			Type:        "linear",
+			Title:       formatLinearTitle(team, issueID),
+			IssueID:     issueID,
+		}
+	}
+
+	return nil
+}
+
+// normalizeGitHubURL removes query params, fragments, and trailing slashes to get clean PR URL
+func normalizeGitHubURL(url string) string {
+	// Extract base URL without query params or fragments
+	if idx := strings.Index(url, "?"); idx != -1 {
+		url = url[:idx]
+	}
+	if idx := strings.Index(url, "#"); idx != -1 {
+		url = url[:idx]
+	}
+	// Remove trailing slash
+	url = strings.TrimSuffix(url, "/")
+	return url
+}
+
+func formatGitHubPRTitle(owner, repo string, prNumber int) string {
+	return repo + " #" + strconv.Itoa(prNumber)
+}
+
+func formatGitHubIssueTitle(owner, repo string, issueNumber int) string {
+	return repo + " #" + strconv.Itoa(issueNumber)
+}
+
+func formatLinearTitle(team, issueID string) string {
+	return issueID
+}

--- a/internal/ui/url_parser_test.go
+++ b/internal/ui/url_parser_test.go
@@ -1,0 +1,242 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestParseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *ParsedURL
+	}{
+		// GitHub PR tests
+		{
+			name:  "GitHub PR basic",
+			input: "https://github.com/owner/repo/pull/123",
+			expected: &ParsedURL{
+				OriginalURL: "https://github.com/owner/repo/pull/123",
+				Type:        "github_pr",
+				Title:       "repo #123",
+				PRURL:       "https://github.com/owner/repo/pull/123",
+				PRNumber:    123,
+			},
+		},
+		{
+			name:  "GitHub PR with query params",
+			input: "https://github.com/owner/repo/pull/456?tab=files",
+			expected: &ParsedURL{
+				OriginalURL: "https://github.com/owner/repo/pull/456?tab=files",
+				Type:        "github_pr",
+				Title:       "repo #456",
+				PRURL:       "https://github.com/owner/repo/pull/456",
+				PRNumber:    456,
+			},
+		},
+		{
+			name:  "GitHub PR with fragment",
+			input: "https://github.com/owner/repo/pull/789#issuecomment-123456",
+			expected: &ParsedURL{
+				OriginalURL: "https://github.com/owner/repo/pull/789#issuecomment-123456",
+				Type:        "github_pr",
+				Title:       "repo #789",
+				PRURL:       "https://github.com/owner/repo/pull/789",
+				PRNumber:    789,
+			},
+		},
+		{
+			name:  "GitHub PR http (not https)",
+			input: "http://github.com/owner/repo/pull/999",
+			expected: &ParsedURL{
+				OriginalURL: "http://github.com/owner/repo/pull/999",
+				Type:        "github_pr",
+				Title:       "repo #999",
+				PRURL:       "http://github.com/owner/repo/pull/999",
+				PRNumber:    999,
+			},
+		},
+		{
+			name:  "GitHub PR with trailing slash",
+			input: "https://github.com/owner/repo/pull/111/",
+			expected: &ParsedURL{
+				OriginalURL: "https://github.com/owner/repo/pull/111/",
+				Type:        "github_pr",
+				Title:       "repo #111",
+				PRURL:       "https://github.com/owner/repo/pull/111",
+				PRNumber:    111,
+			},
+		},
+		// GitHub Issue tests
+		{
+			name:  "GitHub Issue basic",
+			input: "https://github.com/owner/repo/issues/42",
+			expected: &ParsedURL{
+				OriginalURL: "https://github.com/owner/repo/issues/42",
+				Type:        "github_issue",
+				Title:       "repo #42",
+				IssueNumber: 42,
+			},
+		},
+		{
+			name:  "GitHub Issue with query params",
+			input: "https://github.com/owner/repo/issues/99?q=is%3Aopen",
+			expected: &ParsedURL{
+				OriginalURL: "https://github.com/owner/repo/issues/99?q=is%3Aopen",
+				Type:        "github_issue",
+				Title:       "repo #99",
+				IssueNumber: 99,
+			},
+		},
+		// Linear tests
+		{
+			name:  "Linear basic",
+			input: "https://linear.app/myteam/issue/PROJ-123",
+			expected: &ParsedURL{
+				OriginalURL: "https://linear.app/myteam/issue/PROJ-123",
+				Type:        "linear",
+				Title:       "PROJ-123",
+				IssueID:     "PROJ-123",
+			},
+		},
+		{
+			name:  "Linear with issue title",
+			input: "https://linear.app/myteam/issue/PROJ-456/fix-the-bug",
+			expected: &ParsedURL{
+				OriginalURL: "https://linear.app/myteam/issue/PROJ-456/fix-the-bug",
+				Type:        "linear",
+				Title:       "PROJ-456",
+				IssueID:     "PROJ-456",
+			},
+		},
+		{
+			name:  "Linear with longer issue title",
+			input: "https://linear.app/workflow/issue/WF-789/implement-magic-paste-functionality",
+			expected: &ParsedURL{
+				OriginalURL: "https://linear.app/workflow/issue/WF-789/implement-magic-paste-functionality",
+				Type:        "linear",
+				Title:       "WF-789",
+				IssueID:     "WF-789",
+			},
+		},
+		// Non-matching tests
+		{
+			name:     "Regular text",
+			input:    "just some regular text",
+			expected: nil,
+		},
+		{
+			name:     "GitHub but not PR or issue",
+			input:    "https://github.com/owner/repo",
+			expected: nil,
+		},
+		{
+			name:     "GitHub PR malformed (no number)",
+			input:    "https://github.com/owner/repo/pull/",
+			expected: nil,
+		},
+		{
+			name:     "Random URL",
+			input:    "https://example.com/some/path",
+			expected: nil,
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "Whitespace only",
+			input:    "   ",
+			expected: nil,
+		},
+		{
+			name:  "GitHub PR with whitespace",
+			input: "  https://github.com/owner/repo/pull/123  ",
+			expected: &ParsedURL{
+				OriginalURL: "https://github.com/owner/repo/pull/123",
+				Type:        "github_pr",
+				Title:       "repo #123",
+				PRURL:       "https://github.com/owner/repo/pull/123",
+				PRNumber:    123,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseURL(tt.input)
+
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("Expected nil, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Errorf("Expected %+v, got nil", tt.expected)
+				return
+			}
+
+			if result.OriginalURL != tt.expected.OriginalURL {
+				t.Errorf("OriginalURL: expected %q, got %q", tt.expected.OriginalURL, result.OriginalURL)
+			}
+			if result.Type != tt.expected.Type {
+				t.Errorf("Type: expected %q, got %q", tt.expected.Type, result.Type)
+			}
+			if result.Title != tt.expected.Title {
+				t.Errorf("Title: expected %q, got %q", tt.expected.Title, result.Title)
+			}
+			if result.PRURL != tt.expected.PRURL {
+				t.Errorf("PRURL: expected %q, got %q", tt.expected.PRURL, result.PRURL)
+			}
+			if result.PRNumber != tt.expected.PRNumber {
+				t.Errorf("PRNumber: expected %d, got %d", tt.expected.PRNumber, result.PRNumber)
+			}
+			if result.IssueNumber != tt.expected.IssueNumber {
+				t.Errorf("IssueNumber: expected %d, got %d", tt.expected.IssueNumber, result.IssueNumber)
+			}
+			if result.IssueID != tt.expected.IssueID {
+				t.Errorf("IssueID: expected %q, got %q", tt.expected.IssueID, result.IssueID)
+			}
+		})
+	}
+}
+
+func TestNormalizeGitHubURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL with query params",
+			input:    "https://github.com/owner/repo/pull/123?tab=files",
+			expected: "https://github.com/owner/repo/pull/123",
+		},
+		{
+			name:     "URL with fragment",
+			input:    "https://github.com/owner/repo/pull/123#issuecomment-456",
+			expected: "https://github.com/owner/repo/pull/123",
+		},
+		{
+			name:     "URL with both query and fragment",
+			input:    "https://github.com/owner/repo/pull/123?tab=files#top",
+			expected: "https://github.com/owner/repo/pull/123",
+		},
+		{
+			name:     "URL without query or fragment",
+			input:    "https://github.com/owner/repo/pull/123",
+			expected: "https://github.com/owner/repo/pull/123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeGitHubURL(tt.input)
+			if result != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Implements automatic parsing and formatting when pasting GitHub PR, GitHub Issue, or Linear ticket URLs into the task title field.

## Changes
- ✨ Created `url_parser.go` with `ParseURL()` to extract structured info from URLs
- ✅ Supports GitHub PRs (e.g., `github.com/owner/repo/pull/123`)
- ✅ Supports GitHub Issues (e.g., `github.com/owner/repo/issues/42`)
- ✅ Supports Linear tickets (e.g., `linear.app/team/issue/PROJ-123`)
- 🔧 Modified `form.go` paste handler to detect and process URLs in title field
- 📝 Auto-populates task title with formatted reference (e.g., "repo #123", "PROJ-456")
- 💾 Stores GitHub PR URL and number in task for later association
- 🧪 Added comprehensive unit and integration tests (100% pass rate)

## How It Works
When users paste a supported URL into the task title:
1. The URL is parsed and validated using regex patterns
2. Title is replaced with a clean, formatted reference
3. For GitHub PRs, `PRURL` and `PRNumber` are stored on the task
4. Non-URL text continues to work as before (appended to field)
5. Magic paste only activates when the title field is focused

## Examples
- Paste `https://github.com/bborn/taskyou/pull/123` → Title becomes "taskyou #123"
- Paste `https://github.com/owner/repo/issues/42` → Title becomes "repo #42"  
- Paste `https://linear.app/team/issue/PROJ-456/bug-fix` → Title becomes "PROJ-456"
- Paste regular text → Works as before (appended to current value)

## Test Coverage
- ✅ URL parsing for all supported formats
- ✅ URL normalization (removes query params, fragments, trailing slashes)
- ✅ Integration with form paste handler
- ✅ Behavior differs based on focused field
- ✅ Task creation includes PR metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)