### PR TITLE
fix: use 'mergeable' field for PR conflict detection

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -49,7 +49,7 @@ type ghPRResponse struct {
 	State               string `json:"state"`
 	IsDraft             bool   `json:"isDraft"`
 	Title               string `json:"title"`
-	MergeStateStatus    string `json:"mergeStateStatus"`
+	Mergeable           string `json:"mergeable"`
 	StatusCheckRollup   []ghCheck `json:"statusCheckRollup"`
 	UpdatedAt           string `json:"updatedAt"`
 }
@@ -133,9 +133,9 @@ func fetchPRInfo(repoDir, branchName string) *PRInfo {
 	defer cancel()
 
 	// Query for PR associated with this branch
-	// gh pr view <branch> --json number,url,state,isDraft,title,mergeStateStatus,statusCheckRollup,updatedAt
+	// gh pr view <branch> --json number,url,state,isDraft,title,mergeable,statusCheckRollup,updatedAt
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", branchName,
-		"--json", "number,url,state,isDraft,title,mergeStateStatus,statusCheckRollup,updatedAt")
+		"--json", "number,url,state,isDraft,title,mergeable,statusCheckRollup,updatedAt")
 	cmd.Dir = repoDir
 
 	output, err := cmd.Output()
@@ -155,7 +155,7 @@ func fetchPRInfo(repoDir, branchName string) *PRInfo {
 		URL:       resp.URL,
 		Title:     resp.Title,
 		IsDraft:   resp.IsDraft,
-		Mergeable: resp.MergeStateStatus,
+		Mergeable: resp.Mergeable,
 	}
 
 	// Parse state
@@ -295,7 +295,7 @@ type ghPRListResponse struct {
 	IsDraft           bool      `json:"isDraft"`
 	Title             string    `json:"title"`
 	HeadRefName       string    `json:"headRefName"`
-	MergeStateStatus  string    `json:"mergeStateStatus"`
+	Mergeable         string    `json:"mergeable"`
 	StatusCheckRollup []ghCheck `json:"statusCheckRollup"`
 	UpdatedAt         string    `json:"updatedAt"`
 }
@@ -316,7 +316,7 @@ func FetchAllPRsForRepo(repoDir string) map[string]*PRInfo {
 	// Get all open PRs in one call
 	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
 		"--state", "open",
-		"--json", "number,url,state,isDraft,title,headRefName,mergeStateStatus,statusCheckRollup,updatedAt",
+		"--json", "number,url,state,isDraft,title,headRefName,mergeable,statusCheckRollup,updatedAt",
 		"--limit", "100")
 	cmd.Dir = repoDir
 
@@ -343,7 +343,7 @@ func FetchAllPRsForRepo(repoDir string) map[string]*PRInfo {
 
 	cmd2 := exec.CommandContext(ctx2, "gh", "pr", "list",
 		"--state", "merged",
-		"--json", "number,url,state,isDraft,title,headRefName,mergeStateStatus,updatedAt",
+		"--json", "number,url,state,isDraft,title,headRefName,mergeable,updatedAt",
 		"--limit", "20")
 	cmd2.Dir = repoDir
 
@@ -373,7 +373,7 @@ func parsePRListResponse(pr *ghPRListResponse) *PRInfo {
 		URL:       pr.URL,
 		Title:     pr.Title,
 		IsDraft:   pr.IsDraft,
-		Mergeable: pr.MergeStateStatus,
+		Mergeable: pr.Mergeable,
 	}
 
 	// Parse state


### PR DESCRIPTION
## Summary

- Fixed PR merge conflict detection by using the correct GitHub API field
- Tasks with PRs that have merge conflicts now properly display the conflict indicator

## Problem

The merge conflict detection feature was implemented but not working because:
- The code was querying GitHub's `mergeStateStatus` field (returns "DIRTY", "CLEAN", etc.)
- But checking for the value `"CONFLICTING"` (which only appears in the `mergeable` field)
- This meant PRs with conflicts were never detected

## Solution

Updated all GitHub CLI queries to use the `mergeable` field instead of `mergeStateStatus`:
- Single PR queries: `gh pr view`
- Batch PR queries: `gh pr list` (both open and merged)
- Updated both JSON struct definitions and parsing code

## Testing

- ✅ All existing unit tests pass (github and ui packages)
- ✅ Verified with actual PR #140 which has conflicts: `gh pr view` now returns `"mergeable":"CONFLICTING"`

## Changes

**File**: `internal/github/pr.go`
- Updated `ghPRResponse` struct to use `Mergeable` field
- Updated `ghPRListResponse` struct to use `Mergeable` field  
- Changed all 3 GitHub CLI queries to request `mergeable` instead of `mergeStateStatus`
- Updated response parsing to use `resp.Mergeable` instead of `resp.MergeStateStatus`

## User Impact

Users will now see:
- Red "C" badge on tasks with PRs that have merge conflicts
- "Has conflicts" status description in both Kanban board and detail view
- This status updates every 30 seconds with the PR refresh cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)