### PR TITLE
feat: surface executor name in the UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,12 +367,15 @@ wish.WithPublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `WORKTREE_DB_PATH` | SQLite database path | `~/.local/share/task/tasks.db` |
+| `TASK_EXECUTOR` | Overrides the executor name shown in the UI (e.g., `codex`) | `Claude` |
 | `WORKTREE_TASK_ID` | Current task ID (set by executor) | - |
 | `WORKTREE_PORT` | Task-specific port | - |
 | `WORKTREE_PATH` | Worktree directory | - |
 | `WORKTREE_SESSION_ID` | tmux session ID | - |
 | `WORKTREE_DANGEROUS_MODE` | Skip Claude permissions | - |
 | `WORKTREE_CWD` | Working directory for project detection | - |
+
+Set `TASK_EXECUTOR` before launching `task -l`/`task daemon` to change the executor label shown in the UI (e.g., `TASK_EXECUTOR=codex`). For compatibility, `WORKFLOW_EXECUTOR`, `TASKYOU_EXECUTOR`, and `WORKTREE_EXECUTOR` are also recognized.
 
 ## Project Configuration
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/bborn/workflow/internal/config"
 	"github.com/bborn/workflow/internal/db"
@@ -60,13 +61,64 @@ type Executor struct {
 
 	// Silent mode suppresses log output (for TUI embedding)
 	silent bool
+
+	executorSlug string
+	executorName string
 }
 
 // SuspendIdleTimeout is how long a blocked task must be idle before being suspended.
 const SuspendIdleTimeout = 5 * time.Minute
 
+const (
+	defaultExecutorSlug = "claude"
+	defaultExecutorName = "Claude"
+)
+
+var executorEnvKeys = []string{"TASK_EXECUTOR", "WORKFLOW_EXECUTOR", "TASKYOU_EXECUTOR", "WORKTREE_EXECUTOR"}
+
+// detectExecutorIdentity determines the current executor based on environment variables.
+// It falls back to the default Claude executor when no overrides are provided.
+func detectExecutorIdentity() (slug, display string) {
+	for _, key := range executorEnvKeys {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			slug = strings.ToLower(value)
+			return slug, formatExecutorDisplayName(slug, value)
+		}
+	}
+	return defaultExecutorSlug, defaultExecutorName
+}
+
+func formatExecutorDisplayName(slug, raw string) string {
+	switch slug {
+	case "codex":
+		return "Codex"
+	case "claude":
+		return defaultExecutorName
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return defaultExecutorName
+	}
+	lower := strings.ToLower(trimmed)
+	if trimmed == lower {
+		runes := []rune(lower)
+		if len(runes) == 0 {
+			return defaultExecutorName
+		}
+		runes[0] = unicode.ToUpper(runes[0])
+		return string(runes)
+	}
+	return trimmed
+}
+
+// DefaultExecutorName returns the fallback executor display name.
+func DefaultExecutorName() string {
+	return defaultExecutorName
+}
+
 // New creates a new executor.
 func New(database *db.DB, cfg *config.Config) *Executor {
+	slug, display := detectExecutorIdentity()
 	e := &Executor{
 		db:              database,
 		config:          cfg,
@@ -81,6 +133,8 @@ func New(database *db.DB, cfg *config.Config) *Executor {
 		cancelFuncs:     make(map[int64]context.CancelFunc),
 		suspendedTasks:  make(map[int64]time.Time),
 		silent:          true,
+		executorSlug:    slug,
+		executorName:    display,
 	}
 
 	// Register available executors
@@ -92,6 +146,7 @@ func New(database *db.DB, cfg *config.Config) *Executor {
 
 // NewWithLogging creates an executor that logs to stderr (for daemon mode).
 func NewWithLogging(database *db.DB, cfg *config.Config, w io.Writer) *Executor {
+	slug, display := detectExecutorIdentity()
 	e := &Executor{
 		db:              database,
 		config:          cfg,
@@ -106,6 +161,8 @@ func NewWithLogging(database *db.DB, cfg *config.Config, w io.Writer) *Executor 
 		cancelFuncs:     make(map[int64]context.CancelFunc),
 		suspendedTasks:  make(map[int64]time.Time),
 		silent:          false,
+		executorSlug:    slug,
+		executorName:    display,
 	}
 
 	// Register available executors
@@ -113,6 +170,22 @@ func NewWithLogging(database *db.DB, cfg *config.Config, w io.Writer) *Executor 
 	e.executorFactory.Register(NewCodexExecutor(e))
 
 	return e
+}
+
+// DisplayName returns the configured executor display name.
+func (e *Executor) DisplayName() string {
+	if e == nil || e.executorName == "" {
+		return defaultExecutorName
+	}
+	return e.executorName
+}
+
+// ExecutorSlug returns the normalized identifier for the executor (e.g., "codex").
+func (e *Executor) ExecutorSlug() string {
+	if e == nil || e.executorSlug == "" {
+		return defaultExecutorSlug
+	}
+	return e.executorSlug
 }
 
 // Start begins the background worker.
@@ -2198,10 +2271,10 @@ func (e *Executor) ensureShellPane(windowTarget, workDir string, taskID int64, p
 		shell = "/bin/zsh"
 	}
 	splitCmd := exec.CommandContext(ctx, "tmux", "split-window",
-		"-h",           // horizontal split (side by side)
-		"-t", windowTarget+".0",  // split from Claude pane
-		"-c", workDir,  // start in task workdir
-		shell,          // user's shell to prevent immediate exit
+		"-h",                    // horizontal split (side by side)
+		"-t", windowTarget+".0", // split from Claude pane
+		"-c", workDir, // start in task workdir
+		shell, // user's shell to prevent immediate exit
 	)
 	splitOut, splitErr := splitCmd.CombinedOutput()
 	if splitErr != nil {
@@ -2248,7 +2321,6 @@ func (e *Executor) configureTmuxWindow(windowTarget string) {
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", daemonSession, "status-right", " Ctrl+C kills Claude ").Run()
 	exec.CommandContext(ctx, "tmux", "set-option", "-t", daemonSession, "status-right-length", "30").Run()
 }
-
 
 func (e *Executor) logLine(taskID int64, lineType, content string) {
 	// Store in database

--- a/internal/executor/executor_identity_test.go
+++ b/internal/executor/executor_identity_test.go
@@ -1,0 +1,40 @@
+package executor
+
+import "testing"
+
+func TestDetectExecutorIdentityDefault(t *testing.T) {
+	t.Setenv("TASK_EXECUTOR", "")
+	t.Setenv("WORKFLOW_EXECUTOR", "")
+	t.Setenv("TASKYOU_EXECUTOR", "")
+	t.Setenv("WORKTREE_EXECUTOR", "")
+
+	slug, display := detectExecutorIdentity()
+	if slug != defaultExecutorSlug {
+		t.Fatalf("expected slug %q, got %q", defaultExecutorSlug, slug)
+	}
+	if display != defaultExecutorName {
+		t.Fatalf("expected display %q, got %q", defaultExecutorName, display)
+	}
+}
+
+func TestDetectExecutorIdentityCodex(t *testing.T) {
+	t.Setenv("TASK_EXECUTOR", "codex")
+	slug, display := detectExecutorIdentity()
+	if slug != "codex" {
+		t.Fatalf("expected slug codex, got %q", slug)
+	}
+	if display != "Codex" {
+		t.Fatalf("expected display Codex, got %q", display)
+	}
+}
+
+func TestDetectExecutorIdentityUnknown(t *testing.T) {
+	t.Setenv("TASK_EXECUTOR", "beta")
+	slug, display := detectExecutorIdentity()
+	if slug != "beta" {
+		t.Fatalf("expected slug beta, got %q", slug)
+	}
+	if display != "Beta" {
+		t.Fatalf("expected display Beta, got %q", display)
+	}
+}


### PR DESCRIPTION
## Summary
- detect the executor label from env vars and expose it via the executor
- render the configured executor name throughout the detail view and hotkeys
- document TASK_EXECUTOR usage and add coverage for the new detection logic

## Testing
- go test ./...
