### PR TITLE
fix: improve escape key handling in task form

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -87,6 +87,9 @@ type FormModel struct {
 	// Task reference autocomplete (for #123 references)
 	taskRefAutocomplete     *TaskRefAutocompleteModel
 	showTaskRefAutocomplete bool
+
+	// Cancel confirmation state
+	showCancelConfirm bool
 }
 
 // Autocomplete message types for async LLM suggestions
@@ -442,6 +445,20 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// Handle cancel confirmation state
+		if m.showCancelConfirm {
+			switch msg.String() {
+			case "y", "Y", "enter":
+				m.cancelled = true
+				return m, nil
+			case "n", "N", "esc":
+				m.showCancelConfirm = false
+				return m, nil
+			}
+			// Ignore other keys while confirmation is showing
+			return m, nil
+		}
+
 		// Handle task reference autocomplete when active
 		if m.showTaskRefAutocomplete && m.taskRefAutocomplete != nil && m.taskRefAutocomplete.HasResults() {
 			switch msg.String() {
@@ -469,15 +486,27 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "esc":
-			// If task ref autocomplete is showing, dismiss it first
-			if m.showTaskRefAutocomplete {
+			// If task ref autocomplete is showing WITH visible results, dismiss it first
+			if m.showTaskRefAutocomplete && m.taskRefAutocomplete != nil && m.taskRefAutocomplete.HasResults() {
 				m.showTaskRefAutocomplete = false
 				m.taskRefAutocomplete.Reset()
 				return m, nil
 			}
+			// Clean up invisible autocomplete state (no return - continue processing)
+			if m.showTaskRefAutocomplete {
+				m.showTaskRefAutocomplete = false
+				if m.taskRefAutocomplete != nil {
+					m.taskRefAutocomplete.Reset()
+				}
+			}
 			// If there's a ghost suggestion or loading, dismiss it first
 			if m.ghostText != "" || m.loadingAutocomplete || m.pendingDebounce {
 				m.clearGhostText()
+				return m, nil
+			}
+			// If form has data, show confirmation before cancelling
+			if m.hasFormData() {
+				m.showCancelConfirm = true
 				return m, nil
 			}
 			// Otherwise cancel the form
@@ -1206,6 +1235,14 @@ func (m *FormModel) View() string {
 	b.WriteString(cursor + " " + labelStyle.Render("Recurrence") + m.renderSelector(recurrenceLabels, m.recurrenceIdx, m.focused == FieldRecurrence, selectedStyle, optionStyle, dimStyle))
 	b.WriteString("\n\n")
 
+	// Cancel confirmation message
+	if m.showCancelConfirm {
+		confirmStyle := lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("214")) // Orange/warning color
+		b.WriteString("  " + confirmStyle.Render("Discard changes? (y/n)") + "\n")
+	}
+
 	// Help
 	helpText := "tab accept/navigate • # ref task • ctrl+space suggest • ←→ select • ctrl+s submit • esc dismiss/cancel"
 	b.WriteString("  " + dimStyle.Render(helpText))
@@ -1239,6 +1276,16 @@ func (m *FormModel) renderSelector(options []string, selected int, focused bool,
 		}
 	}
 	return strings.Join(parts, "  ")
+}
+
+// hasFormData returns true if the form has any user-entered data.
+// This is used to determine if we should show a confirmation before cancelling.
+func (m *FormModel) hasFormData() bool {
+	return strings.TrimSpace(m.titleInput.Value()) != "" ||
+		strings.TrimSpace(m.bodyInput.Value()) != "" ||
+		strings.TrimSpace(m.scheduleInput.Value()) != "" ||
+		strings.TrimSpace(m.attachmentsInput.Value()) != "" ||
+		len(m.attachments) > 0
 }
 
 // GetDBTask returns a db.Task from the form values.


### PR DESCRIPTION
## Summary
- Fix escape key to properly dismiss autocomplete when showing (even when there are no matching results visible)
- Only consume escape keypress if a visible autocomplete dropdown is dismissed
- Add confirmation prompt ("Discard changes? (y/n)") when pressing escape on a form with data entered

## Changes
- Modified `internal/ui/form.go`:
  - Added `showCancelConfirm` field for confirmation state
  - Added `hasFormData()` method to check if form has user-entered content
  - Updated escape key handler to:
    1. Dismiss visible task ref autocomplete dropdown first
    2. Clean up invisible autocomplete state without consuming keypress
    3. Dismiss ghost text if showing
    4. Show confirmation before cancelling if form has data
  - Added confirmation dialog rendering in View()
  - Added confirmation key handling (y/Y/Enter to confirm, n/N/Esc to cancel)

- Modified `internal/ui/form_test.go`:
  - Added `TestHasFormData` - tests for detecting form content
  - Added `TestEscapeWithEmptyFormCancelsImmediately` - verifies empty form cancels without confirmation
  - Added `TestEscapeWithDataShowsConfirmation` - verifies confirmation prompt shows
  - Added `TestConfirmationYesCancelsForm` - verifies 'y' confirms cancel
  - Added `TestConfirmationNoCancelsConfirmation` - verifies 'n' dismisses confirmation
  - Added `TestConfirmationEscCancelsConfirmation` - verifies Esc dismisses confirmation
  - Added `TestEscapeDismissesGhostTextFirst` - verifies ghost text is dismissed first
  - Added `TestEscapeDismissesTaskRefAutocompleteFirst` - verifies autocomplete state cleanup
  - Added `TestConfirmationMessageAppearsInView` - verifies UI rendering

## Test plan
- [x] All existing tests pass
- [x] New tests pass for:
  - hasFormData detection
  - Escape with empty form
  - Escape with data shows confirmation
  - y/Y/Enter confirms cancel
  - n/N/Esc dismisses confirmation
  - Ghost text dismissed before confirmation
  - Autocomplete state cleaned up properly
  - Confirmation message appears in view

🤖 Generated with [Claude Code](https://claude.com/claude-code)