### PR TITLE
feat: render markdown in task descriptions with dynamic width

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1208,11 +1208,20 @@ func (m *DetailModel) renderContent() string {
 		b.WriteString(Bold.Render("Description"))
 		b.WriteString("\n\n")
 
-		rendered, err := glamour.Render(t.Body, "dark")
+		// Create a renderer with the correct width for the viewport
+		renderer, err := glamour.NewTermRenderer(
+			glamour.WithStylePath("dark"),
+			glamour.WithWordWrap(m.width-4), // Match viewport width
+		)
 		if err != nil {
 			b.WriteString(t.Body)
 		} else {
-			b.WriteString(strings.TrimSpace(rendered))
+			rendered, err := renderer.Render(t.Body)
+			if err != nil {
+				b.WriteString(t.Body)
+			} else {
+				b.WriteString(strings.TrimSpace(rendered))
+			}
 		}
 		b.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary
- Updated the task detail view to properly render markdown in task descriptions using glamour with viewport-aware word wrapping
- Previously markdown was rendered with a hardcoded 80-character width, now it adapts to the actual viewport width
- Ensures proper text wrapping regardless of terminal size

## Test plan
- [x] Build compiles successfully
- [x] All existing tests pass
- [ ] Manual testing: Open a task with markdown in the description, verify it renders correctly at various terminal widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)