### PR TITLE
feat: make task form use full height

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -497,6 +497,12 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.commandPaletteView != nil {
 			m.commandPaletteView.SetSize(msg.Width, msg.Height)
 		}
+		if m.newTaskForm != nil {
+			m.newTaskForm.SetSize(msg.Width, msg.Height)
+		}
+		if m.editTaskForm != nil {
+			m.editTaskForm.SetSize(msg.Width, msg.Height)
+		}
 
 	case tasksLoadedMsg:
 		m.loading = false

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -922,12 +922,13 @@ func (m *FormModel) View() string {
 	helpText := "tab accept/navigate • ctrl+space suggest • ←→ select • ctrl+s submit • esc dismiss/cancel"
 	b.WriteString("  " + dimStyle.Render(helpText))
 
-	// Wrap in box
+	// Wrap in box - use full height (subtract 2 for border)
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(ColorPrimary).
 		Padding(1, 2).
-		Width(m.width - 4)
+		Width(m.width - 4).
+		Height(m.height - 2)
 
 	return box.Render(b.String())
 }
@@ -1096,6 +1097,20 @@ func parseTimeOfDay(s string, date time.Time) *db.LocalTime {
 // SetQueue sets whether to queue the task.
 func (m *FormModel) SetQueue(queue bool) {
 	m.queue = queue
+}
+
+// SetSize updates the form dimensions for window resize handling.
+func (m *FormModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	// Update input widths
+	inputWidth := width - 24
+	m.titleInput.Width = inputWidth
+	m.bodyInput.SetWidth(inputWidth)
+	m.scheduleInput.Width = inputWidth
+	m.attachmentsInput.Width = inputWidth
+	// Recalculate body height based on new dimensions
+	m.updateBodyHeight()
 }
 
 // calculateBodyHeight calculates the appropriate height for the body textarea based on content.


### PR DESCRIPTION
## Summary
- Add `SetSize` method to `FormModel` to handle window resizing
- Call `SetSize` on task forms when `WindowSizeMsg` is received in app.go
- Set `Height` on the form box style to fill the entire screen

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manually verify the new/edit task form now fills the full terminal height
- [ ] Verify form responds correctly when terminal is resized

🤖 Generated with [Claude Code](https://claude.com/claude-code)