### PR TITLE
fix: improve task recurrence visibility and logging

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -524,6 +524,16 @@ Examples:
 						"project":    t.Project,
 						"created_at": t.CreatedAt.Time.Format(time.RFC3339),
 					}
+					// Add schedule fields
+					if t.ScheduledAt != nil {
+						item["scheduled_at"] = t.ScheduledAt.Time.Format(time.RFC3339)
+					}
+					if t.Recurrence != "" {
+						item["recurrence"] = t.Recurrence
+					}
+					if t.LastRunAt != nil {
+						item["last_run_at"] = t.LastRunAt.Time.Format(time.RFC3339)
+					}
 					// Add PR info to JSON output if available
 					if prInfo, ok := prInfoMap[t.ID]; ok {
 						item["pr"] = map[string]interface{}{
@@ -608,11 +618,18 @@ Examples:
 					if t.Project != "" {
 						project = dimStyle.Render(fmt.Sprintf("[%s] ", t.Project))
 					}
+					// Schedule indicator
+					scheduleIndicator := ""
+					if t.IsRecurring() {
+						scheduleIndicator = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render("🔁 ")
+					} else if t.IsScheduled() {
+						scheduleIndicator = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render("⏰ ")
+					}
 					prStatus := ""
 					if showPR {
 						prStatus = prStatusStyle(prInfoMap[t.ID])
 					}
-					fmt.Printf("%s %s %s%s%s\n", id, status, project, t.Title, prStatus)
+					fmt.Printf("%s %s %s%s%s%s\n", id, status, project, scheduleIndicator, t.Title, prStatus)
 				}
 			}
 		},
@@ -696,6 +713,16 @@ Examples:
 				}
 				if task.CompletedAt != nil {
 					output["completed_at"] = task.CompletedAt.Time.Format(time.RFC3339)
+				}
+				// Add schedule fields
+				if task.ScheduledAt != nil {
+					output["scheduled_at"] = task.ScheduledAt.Time.Format(time.RFC3339)
+				}
+				if task.Recurrence != "" {
+					output["recurrence"] = task.Recurrence
+				}
+				if task.LastRunAt != nil {
+					output["last_run_at"] = task.LastRunAt.Time.Format(time.RFC3339)
 				}
 				// Add PR info to JSON output
 				if prInfo != nil {
@@ -788,6 +815,23 @@ Examples:
 					}
 					prStatusStyled := lipgloss.NewStyle().Foreground(prStatusColor).Render(prInfo.StatusDescription())
 					fmt.Printf("CI:       %s\n", prStatusStyled)
+				}
+
+				// Schedule info
+				scheduleColor := lipgloss.Color("#F59E0B") // Orange for schedule
+				if task.IsRecurring() || task.IsScheduled() {
+					fmt.Println()
+					fmt.Println(boldStyle.Render("Schedule:"))
+					if task.Recurrence != "" {
+						recurrenceStyled := lipgloss.NewStyle().Foreground(scheduleColor).Render(task.Recurrence)
+						fmt.Printf("  Recurrence: %s\n", recurrenceStyled)
+					}
+					if task.ScheduledAt != nil {
+						fmt.Printf("  Next run:   %s\n", task.ScheduledAt.Time.Format("2006-01-02 15:04:05"))
+					}
+					if task.LastRunAt != nil {
+						fmt.Printf("  Last run:   %s\n", task.LastRunAt.Time.Format("2006-01-02 15:04:05"))
+					}
 				}
 
 				// Body

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -550,9 +550,12 @@ func (e *Executor) handleRecurringTaskCompletion(task *db.Task) {
 		return
 	}
 
-	e.logLine(task.ID, "system", fmt.Sprintf("Recurring task (%s) will run again at %s",
-		currentTask.Recurrence,
-		currentTask.ScheduledAt.Format("Jan 2 3:04pm")))
+	e.logLine(task.ID, "system", "───────────────────────────────────────────────────────")
+	e.logLine(task.ID, "system", fmt.Sprintf("✅ RECURRING RUN COMPLETED - %s", time.Now().Format("Jan 2, 2006 3:04:05 PM")))
+	e.logLine(task.ID, "system", fmt.Sprintf("   Next run scheduled for: %s (%s)",
+		currentTask.ScheduledAt.Format("Jan 2, 2006 3:04:05 PM"),
+		currentTask.Recurrence))
+	e.logLine(task.ID, "system", "───────────────────────────────────────────────────────")
 
 	// Broadcast the status change
 	e.broadcastTaskEvent(TaskEvent{
@@ -573,12 +576,15 @@ func (e *Executor) queueDueScheduledTasks() {
 	for _, task := range tasks {
 		e.logger.Info("Queuing scheduled task", "id", task.ID, "title", task.Title, "scheduled_at", task.ScheduledAt)
 
-		// Log the scheduled execution
-		msg := "Scheduled task triggered"
+		// Log the scheduled execution with a clear separator
+		e.logLine(task.ID, "system", "")
+		e.logLine(task.ID, "system", "═══════════════════════════════════════════════════════")
 		if task.IsRecurring() {
-			msg = fmt.Sprintf("Recurring task triggered (%s)", task.Recurrence)
+			e.logLine(task.ID, "system", fmt.Sprintf("🔁 RECURRING RUN STARTED (%s) - %s", task.Recurrence, time.Now().Format("Jan 2, 2006 3:04:05 PM")))
+		} else {
+			e.logLine(task.ID, "system", fmt.Sprintf("⏰ SCHEDULED RUN STARTED - %s", time.Now().Format("Jan 2, 2006 3:04:05 PM")))
 		}
-		e.logLine(task.ID, "system", msg)
+		e.logLine(task.ID, "system", "═══════════════════════════════════════════════════════")
 
 		// Queue the task (this also updates the next run time for recurring tasks)
 		if err := e.db.QueueScheduledTask(task.ID); err != nil {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1166,8 +1166,8 @@ func (m *DetailModel) renderHeader() string {
 		meta.WriteString(prDesc)
 	}
 
-	// Schedule info
-	if t.IsScheduled() {
+	// Schedule info - show if scheduled OR recurring
+	if t.IsScheduled() || t.IsRecurring() {
 		meta.WriteString("  ")
 		scheduleStyle := lipgloss.NewStyle().
 			Padding(0, 1).
@@ -1177,11 +1177,24 @@ func (m *DetailModel) renderHeader() string {
 		if t.IsRecurring() {
 			icon = "🔁"
 		}
-		scheduleText := icon + " " + formatScheduleTime(t.ScheduledAt.Time)
+		var scheduleText string
+		if t.IsScheduled() {
+			scheduleText = icon + " " + formatScheduleTime(t.ScheduledAt.Time)
+		} else {
+			scheduleText = icon
+		}
 		if t.IsRecurring() {
 			scheduleText += " (" + t.Recurrence + ")"
 		}
 		meta.WriteString(scheduleStyle.Render(scheduleText))
+
+		// Show last run info for recurring tasks
+		if t.LastRunAt != nil {
+			lastRunStyle := lipgloss.NewStyle().
+				Foreground(lipgloss.Color("214"))
+			lastRunText := fmt.Sprintf(" Last: %s", t.LastRunAt.Time.Format("Jan 2 3:04pm"))
+			meta.WriteString(lastRunStyle.Render(lastRunText))
+		}
 	}
 
 	// PR link if available

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -708,10 +708,13 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool) 
 		b.WriteString(PRStatusBadge(prInfo))
 	}
 
-	// Schedule indicator
-	if task.IsScheduled() {
+	// Schedule indicator - show if scheduled OR recurring
+	if task.IsScheduled() || task.IsRecurring() {
 		scheduleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // Orange for schedule
-		scheduleText := formatScheduleTime(task.ScheduledAt.Time)
+		var scheduleText string
+		if task.IsScheduled() {
+			scheduleText = formatScheduleTime(task.ScheduledAt.Time)
+		}
 		icon := "⏰"
 		if task.IsRecurring() {
 			icon = "🔁" // Use repeat icon to indicate recurring task


### PR DESCRIPTION
## Summary
- Fix task recurrence visibility issues by adding schedule, recurrence, and last_run_at fields to `task show` and `task list` commands
- Show schedule indicators (🔁/⏰) in task list and UI even when scheduled_at is temporarily nil
- Add clear log separators with timestamps for recurring task runs to improve visibility

## Changes

### CLI Commands
- `task show` now displays Schedule section with recurrence pattern, next run time, and last run time
- `task show --json` includes `scheduled_at`, `recurrence`, and `last_run_at` fields
- `task list --json` includes schedule fields
- `task list` shows 🔁 (recurring) or ⏰ (scheduled) indicator next to task title

### UI Improvements
- Detail view shows recurrence info even when scheduled_at is nil
- Shows last run time for recurring tasks in the header
- Kanban board shows schedule indicator for recurring tasks

### Logging Improvements
- Recurring run start: Clear separator with timestamp and recurrence pattern
- Recurring run completion: Clear separator with timestamp and next scheduled time
- Makes it easy to identify each recurrence run in task logs

## Test plan
- [x] All existing tests pass
- [ ] Create a task with hourly recurrence and verify schedule info appears in `task show`
- [ ] Verify `task list --json` includes schedule fields
- [ ] Verify UI shows recurrence indicator even without scheduled_at
- [ ] Check logs show clear separators for recurring runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)