### PR TITLE
docs: update README to document Codex executor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Task You
 
-A personal task management system with a beautiful terminal UI, SQLite storage, and background task execution via Claude Code.
+A personal task management system with a beautiful terminal UI, SQLite storage, and background task execution via pluggable AI agents (Claude Code or OpenAI Codex CLI).
 
 ## Screenshots
 
@@ -24,7 +24,7 @@ A personal task management system with a beautiful terminal UI, SQLite storage, 
 
 - **Kanban Board** - Visual task management with 4 columns (Backlog, In Progress, Blocked, Done)
 - **Git Worktrees** - Each task runs in an isolated worktree, no conflicts between parallel tasks
-- **Background Executor** - Claude Code processes tasks automatically
+- **Pluggable Executors** - Choose between Claude Code or OpenAI Codex CLI per task
 - **Project Memories** - Persistent context that carries across tasks
 - **Real-time Updates** - Watch tasks execute live
 - **SSH Access** - Connect from anywhere via `ssh -p 2222 server`
@@ -115,6 +115,32 @@ backlog → queued → processing → done
 | `processing` | Currently being executed |
 | `blocked` | Needs input/clarification |
 | `done` | Completed |
+
+## Task Executors
+
+Task You supports multiple AI executors for processing tasks. You can choose the executor when creating or editing a task.
+
+| Executor | CLI | Description |
+|----------|-----|-------------|
+| Claude (default) | `claude` | [Claude Code](https://claude.ai/claude-code) - Anthropic's coding agent with session resumption |
+| Codex | `codex` | [OpenAI Codex CLI](https://github.com/openai/codex) - OpenAI's coding assistant |
+
+Both executors run in tmux windows with the same worktree isolation and environment variables. The main differences:
+
+- **Claude Code** supports session resumption - when you retry a task, Claude continues with full conversation history
+- **Codex** starts fresh on each execution but receives the full prompt with any feedback
+
+### Installing Executors
+
+At least one executor CLI must be installed for tasks to run:
+
+```bash
+# Claude Code (recommended)
+# See https://claude.ai/claude-code for installation
+
+# OpenAI Codex CLI
+npm install -g @openai/codex
+```
 
 ## Configuration
 
@@ -228,7 +254,7 @@ bundle install
 bin/rails db:create db:migrate
 ```
 
-Now Claude can:
+Now the AI executor (Claude or Codex) can:
 - Run your app with `bin/dev`
 - Access it at `http://localhost:$WORKTREE_PORT`
 - Work on multiple tasks in parallel without database or port conflicts


### PR DESCRIPTION
## Summary
- Updates README to document the new Codex CLI executor support added in #175
- Adds a new "Task Executors" section explaining both Claude Code and OpenAI Codex CLI options
- Updates the project description and features to mention pluggable AI agents

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Check all links are valid
- [x] Confirm documentation matches implementation in #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)