### PR TITLE
feat: warn before closing a task with confirmation dialog

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1671,7 +1671,7 @@ func (e *Executor) ResumeSafe(taskID int64) bool {
 	}
 
 	// Ensure task-daemon session exists
-	if err := ensureTmuxDaemon(); err != nil {
+	if _, err := ensureTmuxDaemon(); err != nil {
 		e.logger.Warn("could not create task-daemon session", "error", err)
 		return false
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -114,3 +114,82 @@ func TestShowChangeStatus_ExcludesCurrentStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestShowCloseConfirm_SetsUpConfirmation(t *testing.T) {
+	// Create a minimal app model
+	m := &AppModel{
+		width: 100,
+	}
+
+	// Create a test task
+	task := &db.Task{
+		ID:     42,
+		Title:  "Test Task to Close",
+		Status: db.StatusQueued,
+	}
+
+	// Call showCloseConfirm
+	m.showCloseConfirm(task)
+
+	// Verify that the close confirmation form was created
+	if m.closeConfirm == nil {
+		t.Fatal("closeConfirm form was not created")
+	}
+
+	// Verify that the current view is set to ViewCloseConfirm
+	if m.currentView != ViewCloseConfirm {
+		t.Errorf("currentView = %v, want %v", m.currentView, ViewCloseConfirm)
+	}
+
+	// Verify that the pending close task is set correctly
+	if m.pendingCloseTask != task {
+		t.Error("pendingCloseTask was not set correctly")
+	}
+
+	// Verify that the confirm value starts as false (user hasn't confirmed yet)
+	if m.closeConfirmValue != false {
+		t.Error("closeConfirmValue should be false initially")
+	}
+}
+
+func TestShowCloseConfirm_DifferentTasks(t *testing.T) {
+	m := &AppModel{
+		width: 100,
+	}
+
+	tests := []struct {
+		name   string
+		taskID int64
+		title  string
+		status string
+	}{
+		{"backlog task", 1, "Backlog Task", db.StatusBacklog},
+		{"queued task", 2, "In Progress Task", db.StatusQueued},
+		{"processing task", 3, "Processing Task", db.StatusProcessing},
+		{"blocked task", 4, "Blocked Task", db.StatusBlocked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &db.Task{
+				ID:     tt.taskID,
+				Title:  tt.title,
+				Status: tt.status,
+			}
+
+			m.showCloseConfirm(task)
+
+			if m.closeConfirm == nil {
+				t.Fatal("closeConfirm form was not created")
+			}
+
+			if m.currentView != ViewCloseConfirm {
+				t.Errorf("currentView = %v, want %v", m.currentView, ViewCloseConfirm)
+			}
+
+			if m.pendingCloseTask != task {
+				t.Error("pendingCloseTask was not set correctly")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add a confirmation dialog when pressing 'c' to close a task, preventing accidental closures
- Follow the same pattern as existing delete and quit confirmation dialogs
- Users must explicitly confirm before a task is marked as done and its tmux window is killed

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] New tests added for close confirmation functionality
- [ ] Manual testing: Press 'c' on a task in dashboard view - confirmation dialog should appear
- [ ] Manual testing: Press 'c' on a task in detail view - confirmation dialog should appear  
- [ ] Manual testing: Press Escape to cancel the confirmation
- [ ] Manual testing: Confirm close to mark task as done

🤖 Generated with [Claude Code](https://claude.com/claude-code)