### PR TITLE
fix: save correct pane height when user is focused on Claude/Shell pane

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -743,7 +743,7 @@ func (m *DetailModel) joinTmuxPanes() {
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
 
-	// Resize TUI pane to configured height (default 18%)
+	// Resize TUI pane to configured height (default 20%)
 	detailHeight := m.getDetailPaneHeight()
 	exec.CommandContext(ctx, "tmux", "resize-pane", "-t", tuiPaneID, "-y", detailHeight).Run()
 }
@@ -782,12 +782,11 @@ func (m *DetailModel) breakTmuxPanes(saveHeight bool) {
 	m.saveShellPaneWidth()
 	// Only save detail pane height when explicitly requested (e.g., leaving detail view)
 	// Skip during task transitions to avoid rounding errors that accumulate
-	if saveHeight {
-		currentPaneCmd := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}")
-		if currentPaneOut, err := currentPaneCmd.Output(); err == nil {
-			tuiPaneID := strings.TrimSpace(string(currentPaneOut))
-			m.saveDetailPaneHeight(tuiPaneID)
-		}
+	if saveHeight && m.tuiPaneID != "" {
+		// Use the stored TUI pane ID, not the currently focused pane.
+		// The user may have Tab'd to Claude or Shell pane before pressing Escape,
+		// so #{pane_id} could return the wrong pane.
+		m.saveDetailPaneHeight(m.tuiPaneID)
 	}
 
 	// Reset status bar and pane styling


### PR DESCRIPTION
## Summary
- Fixed a bug where the task details pane height would shrink after multiple enter/exit cycles when the user had Tab'd to the Claude or Shell pane before exiting
- The issue was that when saving the pane height, the code queried for the currently focused pane instead of using the stored TUI pane ID
- Also fixed a stale comment that said "default 18%" when the actual default is 20%

## Test plan
- [ ] Open a task detail view
- [ ] Press Tab to switch focus to the Claude pane
- [ ] Press Escape to exit
- [ ] Open another task
- [ ] Verify the details pane height is preserved correctly (not shrunk)
- [ ] Repeat several times to ensure no accumulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)