### PR TITLE
feat: add keyboard shortcut to toggle dangerous mode for running tasks

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1016,6 +1016,14 @@ func (m *DetailModel) renderHelp() string {
 		desc string
 	}{"S", "status"})
 
+	// Show dangerous mode toggle when task is processing or blocked
+	if m.task != nil && (m.task.Status == db.StatusProcessing || m.task.Status == db.StatusBlocked) {
+		keys = append(keys, struct {
+			key  string
+			desc string
+		}{"!", "dangerous mode"})
+	}
+
 	// Show Tab shortcut when panes are visible
 	if hasPanes && os.Getenv("TMUX") != "" {
 		keys = append(keys, struct {


### PR DESCRIPTION
## Summary
Adds a keyboard shortcut (`!`) in the task detail view to restart a running Claude instance with `--dangerously-skip-permissions` flag enabled.

This allows users to enable dangerous mode for a specific running task without restarting the daemon or affecting other tasks.

## Changes Made

### UI Changes
- Added `ToggleDangerous` key binding mapped to `!` key
- Added help text showing `! dangerous mode` when task is processing or blocked
- Wire up keyboard handler to call new executor method

### Executor Changes
- Implemented `ResumeDangerous()` method that:
  - Kills the current Claude tmux window for the task
  - Restarts Claude with `--resume <sessionID> --dangerously-skip-permissions`
  - Preserves the Claude session state for continuity
  - Only works if task has a Claude session ID

### App Model Changes
- Added `toggleDangerousMode()` command to handle the keyboard shortcut
- Added `taskDangerousModeToggledMsg` message type for UI updates

## How It Works

1. User presses `!` while viewing a processing or blocked task
2. The executor kills the current Claude tmux window
3. A new Claude process starts with the same session ID but with `--dangerously-skip-permissions` flag
4. Claude resumes from where it left off, but now without permission prompts
5. Task execution log shows "Claude restarted in dangerous mode"

## Testing

- Code compiles without errors
- Keyboard shortcut only shows for processing/blocked tasks
- Method preserves Claude session for continuity

## Related

Closes #302

## Notes

- This only affects the specific task, not the global daemon mode
- The dangerous flag is forced regardless of `WORKTREE_DANGEROUS_MODE` setting
- The feature requires an active Claude session (task must have been started at least once)