### PR TITLE
fix: prevent pane height shrinking during task transitions

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -985,9 +985,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.taskTransitionInProgress = true
-		// Clean up current detail view before switching
+		// Clean up current detail view before switching (without saving height
+		// to avoid rounding error accumulation that causes pane to shrink)
 		if m.detailView != nil {
-			m.detailView.Cleanup()
+			m.detailView.CleanupWithoutSaving()
 			m.detailView = nil
 		}
 		// Move selection up in the kanban
@@ -1005,9 +1006,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.taskTransitionInProgress = true
-		// Clean up current detail view before switching
+		// Clean up current detail view before switching (without saving height
+		// to avoid rounding error accumulation that causes pane to shrink)
 		if m.detailView != nil {
-			m.detailView.Cleanup()
+			m.detailView.CleanupWithoutSaving()
 			m.detailView = nil
 		}
 		// Move selection down in the kanban

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -227,10 +227,19 @@ func (m *DetailModel) Update(msg tea.Msg) (*DetailModel, tea.Cmd) {
 }
 
 // Cleanup should be called when leaving detail view.
+// It saves the current pane height before breaking the panes.
 func (m *DetailModel) Cleanup() {
 	if m.claudePaneID != "" || m.workdirPaneID != "" {
-		// breakTmuxPanes saves pane positions before breaking
-		m.breakTmuxPanes()
+		m.breakTmuxPanes(true)
+	}
+}
+
+// CleanupWithoutSaving cleans up panes without saving the height.
+// Use this during task transitions (prev/next) to avoid rounding errors
+// that accumulate with each transition and cause the pane to shrink.
+func (m *DetailModel) CleanupWithoutSaving() {
+	if m.claudePaneID != "" || m.workdirPaneID != "" {
+		m.breakTmuxPanes(false)
 	}
 }
 
@@ -740,17 +749,24 @@ func (m *DetailModel) getWorkdir() string {
 }
 
 // breakTmuxPanes breaks both joined panes - kills workdir, returns Claude to task-daemon.
-func (m *DetailModel) breakTmuxPanes() {
+// If saveHeight is true, the current pane height is saved to settings.
+// Pass false during task transitions to avoid rounding error accumulation.
+func (m *DetailModel) breakTmuxPanes(saveHeight bool) {
 	// Use timeout for all tmux operations to prevent blocking UI
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Save pane positions before breaking (must save width before killing workdir pane)
+	// Only save shell width - it doesn't have the same rounding accumulation issue
 	m.saveShellPaneWidth()
-	currentPaneCmd := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}")
-	if currentPaneOut, err := currentPaneCmd.Output(); err == nil {
-		tuiPaneID := strings.TrimSpace(string(currentPaneOut))
-		m.saveDetailPaneHeight(tuiPaneID)
+	// Only save detail pane height when explicitly requested (e.g., leaving detail view)
+	// Skip during task transitions to avoid rounding errors that accumulate
+	if saveHeight {
+		currentPaneCmd := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}")
+		if currentPaneOut, err := currentPaneCmd.Output(); err == nil {
+			tuiPaneID := strings.TrimSpace(string(currentPaneOut))
+			m.saveDetailPaneHeight(tuiPaneID)
+		}
 	}
 
 	// Reset status bar and pane styling


### PR DESCRIPTION
## Summary
- Fixes issue where the task detail pane height gets shorter with each arrow key movement to next/previous task
- Root cause: rounding error accumulation when saving/restoring pane height as integer percentage
- Solution: Skip saving height during task transitions, only save when explicitly leaving detail view

## Changes
- Added `CleanupWithoutSaving()` method to `DetailModel` for task transitions
- Modified `breakTmuxPanes()` to accept `saveHeight` parameter
- Updated arrow key handlers to use `CleanupWithoutSaving()` instead of `Cleanup()`

## Test plan
- [x] Code compiles successfully
- [x] All tests pass
- [ ] Manual test: Navigate between tasks with arrow keys and verify pane height remains consistent
- [ ] Manual test: Exit detail view with escape and verify height is still saved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)