### PR TITLE
feat: add task reference autocomplete with # trigger

### DIFF
--- a/internal/ui/task_ref_autocomplete.go
+++ b/internal/ui/task_ref_autocomplete.go
@@ -1,0 +1,304 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TaskRefAutocompleteModel provides inline autocomplete for task references (#123).
+// It appears as a floating dropdown when the user types '#' in a text field.
+type TaskRefAutocompleteModel struct {
+	db            *db.DB
+	allTasks      []*db.Task // Preloaded tasks for fast filtering
+	filteredTasks []*db.Task
+	selectedIndex int
+	query         string // The text after '#' (e.g., "30" for "#30")
+	cursorPos     int    // Position in the text where '#' was typed
+	maxVisible    int
+	width         int
+
+	// Result
+	selectedTask *db.Task
+	dismissed    bool
+}
+
+// NewTaskRefAutocompleteModel creates a new task reference autocomplete model.
+func NewTaskRefAutocompleteModel(database *db.DB, width int) *TaskRefAutocompleteModel {
+	m := &TaskRefAutocompleteModel{
+		db:         database,
+		maxVisible: 5,
+		width:      width,
+	}
+	m.loadTasks()
+	return m
+}
+
+// loadTasks loads tasks from the database for filtering.
+func (m *TaskRefAutocompleteModel) loadTasks() {
+	if m.db == nil {
+		return
+	}
+
+	// Load recent tasks (excluding archived)
+	tasks, err := m.db.ListTasks(db.ListTasksOptions{
+		Limit:         100,
+		IncludeClosed: true, // Include done tasks for referencing
+	})
+	if err != nil {
+		return
+	}
+	m.allTasks = tasks
+}
+
+// SetQuery sets the search query and filters tasks.
+func (m *TaskRefAutocompleteModel) SetQuery(query string, cursorPos int) {
+	m.query = query
+	m.cursorPos = cursorPos
+	m.filterTasks()
+}
+
+// filterTasks filters tasks based on the current query.
+func (m *TaskRefAutocompleteModel) filterTasks() {
+	if m.query == "" {
+		// Show all tasks when just '#' is typed
+		m.filteredTasks = m.allTasks
+		if len(m.filteredTasks) > 20 {
+			m.filteredTasks = m.filteredTasks[:20]
+		}
+	} else {
+		m.filteredTasks = nil
+		queryLower := strings.ToLower(m.query)
+
+		// First, try to match by ID if query is numeric
+		if id, err := strconv.ParseInt(m.query, 10, 64); err == nil {
+			// Prioritize exact or prefix ID matches
+			for _, task := range m.allTasks {
+				if task.ID == id {
+					m.filteredTasks = append([]*db.Task{task}, m.filteredTasks...)
+				} else if strings.HasPrefix(fmt.Sprintf("%d", task.ID), m.query) {
+					m.filteredTasks = append(m.filteredTasks, task)
+				}
+			}
+		}
+
+		// Also search by title
+		for _, task := range m.allTasks {
+			// Skip if already added by ID match
+			alreadyAdded := false
+			for _, added := range m.filteredTasks {
+				if added.ID == task.ID {
+					alreadyAdded = true
+					break
+				}
+			}
+			if alreadyAdded {
+				continue
+			}
+
+			if strings.Contains(strings.ToLower(task.Title), queryLower) {
+				m.filteredTasks = append(m.filteredTasks, task)
+			}
+		}
+
+		// Limit results
+		if len(m.filteredTasks) > 20 {
+			m.filteredTasks = m.filteredTasks[:20]
+		}
+	}
+
+	// Reset selection if out of bounds
+	if m.selectedIndex >= len(m.filteredTasks) {
+		m.selectedIndex = 0
+	}
+}
+
+// MoveUp moves selection up.
+func (m *TaskRefAutocompleteModel) MoveUp() {
+	if m.selectedIndex > 0 {
+		m.selectedIndex--
+	} else if len(m.filteredTasks) > 0 {
+		m.selectedIndex = len(m.filteredTasks) - 1
+	}
+}
+
+// MoveDown moves selection down.
+func (m *TaskRefAutocompleteModel) MoveDown() {
+	if m.selectedIndex < len(m.filteredTasks)-1 {
+		m.selectedIndex++
+	} else {
+		m.selectedIndex = 0
+	}
+}
+
+// Select confirms the current selection.
+func (m *TaskRefAutocompleteModel) Select() {
+	if len(m.filteredTasks) > 0 && m.selectedIndex < len(m.filteredTasks) {
+		m.selectedTask = m.filteredTasks[m.selectedIndex]
+	}
+}
+
+// Dismiss closes the autocomplete without selecting.
+func (m *TaskRefAutocompleteModel) Dismiss() {
+	m.dismissed = true
+}
+
+// SelectedTask returns the selected task, or nil if none selected.
+func (m *TaskRefAutocompleteModel) SelectedTask() *db.Task {
+	return m.selectedTask
+}
+
+// IsDismissed returns true if the autocomplete was dismissed.
+func (m *TaskRefAutocompleteModel) IsDismissed() bool {
+	return m.dismissed
+}
+
+// HasResults returns true if there are matching tasks.
+func (m *TaskRefAutocompleteModel) HasResults() bool {
+	return len(m.filteredTasks) > 0
+}
+
+// GetReference returns the task reference string (e.g., "#123") for the selected task.
+func (m *TaskRefAutocompleteModel) GetReference() string {
+	if m.selectedTask == nil {
+		return ""
+	}
+	return fmt.Sprintf("#%d", m.selectedTask.ID)
+}
+
+// GetCursorPos returns the position where '#' was typed.
+func (m *TaskRefAutocompleteModel) GetCursorPos() int {
+	return m.cursorPos
+}
+
+// GetQueryLength returns the length of the query (including #).
+func (m *TaskRefAutocompleteModel) GetQueryLength() int {
+	return len(m.query) + 1 // +1 for the '#'
+}
+
+// Reset resets the autocomplete state.
+func (m *TaskRefAutocompleteModel) Reset() {
+	m.query = ""
+	m.cursorPos = 0
+	m.selectedIndex = 0
+	m.selectedTask = nil
+	m.dismissed = false
+	m.filteredTasks = nil
+}
+
+// View renders the autocomplete dropdown.
+func (m *TaskRefAutocompleteModel) View() string {
+	if len(m.filteredTasks) == 0 {
+		return ""
+	}
+
+	// Calculate visible range
+	start := 0
+	end := len(m.filteredTasks)
+	if end > m.maxVisible {
+		halfVisible := m.maxVisible / 2
+		start = m.selectedIndex - halfVisible
+		if start < 0 {
+			start = 0
+		}
+		end = start + m.maxVisible
+		if end > len(m.filteredTasks) {
+			end = len(m.filteredTasks)
+			start = end - m.maxVisible
+			if start < 0 {
+				start = 0
+			}
+		}
+	}
+
+	var lines []string
+
+	// Show scroll indicator at top
+	if start > 0 {
+		scrollUp := lipgloss.NewStyle().
+			Foreground(ColorMuted).
+			Italic(true).
+			Render(fmt.Sprintf("  ... %d more", start))
+		lines = append(lines, scrollUp)
+	}
+
+	// Render visible tasks
+	for i := start; i < end; i++ {
+		task := m.filteredTasks[i]
+		isSelected := i == m.selectedIndex
+		lines = append(lines, m.renderTaskItem(task, isSelected))
+	}
+
+	// Show scroll indicator at bottom
+	remaining := len(m.filteredTasks) - end
+	if remaining > 0 {
+		scrollDown := lipgloss.NewStyle().
+			Foreground(ColorMuted).
+			Italic(true).
+			Render(fmt.Sprintf("  ... %d more", remaining))
+		lines = append(lines, scrollDown)
+	}
+
+	content := strings.Join(lines, "\n")
+
+	// Style the dropdown
+	dropdownWidth := m.width
+	if dropdownWidth > 60 {
+		dropdownWidth = 60
+	}
+	if dropdownWidth < 30 {
+		dropdownWidth = 30
+	}
+
+	dropdown := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary).
+		Background(lipgloss.Color("236")).
+		Padding(0, 1).
+		Width(dropdownWidth)
+
+	return dropdown.Render(content)
+}
+
+// renderTaskItem renders a single task in the dropdown.
+func (m *TaskRefAutocompleteModel) renderTaskItem(task *db.Task, isSelected bool) string {
+	var line strings.Builder
+
+	// Selection indicator
+	if isSelected {
+		line.WriteString(lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true).Render("> "))
+	} else {
+		line.WriteString("  ")
+	}
+
+	// Task ID
+	idStyle := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
+	line.WriteString(idStyle.Render(fmt.Sprintf("#%-4d", task.ID)))
+	line.WriteString(" ")
+
+	// Status icon
+	statusIcon := StatusIcon(task.Status)
+	statusColor := StatusColor(task.Status)
+	line.WriteString(lipgloss.NewStyle().Foreground(statusColor).Render(statusIcon))
+	line.WriteString(" ")
+
+	// Title (truncate if needed)
+	title := task.Title
+	maxTitleLen := 40
+	if len(title) > maxTitleLen {
+		title = title[:maxTitleLen-3] + "..."
+	}
+
+	titleStyle := lipgloss.NewStyle()
+	if isSelected {
+		titleStyle = titleStyle.Bold(true).Foreground(ColorPrimary)
+	} else {
+		titleStyle = titleStyle.Foreground(lipgloss.Color("252"))
+	}
+	line.WriteString(titleStyle.Render(title))
+
+	return line.String()
+}

--- a/internal/ui/task_ref_autocomplete_test.go
+++ b/internal/ui/task_ref_autocomplete_test.go
@@ -1,0 +1,304 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func TestTaskRefAutocompleteFiltering(t *testing.T) {
+	tasks := []*db.Task{
+		{ID: 1, Title: "Implement login feature", Project: "webapp", Status: db.StatusBacklog},
+		{ID: 42, Title: "Fix bug in dashboard", Project: "webapp", Status: db.StatusProcessing},
+		{ID: 123, Title: "Add unit tests", Project: "api", Status: db.StatusDone},
+		{ID: 302, Title: "Task reference feature", Project: "workflow", Status: db.StatusQueued},
+	}
+
+	tests := []struct {
+		name     string
+		query    string
+		expected int // number of expected results
+	}{
+		{"empty query shows all", "", 4},
+		{"filter by ID prefix", "30", 1},
+		{"filter by exact ID", "302", 1},
+		{"filter by title word", "bug", 1},
+		{"filter by title lowercase", "login", 1},
+		{"filter by title partial", "ref", 1},
+		{"no results", "nonexistent", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &TaskRefAutocompleteModel{
+				allTasks:   tasks,
+				maxVisible: 5,
+				width:      60,
+			}
+			m.SetQuery(tt.query, 0)
+
+			if len(m.filteredTasks) != tt.expected {
+				t.Errorf("query %q: got %d results, want %d", tt.query, len(m.filteredTasks), tt.expected)
+			}
+		})
+	}
+}
+
+func TestTaskRefAutocompleteNavigation(t *testing.T) {
+	tasks := []*db.Task{
+		{ID: 1, Title: "First task", Status: db.StatusBacklog},
+		{ID: 2, Title: "Second task", Status: db.StatusBacklog},
+		{ID: 3, Title: "Third task", Status: db.StatusBacklog},
+	}
+
+	m := &TaskRefAutocompleteModel{
+		allTasks:   tasks,
+		maxVisible: 5,
+		width:      60,
+	}
+	m.SetQuery("", 0) // Show all
+
+	// Initially at index 0
+	if m.selectedIndex != 0 {
+		t.Errorf("initial selectedIndex = %d, want 0", m.selectedIndex)
+	}
+
+	// Move down
+	m.MoveDown()
+	if m.selectedIndex != 1 {
+		t.Errorf("after MoveDown selectedIndex = %d, want 1", m.selectedIndex)
+	}
+
+	// Move down again
+	m.MoveDown()
+	if m.selectedIndex != 2 {
+		t.Errorf("after second MoveDown selectedIndex = %d, want 2", m.selectedIndex)
+	}
+
+	// Move down wraps to top
+	m.MoveDown()
+	if m.selectedIndex != 0 {
+		t.Errorf("after wrap MoveDown selectedIndex = %d, want 0", m.selectedIndex)
+	}
+
+	// Move up wraps to bottom
+	m.MoveUp()
+	if m.selectedIndex != 2 {
+		t.Errorf("after wrap MoveUp selectedIndex = %d, want 2", m.selectedIndex)
+	}
+}
+
+func TestTaskRefAutocompleteSelection(t *testing.T) {
+	tasks := []*db.Task{
+		{ID: 302, Title: "Task reference feature", Status: db.StatusBacklog},
+		{ID: 303, Title: "Another task", Status: db.StatusBacklog},
+	}
+
+	m := &TaskRefAutocompleteModel{
+		allTasks:   tasks,
+		maxVisible: 5,
+		width:      60,
+	}
+	m.SetQuery("30", 5) // Set query and position
+
+	// Before selection
+	if m.SelectedTask() != nil {
+		t.Error("expected nil SelectedTask before Select()")
+	}
+
+	// Select first item
+	m.Select()
+	selected := m.SelectedTask()
+	if selected == nil {
+		t.Fatal("expected non-nil SelectedTask after Select()")
+	}
+	if selected.ID != 302 {
+		t.Errorf("selected task ID = %d, want 302", selected.ID)
+	}
+
+	// Check reference format
+	ref := m.GetReference()
+	if ref != "#302" {
+		t.Errorf("GetReference() = %q, want %q", ref, "#302")
+	}
+
+	// Check query length (includes #)
+	if m.GetQueryLength() != 3 { // "30" + "#"
+		t.Errorf("GetQueryLength() = %d, want 3", m.GetQueryLength())
+	}
+
+	// Check cursor position
+	if m.GetCursorPos() != 5 {
+		t.Errorf("GetCursorPos() = %d, want 5", m.GetCursorPos())
+	}
+}
+
+func TestTaskRefAutocompleteDismiss(t *testing.T) {
+	m := &TaskRefAutocompleteModel{
+		allTasks:   []*db.Task{{ID: 1, Title: "Test", Status: db.StatusBacklog}},
+		maxVisible: 5,
+		width:      60,
+	}
+	m.SetQuery("", 0)
+
+	if m.IsDismissed() {
+		t.Error("expected IsDismissed() = false before Dismiss()")
+	}
+
+	m.Dismiss()
+
+	if !m.IsDismissed() {
+		t.Error("expected IsDismissed() = true after Dismiss()")
+	}
+}
+
+func TestTaskRefAutocompleteReset(t *testing.T) {
+	tasks := []*db.Task{
+		{ID: 302, Title: "Task reference feature", Status: db.StatusBacklog},
+	}
+
+	m := &TaskRefAutocompleteModel{
+		allTasks:   tasks,
+		maxVisible: 5,
+		width:      60,
+	}
+	m.SetQuery("302", 5)
+	m.Select()
+
+	// Verify state before reset
+	if m.SelectedTask() == nil {
+		t.Error("expected SelectedTask to be set before Reset()")
+	}
+
+	// Reset
+	m.Reset()
+
+	// Verify state after reset
+	if m.query != "" {
+		t.Errorf("after Reset() query = %q, want empty", m.query)
+	}
+	if m.cursorPos != 0 {
+		t.Errorf("after Reset() cursorPos = %d, want 0", m.cursorPos)
+	}
+	if m.selectedIndex != 0 {
+		t.Errorf("after Reset() selectedIndex = %d, want 0", m.selectedIndex)
+	}
+	if m.SelectedTask() != nil {
+		t.Error("after Reset() expected SelectedTask() = nil")
+	}
+	if m.IsDismissed() {
+		t.Error("after Reset() expected IsDismissed() = false")
+	}
+}
+
+func TestTaskRefAutocompleteHasResults(t *testing.T) {
+	tasks := []*db.Task{
+		{ID: 1, Title: "Test task", Status: db.StatusBacklog},
+	}
+
+	m := &TaskRefAutocompleteModel{
+		allTasks:   tasks,
+		maxVisible: 5,
+		width:      60,
+	}
+
+	// No query yet
+	if m.HasResults() {
+		t.Error("expected HasResults() = false before SetQuery")
+	}
+
+	// Set query that matches
+	m.SetQuery("", 0)
+	if !m.HasResults() {
+		t.Error("expected HasResults() = true after matching query")
+	}
+
+	// Set query with no matches
+	m.SetQuery("nonexistent", 0)
+	if m.HasResults() {
+		t.Error("expected HasResults() = false for non-matching query")
+	}
+}
+
+func TestTaskRefAutocompleteIDPrioritization(t *testing.T) {
+	// When searching by ID, exact and prefix matches should be prioritized
+	tasks := []*db.Task{
+		{ID: 100, Title: "Hundred task", Status: db.StatusBacklog},
+		{ID: 1, Title: "First task", Status: db.StatusBacklog},
+		{ID: 10, Title: "Ten task", Status: db.StatusBacklog},
+	}
+
+	m := &TaskRefAutocompleteModel{
+		allTasks:   tasks,
+		maxVisible: 5,
+		width:      60,
+	}
+
+	// Query "1" should find tasks with IDs containing "1"
+	m.SetQuery("1", 0)
+
+	if len(m.filteredTasks) < 1 {
+		t.Fatal("expected at least 1 filtered task")
+	}
+
+	// Exact ID match (1) should be first
+	if m.filteredTasks[0].ID != 1 {
+		t.Errorf("first result ID = %d, want 1 (exact match)", m.filteredTasks[0].ID)
+	}
+}
+
+func TestTaskRefAutocompleteView(t *testing.T) {
+	tasks := []*db.Task{
+		{ID: 302, Title: "Task reference feature", Status: db.StatusBacklog},
+		{ID: 303, Title: "Another task", Status: db.StatusDone},
+	}
+
+	m := &TaskRefAutocompleteModel{
+		allTasks:   tasks,
+		maxVisible: 5,
+		width:      60,
+	}
+	m.SetQuery("30", 0)
+
+	view := m.View()
+
+	// View should not be empty when there are results
+	if view == "" {
+		t.Error("expected non-empty View() when there are results")
+	}
+
+	// View should contain task IDs
+	if !contains(view, "#302") {
+		t.Error("expected View() to contain #302")
+	}
+	if !contains(view, "#303") {
+		t.Error("expected View() to contain #303")
+	}
+}
+
+func TestTaskRefAutocompleteEmptyView(t *testing.T) {
+	m := &TaskRefAutocompleteModel{
+		allTasks:   []*db.Task{},
+		maxVisible: 5,
+		width:      60,
+	}
+
+	view := m.View()
+	if view != "" {
+		t.Errorf("expected empty View() for no results, got %q", view)
+	}
+}
+
+// Helper function
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds task reference autocomplete when typing `#` in the Details field
- Shows matching tasks filtered by ID or title with an inline dropdown
- Arrow keys to navigate, Enter/Tab to select, Esc to dismiss
- Works alongside existing ghost text autocomplete (task ref takes priority when active)

## Test plan
- [x] Type `#` in the task description field
- [x] Verify autocomplete dropdown appears with task suggestions
- [x] Type a number (e.g., `#30`) to filter by task ID
- [x] Type text (e.g., `#bug`) to filter by title
- [x] Press up/down arrows to navigate
- [x] Press Enter or Tab to select and insert reference
- [x] Press Esc to dismiss without selecting
- [x] Verify reference format is `#<task_id>`
- [x] Verify ghost text autocomplete still works when not using task refs
- [x] Run `go test ./internal/ui/...` - all tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)