### PR TITLE
feat: clean up Claude sessions and worktree when deleting a task

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -2220,8 +2220,14 @@ func deleteTask(taskID int64) error {
 	// Kill Claude session if running (ignore errors - session may not exist)
 	killClaudeSession(int(taskID))
 
-	// Clean up worktree if it exists
+	// Clean up worktree and Claude sessions if they exist
 	if task.WorktreePath != "" {
+		// Clean up Claude session files first (before worktree is removed)
+		if err := executor.CleanupClaudeSessions(task.WorktreePath); err != nil {
+			fmt.Fprintln(os.Stderr, dimStyle.Render(fmt.Sprintf("Warning: could not remove Claude sessions: %v", err)))
+		}
+
+		// Clean up worktree
 		cfg := config.New(database)
 		exec := executor.New(database, cfg)
 		if err := exec.CleanupWorktree(task); err != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1859,8 +1859,12 @@ func (m *AppModel) deleteTask(id int64) tea.Cmd {
 		windowTarget := executor.TmuxSessionName(id)
 		osExec.Command("tmux", "kill-window", "-t", windowTarget).Run()
 
-		// Clean up worktree if it exists
+		// Clean up worktree and Claude sessions if they exist
 		if task != nil && task.WorktreePath != "" {
+			// Clean up Claude session files first (before worktree is removed)
+			executor.CleanupClaudeSessions(task.WorktreePath)
+
+			// Clean up worktree
 			m.executor.CleanupWorktree(task)
 		}
 


### PR DESCRIPTION
## Summary
- Adds `CleanupClaudeSessions` function to remove Claude session files from `~/.claude/projects/<escaped-path>/` when a task is deleted
- Updates both CLI and UI task deletion flows to call this cleanup before removing the worktree
- Prevents orphaned Claude session data from accumulating on disk

## Test plan
- [x] Added unit tests for `CleanupClaudeSessions` function
- [x] All existing tests pass
- [ ] Manual testing: Delete a task with a worktree and verify Claude session directory is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)