### PR TITLE
fix: display task execution log newest to oldest

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -686,7 +686,7 @@ func (db *DB) GetTaskLogs(taskID int64, limit int) ([]*TaskLog, error) {
 		SELECT id, task_id, line_type, content, created_at
 		FROM task_logs
 		WHERE task_id = ?
-		ORDER BY id ASC
+		ORDER BY id DESC
 		LIMIT ?
 	`, taskID, limit)
 	if err != nil {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -87,15 +87,10 @@ func (m *DetailModel) Refresh() {
 	// Reload logs
 	logs, err := m.database.GetTaskLogs(m.task.ID, 500)
 	if err == nil {
-		wasAtBottom := m.viewport.AtBottom()
-		prevLogCount := len(m.logs)
 		m.logs = logs
 
 		if m.ready {
 			m.viewport.SetContent(m.renderContent())
-			if wasAtBottom || len(logs) > prevLogCount {
-				m.viewport.GotoBottom()
-			}
 		}
 	}
 
@@ -182,7 +177,6 @@ func (m *DetailModel) initViewport() {
 
 	m.viewport = viewport.New(m.width-4, vpHeight)
 	m.viewport.SetContent(m.renderContent())
-	m.viewport.GotoBottom()
 	m.ready = true
 }
 


### PR DESCRIPTION
## Summary
- Change execution log display order from oldest-first to newest-first
- Remove unreliable scroll-to-bottom handling in favor of normal scrolling
- New log entries now appear at the top where they're immediately visible

## Test plan
- [x] Project builds successfully
- [x] All tests pass
- [ ] Open task detail view and verify logs show newest first
- [ ] Add new log entries and verify they appear at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)