### PR TITLE
fix: remove q key shortcut, use esc only for back navigation

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -111,8 +111,8 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("enter", "view"),
 		),
 		Back: key.NewBinding(
-			key.WithKeys("esc", "q"),
-			key.WithHelp("q/esc", "back"),
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "back"),
 		),
 		New: key.NewBinding(
 			key.WithKeys("n"),

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1213,7 +1213,7 @@ func (m *DetailModel) renderHelp() string {
 	}{
 		{"c", "close"},
 		{"d", "delete"},
-		{"q/esc", "back"},
+		{"esc", "back"},
 	}...)
 
 	var help string

--- a/internal/ui/memories.go
+++ b/internal/ui/memories.go
@@ -408,7 +408,7 @@ func (m *MemoriesModel) renderHelp() string {
 			{"e", "edit"},
 			{"d", "delete"},
 			{"p/tab", "cycle project"},
-			{"q/esc", "back"},
+			{"esc", "back"},
 		}
 	}
 

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -307,7 +307,7 @@ func (m *SettingsModel) updateBrowser(msg tea.Msg) (*SettingsModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "esc", "q":
+		case "esc":
 			m.browsing = false
 			m.fileBrowser = nil
 			return m, nil
@@ -990,7 +990,7 @@ func (m *SettingsModel) renderHelp() string {
 			{"e", "edit"},
 			{"d", "delete"},
 			{"p", "projects dir"},
-			{"q/esc", "back"},
+			{"esc", "back"},
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Remove 'q' key binding for back navigation across all UI views
- Simplify help text from "q/esc" to just "esc"
- Now only 'esc' is used consistently for going back

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual verification: Press esc to go back in detail, settings, and memories views

🤖 Generated with [Claude Code](https://claude.com/claude-code)