### PR TITLE
feat: increase default details field height from 4 to 8 lines

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -1370,12 +1370,12 @@ func (m *FormModel) SetSize(width, height int) {
 }
 
 // calculateBodyHeight calculates the appropriate height for the body textarea based on content.
-// Returns a height between minHeight (4) and maxHeight (50% of available screen height).
+// Returns a height between minHeight (8) and maxHeight (50% of available screen height).
 func (m *FormModel) calculateBodyHeight() int {
 	content := m.bodyInput.Value()
 
-	// Minimum height
-	minHeight := 4
+	// Minimum height - increased from 4 to 8 to display more content by default
+	minHeight := 8
 
 	// Maximum height is 50% of screen height
 	// Account for other form elements: header(2) + title(2) + body label(1) + project(2) +

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -19,31 +19,31 @@ func TestCalculateBodyHeight(t *testing.T) {
 			content:      "",
 			screenHeight: 50,
 			screenWidth:  100,
-			wantMin:      4,
-			wantMax:      4,
+			wantMin:      8,
+			wantMax:      8,
 		},
 		{
 			name:         "single line returns minimum height",
 			content:      "hello world",
 			screenHeight: 50,
 			screenWidth:  100,
-			wantMin:      4,
-			wantMax:      4,
+			wantMin:      8,
+			wantMax:      8,
 		},
 		{
 			name:         "multiple lines grows height",
 			content:      "line1\nline2\nline3\nline4\nline5\nline6",
 			screenHeight: 50,
 			screenWidth:  100,
-			wantMin:      6,
-			wantMax:      6,
+			wantMin:      8,
+			wantMax:      8,
 		},
 		{
 			name:         "many lines capped at max height (50% of screen)",
 			content:      strings.Repeat("line\n", 50),
 			screenHeight: 50,
 			screenWidth:  100,
-			wantMin:      4,  // at least minimum
+			wantMin:      8,  // at least minimum
 			wantMax:      14, // (50-22)/2 = 14
 		},
 		{
@@ -51,8 +51,8 @@ func TestCalculateBodyHeight(t *testing.T) {
 			content:      strings.Repeat("a", 200), // should wrap on ~76 char width
 			screenHeight: 50,
 			screenWidth:  100,
-			wantMin:      4,
-			wantMax:      6, // wrapped lines
+			wantMin:      8,
+			wantMax:      8, // wrapped lines still within minimum
 		},
 	}
 
@@ -76,7 +76,7 @@ func TestCalculateBodyHeight(t *testing.T) {
 func TestUpdateBodyHeightSetsHeight(t *testing.T) {
 	m := NewFormModel(nil, 100, 50, "")
 
-	// Initially should have minimum height of 4
+	// Initially should have minimum height of 8
 	m.updateBodyHeight()
 	// The textarea height is internal, so we just verify no panic
 
@@ -105,8 +105,8 @@ func TestMaxHeightIs50PercentOfScreen(t *testing.T) {
 
 			// formOverhead is 22, so maxHeight = (screenHeight - 22) / 2
 			expectedMax := (screenHeight - 22) / 2
-			if expectedMax < 4 {
-				expectedMax = 4
+			if expectedMax < 8 {
+				expectedMax = 8
 			}
 
 			if height > expectedMax {


### PR DESCRIPTION
## Summary
- Increases the minimum/default height of the details (body) textarea field from 4 lines to 8 lines
- Allows users to see more content without scrolling or manually expanding the field
- Updates associated tests to reflect the new minimum height

## Test plan
- [x] Verify build passes: `go build ./...`
- [x] Verify all tests pass: `go test ./...`
- [ ] Manually test the task form to verify the larger details field

🤖 Generated with [Claude Code](https://claude.com/claude-code)