### PR TITLE
feat: persist kanban board filter across navigation and restarts

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ const (
 	SettingTheme            = "theme"
 	SettingDetailPaneHeight = "detail_pane_height"
 	SettingShellPaneWidth   = "shell_pane_width"
+	SettingKanbanFilter     = "kanban_filter"
 )
 
 // New creates a config from database.


### PR DESCRIPTION
## Summary
- Kanban board filter now persists when navigating to other views and back
- Filter state is saved to the database and restored on app restart
- Filter is automatically reapplied after task operations (create, update, delete)

## Changes Made
- Added `SettingKanbanFilter` constant to config package for the database setting key
- Modified `NewAppModel()` to load persisted filter from database on startup
- Added `persistFilter()` helper function to save filter text to database
- Updated `updateFilterMode()` to persist filter whenever it changes
- Fixed `tasksLoadedMsg` handler to reapply filter after tasks are reloaded

## Technical Details
The implementation addresses two key issues:
1. **Filter loss during navigation**: Previously, when tasks were reloaded (e.g., after creating a task or navigating), the filter was cleared. Now `applyFilter()` is called after `tasksLoadedMsg` to restore the filtered view.
2. **No persistence across restarts**: The filter is now saved to the `settings` table using the existing `GetSetting`/`SetSetting` infrastructure, and loaded during app initialization.

## Test Plan
- [x] Build passes (`go build`)
- [x] All tests pass (`go test ./internal/ui/... -v`)
- [x] Filter persists when navigating to detail view and back
- [x] Filter persists after creating/updating/deleting tasks
- [x] Filter persists after app restart

Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)