### PR TITLE
feat: de-emphasize inactive panes in detail view

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -812,6 +812,11 @@ func (m *DetailModel) joinTmuxPanes() {
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
 
+	// De-emphasize inactive panes - dim text and remove colors
+	// This makes the focused pane more visually prominent
+	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "window-style", "fg=#6b7280").Run()
+	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "window-active-style", "fg=terminal").Run()
+
 	// Resize TUI pane to configured height (default 20%)
 	detailHeight := m.getDetailPaneHeight()
 	exec.CommandContext(ctx, "tmux", "resize-pane", "-t", tuiPaneID, "-y", detailHeight).Run()
@@ -890,6 +895,10 @@ func (m *DetailModel) breakTmuxPanes(saveHeight bool) {
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "pane-border-indicators", "off").Run()
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "pane-border-style", "fg=#374151").Run()
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "pane-active-border-style", "fg=#61AFEF").Run()
+
+	// Reset window styling (remove inactive pane de-emphasis)
+	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "window-style", "default").Run()
+	exec.CommandContext(ctx, "tmux", "set-option", "-t", "task-ui", "window-active-style", "default").Run()
 
 	// Unbind Shift+Arrow keybindings that were set in joinTmuxPanes
 	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "S-Down").Run()


### PR DESCRIPTION
## Summary
- Adds visual de-emphasis to inactive panes when viewing a task in detail view
- Focused pane displays with normal terminal colors, inactive panes show dimmed gray text
- Styles are reset when returning to the main view

## Test plan
- [ ] Open a task in detail view (with Claude and Shell panes visible)
- [ ] Verify the focused pane has normal colors while other panes appear dimmed
- [ ] Switch focus between panes and confirm the de-emphasis follows focus
- [ ] Exit to main view and verify styling is reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)