### PR TITLE
feat: make task description field autogrow to max 50% of screen height

### DIFF
--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -1,0 +1,117 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCalculateBodyHeight(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		screenHeight int
+		screenWidth  int
+		wantMin      int
+		wantMax      int
+	}{
+		{
+			name:         "empty content returns minimum height",
+			content:      "",
+			screenHeight: 50,
+			screenWidth:  100,
+			wantMin:      4,
+			wantMax:      4,
+		},
+		{
+			name:         "single line returns minimum height",
+			content:      "hello world",
+			screenHeight: 50,
+			screenWidth:  100,
+			wantMin:      4,
+			wantMax:      4,
+		},
+		{
+			name:         "multiple lines grows height",
+			content:      "line1\nline2\nline3\nline4\nline5\nline6",
+			screenHeight: 50,
+			screenWidth:  100,
+			wantMin:      6,
+			wantMax:      6,
+		},
+		{
+			name:         "many lines capped at max height (50% of screen)",
+			content:      strings.Repeat("line\n", 50),
+			screenHeight: 50,
+			screenWidth:  100,
+			wantMin:      4,  // at least minimum
+			wantMax:      14, // (50-22)/2 = 14
+		},
+		{
+			name:         "long lines wrap and increase height",
+			content:      strings.Repeat("a", 200), // should wrap on ~76 char width
+			screenHeight: 50,
+			screenWidth:  100,
+			wantMin:      4,
+			wantMax:      6, // wrapped lines
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewFormModel(nil, tt.screenWidth, tt.screenHeight, "")
+			m.bodyInput.SetValue(tt.content)
+
+			height := m.calculateBodyHeight()
+
+			if height < tt.wantMin {
+				t.Errorf("calculateBodyHeight() = %d, want >= %d", height, tt.wantMin)
+			}
+			if height > tt.wantMax {
+				t.Errorf("calculateBodyHeight() = %d, want <= %d", height, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestUpdateBodyHeightSetsHeight(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "")
+
+	// Initially should have minimum height of 4
+	m.updateBodyHeight()
+	// The textarea height is internal, so we just verify no panic
+
+	// Add content and update
+	m.bodyInput.SetValue("line1\nline2\nline3\nline4\nline5")
+	m.updateBodyHeight()
+	// Verify no panic and height should be 5
+
+	// Verify that with large content, height is capped
+	m.bodyInput.SetValue(strings.Repeat("line\n", 100))
+	m.updateBodyHeight()
+	// Should be capped at max height (50% of screen)
+}
+
+func TestMaxHeightIs50PercentOfScreen(t *testing.T) {
+	screenHeights := []int{40, 60, 80, 100}
+
+	for _, screenHeight := range screenHeights {
+		t.Run("screen_height_"+string(rune('0'+screenHeight/10)), func(t *testing.T) {
+			m := NewFormModel(nil, 100, screenHeight, "")
+
+			// Add lots of content to trigger max height
+			m.bodyInput.SetValue(strings.Repeat("line\n", 100))
+
+			height := m.calculateBodyHeight()
+
+			// formOverhead is 22, so maxHeight = (screenHeight - 22) / 2
+			expectedMax := (screenHeight - 22) / 2
+			if expectedMax < 4 {
+				expectedMax = 4
+			}
+
+			if height > expectedMax {
+				t.Errorf("height %d exceeds expected max %d for screen height %d", height, expectedMax, screenHeight)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Task description textarea now dynamically adjusts height based on content
- Minimum height: 4 lines
- Maximum height: 50% of available screen height (accounting for form overhead)
- Added unit tests for the autogrow functionality

## Test plan
- [ ] Create a new task and verify the description field starts with minimum height (4 lines)
- [ ] Type or paste multiple lines and verify the field grows
- [ ] Add many lines and verify it caps at ~50% of screen height
- [ ] Edit an existing task with multi-line description and verify correct initial sizing
- [ ] Run `go test ./internal/ui/...` to verify unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)