### PR TITLE
perf: make title autocomplete much faster

### DIFF
--- a/internal/autocomplete/autocomplete_test.go
+++ b/internal/autocomplete/autocomplete_test.go
@@ -102,3 +102,140 @@ func TestService_Cancel(t *testing.T) {
 	// Should not panic when called with no active request
 	svc.Cancel()
 }
+
+func TestService_Cache(t *testing.T) {
+	svc := NewService()
+
+	// Test adding to cache
+	svc.addToCache("title:project:Fix", "Fix the bug")
+	cached := svc.getFromCache("title:project:Fix")
+	if cached != "Fix the bug" {
+		t.Errorf("getFromCache() = %q, want %q", cached, "Fix the bug")
+	}
+
+	// Test cache miss
+	cached = svc.getFromCache("title:project:NonExistent")
+	if cached != "" {
+		t.Errorf("getFromCache() for non-existent key = %q, want empty string", cached)
+	}
+
+	// Test cache update
+	svc.addToCache("title:project:Fix", "Fix the critical bug")
+	cached = svc.getFromCache("title:project:Fix")
+	if cached != "Fix the critical bug" {
+		t.Errorf("getFromCache() after update = %q, want %q", cached, "Fix the critical bug")
+	}
+}
+
+func TestService_CacheEviction(t *testing.T) {
+	svc := NewService()
+	svc.cacheSize = 3 // Small cache for testing eviction
+
+	// Fill the cache
+	svc.addToCache("key1", "value1")
+	svc.addToCache("key2", "value2")
+	svc.addToCache("key3", "value3")
+
+	// Add one more - should evict key1 (oldest)
+	svc.addToCache("key4", "value4")
+
+	// key1 should be evicted
+	if svc.getFromCache("key1") != "" {
+		t.Error("key1 should have been evicted")
+	}
+
+	// Other keys should still exist
+	if svc.getFromCache("key2") != "value2" {
+		t.Error("key2 should still exist")
+	}
+	if svc.getFromCache("key3") != "value3" {
+		t.Error("key3 should still exist")
+	}
+	if svc.getFromCache("key4") != "value4" {
+		t.Error("key4 should exist")
+	}
+}
+
+func TestService_ProcessSuggestion(t *testing.T) {
+	svc := NewService()
+
+	tests := []struct {
+		name       string
+		suggestion string
+		input      string
+		wantNil    bool
+		wantSuffix string
+	}{
+		{
+			name:       "valid suggestion",
+			suggestion: "Fix the bug",
+			input:      "Fix",
+			wantNil:    false,
+			wantSuffix: " the bug",
+		},
+		{
+			name:       "empty suggestion",
+			suggestion: "",
+			input:      "Fix",
+			wantNil:    true,
+		},
+		{
+			name:       "suggestion equals input",
+			suggestion: "Fix",
+			input:      "Fix",
+			wantNil:    true,
+		},
+		{
+			name:       "suggestion does not start with input",
+			suggestion: "Update the docs",
+			input:      "Fix",
+			wantNil:    true,
+		},
+		{
+			name:       "case-insensitive prefix match",
+			suggestion: "fix the bug",
+			input:      "Fix",
+			wantNil:    false,
+			wantSuffix: " the bug",
+		},
+		{
+			name:       "removes surrounding quotes",
+			suggestion: "\"Fix the bug\"",
+			input:      "Fix",
+			wantNil:    false,
+			wantSuffix: " the bug",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := svc.processSuggestion(tt.suggestion, tt.input, 1)
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("processSuggestion() = %+v, want nil", result)
+				}
+			} else {
+				if result == nil {
+					t.Fatal("processSuggestion() returned nil, want non-nil")
+				}
+				if result.Text != tt.wantSuffix {
+					t.Errorf("processSuggestion().Text = %q, want %q", result.Text, tt.wantSuffix)
+				}
+			}
+		})
+	}
+}
+
+func TestService_Warmup(t *testing.T) {
+	svc := NewService()
+
+	// Should not panic
+	svc.Warmup()
+
+	// Calling warmup twice should be safe (only runs once)
+	svc.Warmup()
+
+	if !svc.warmedUp {
+		t.Error("warmedUp should be true after Warmup()")
+	}
+}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -106,6 +106,12 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int) *FormMo
 		}
 	}
 
+	autocompleteSvc := autocomplete.NewService()
+	// Start warming up the Claude CLI immediately so it's ready when user starts typing
+	if autocompleteEnabled {
+		autocompleteSvc.Warmup()
+	}
+
 	m := &FormModel{
 		db:                  database,
 		width:               width,
@@ -120,7 +126,7 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int) *FormMo
 		prNumber:            task.PRNumber,
 		autocompleteCtx:     ctx,
 		autocompleteCancel:  cancel,
-		autocompleteSvc:     autocomplete.NewService(),
+		autocompleteSvc:     autocompleteSvc,
 		autocompleteEnabled: autocompleteEnabled,
 	}
 
@@ -222,6 +228,12 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 		}
 	}
 
+	autocompleteSvc := autocomplete.NewService()
+	// Start warming up the Claude CLI immediately so it's ready when user starts typing
+	if autocompleteEnabled {
+		autocompleteSvc.Warmup()
+	}
+
 	m := &FormModel{
 		db:                  database,
 		width:               width,
@@ -230,7 +242,7 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 		recurrences:         []string{"", db.RecurrenceHourly, db.RecurrenceDaily, db.RecurrenceWeekly, db.RecurrenceMonthly},
 		autocompleteCtx:     ctx,
 		autocompleteCancel:  cancel,
-		autocompleteSvc:     autocomplete.NewService(),
+		autocompleteSvc:     autocompleteSvc,
 		autocompleteEnabled: autocompleteEnabled,
 	}
 
@@ -542,7 +554,7 @@ func (m *FormModel) scheduleAutocomplete(fieldType, input, project, extraContext
 	debounceID := m.debounceID
 
 	// Return a tick command that fires after the debounce delay
-	return tea.Tick(350*time.Millisecond, func(t time.Time) tea.Msg {
+	return tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
 		return autocompleteTickMsg{
 			debounceID: debounceID,
 			fieldType:  fieldType,


### PR DESCRIPTION
## Summary

- Reduce debounce delay from 350ms to 100ms for faster responsiveness
- Reduce timeout from 4s to 2s (haiku is fast)
- Add LRU cache for suggestions (100 entries, 5min TTL) for instant responses on repeated inputs
- Add warmup request when form opens to pre-warm Claude CLI

## Test plan

- [x] Run `go test ./internal/autocomplete/...` - all tests pass
- [x] Run `go test ./...` - all tests pass
- [ ] Manually test autocomplete speed when creating new tasks
- [ ] Verify cached suggestions return instantly on repeated inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)