### PR TITLE
fix: correct kanban click detection to match rendered task positions

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -848,9 +848,8 @@ func (k *KanbanBoard) handleClickDesktop(x, y int) *db.Task {
 	}
 
 	// Calculate Y position within column
-	// Column structure: 1 border line, then header (2 lines with margin), then task cards
-	// Border is 1 line at top
-	headerLines := 3 // Header text + margin
+	// Column structure: 1 border line at top, then header (1 line), then task cards
+	headerLines := 1 // Header bar is 1 line with no margin
 	taskCardHeight := 3
 
 	// relY is position within the column content (after top border)
@@ -931,7 +930,7 @@ func (k *KanbanBoard) handleClickMobile(x, y int) *db.Task {
 	// Click is in the column content area
 	// Column layout: tab bar (2 lines), then border (1 line), header (1 line), task cards
 	colHeight := k.height - tabBarHeight - 2
-	headerLines := 3 // Header text + margin
+	headerLines := 1 // Header bar is 1 line with no margin
 	taskCardHeight := 3
 
 	// relY is position within the column content (after tab bar and top border)


### PR DESCRIPTION
## Summary
- Fixed bug where clicking on the first task in kanban columns did not work
- The click handler incorrectly assumed 3 lines for the header area when only 1 line is actually rendered
- Updated `headerLines` from 3 to 1 in both desktop and mobile click handlers

## Root Cause
The `handleClickDesktop` and `handleClickMobile` functions used `headerLines := 3`, assuming the header bar plus margins took 3 lines. However, the actual rendered layout only has 1 line for the header bar with no padding or margins.

This caused clicks at y=2 (where the first task card actually starts) to be interpreted as clicks on the header area, making the first task unclickable.

## Test plan
- [x] All existing kanban tests updated and passing
- [x] Added regression test `TestKanbanBoard_FirstTaskClickable` that verifies:
  - First task is clickable at y=2, y=3, and y=4 (the full task card area)
  - Header (y=1) and border (y=0) clicks return nil
- [x] Full test suite passes

Fixes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)