### PR TITLE
Fix: Prevent layout shift from loading indicator in title field

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -802,15 +802,17 @@ func (m *FormModel) View() string {
 		cursor = cursorStyle.Render("▸")
 	}
 	titleView := m.titleInput.View()
-	// Add ghost text or loading indicator after title if field is focused
-	if m.focused == FieldTitle {
-		if m.ghostText != "" {
-			titleView = titleView + ghostStyle.Render(m.ghostText)
-		} else if m.loadingAutocomplete {
-			titleView = titleView + loadingStyle.Render(" ...")
-		}
+	// Add ghost text after title if field is focused and we have a suggestion
+	if m.focused == FieldTitle && m.ghostText != "" {
+		titleView = titleView + ghostStyle.Render(m.ghostText)
 	}
-	b.WriteString(cursor + " " + labelStyle.Render("Title") + titleView)
+	// Show loading indicator on the right side (similar to body field scrollbar)
+	// Use a fixed-width indicator that doesn't shift layout
+	titleIndicator := " " // Reserve space for indicator
+	if m.focused == FieldTitle && m.loadingAutocomplete && m.ghostText == "" {
+		titleIndicator = loadingStyle.Render("…")
+	}
+	b.WriteString(cursor + " " + labelStyle.Render("Title") + titleView + titleIndicator)
 	b.WriteString("\n\n")
 
 	// Body (textarea)
@@ -830,7 +832,7 @@ func (m *FormModel) View() string {
 			if m.ghostText != "" && !strings.Contains(bodyContent, "\n") {
 				line = line + ghostStyle.Render(m.ghostText)
 			} else if m.loadingAutocomplete && !strings.Contains(bodyContent, "\n") {
-				line = line + loadingStyle.Render(" ...")
+				line = line + loadingStyle.Render("…")
 			}
 		}
 		scrollChar := ""


### PR DESCRIPTION
## Summary
- Fixes layout shift issue when autocomplete loading indicator appears in the title field
- Uses a single ellipsis character (…) instead of " ..." (4 characters) to reduce line wrapping
- Always reserves space for the indicator to maintain consistent line width
- Applied the same change to the body field for consistency

## Test plan
- [ ] Open the task form
- [ ] Type in the title field to trigger autocomplete
- [ ] Verify the loading indicator (…) appears on the right side without shifting the layout
- [ ] Verify the same behavior in the body/details field

🤖 Generated with [Claude Code](https://claude.com/claude-code)