### PR TITLE
Fix: Automatically kill Claude processes when tasks complete to prevent memory waste

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1724,7 +1724,10 @@ func (m *AppModel) deleteTask(id int64) tea.Cmd {
 			return taskDeletedMsg{err: err}
 		}
 
-		// Kill Claude session if running (ignore errors)
+		// Kill Claude process to free memory
+		m.executor.KillClaudeProcess(id)
+
+		// Kill tmux window (ignore errors)
 		windowTarget := executor.TmuxSessionName(id)
 		osExec.Command("tmux", "kill-window", "-t", windowTarget).Run()
 


### PR DESCRIPTION
## Summary

- Added automatic cleanup of Claude processes when tasks complete, are interrupted, or are deleted
- Prevents accumulation of orphaned Claude processes that consume 100MB+ each
- Uses graceful SIGTERM shutdown

## Problem

Tasks were leaving Claude processes running even after completion, interruption, or deletion. Over time, users would accumulate 100+ orphaned Claude processes, each consuming significant memory (100MB+). This resulted in severe memory waste on development machines.

## Solution

Implemented `KillClaudeProcess()` method that:
1. Finds the Claude process PID for a given task
2. Sends SIGTERM for graceful shutdown
3. Cleans up suspended task tracking
4. Is called automatically when:
   - Tasks complete successfully (StatusDone)
   - Tasks are interrupted/closed (StatusBacklog)
   - Tasks are explicitly deleted via UI

## Test Plan

- [x] Built project successfully with `make build`
- [x] All existing tests pass with `make test`
- [x] Verified cleanup logic is called at task completion
- [x] Verified cleanup logic is called at task interruption
- [x] Verified cleanup logic is called at task deletion
- [x] Reviewed code changes for correctness

## Impact

Users will no longer experience memory bloat from orphaned Claude processes. Memory usage should remain stable even after working with many tasks over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)