### PR TITLE
fix: remove tmux mouse mode to allow native text selection

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -383,11 +383,6 @@ func (m *AppModel) Init() tea.Cmd {
 	// Start watching database file for changes
 	m.startDatabaseWatcher()
 
-	// Enable mouse support for click-to-focus on tmux panes
-	if os.Getenv("TMUX") != "" {
-		osExec.Command("tmux", "set-option", "-t", "task-ui", "mouse", "on").Run()
-	}
-
 	return tea.Batch(m.loadTasks(), m.waitForTaskEvent(), m.waitForDBChange(), m.tick(), m.prRefreshTick(), m.refreshAllPRs())
 }
 


### PR DESCRIPTION
## Summary

The tmux `mouse on` setting was intercepting all mouse events, making it impossible for users to select and copy text from the TUI using standard terminal text selection.

## Root Cause

The app was calling `tmux set-option -t task-ui mouse on` on startup to enable mouse-based pane switching. However, this prevents native terminal text selection entirely.

## Fix

Simply remove the `mouse on` setting. Users can already switch between panes using **Shift+Arrow** keys, so mouse-based pane switching is not necessary.

## What still works

- **Shift+↑↓** - Switch between panes (Details, Claude, Shell)
- **Click on task cards** - Still works in the kanban dashboard (bubbletea's mouse handling is independent of tmux)
- **Native text selection** - Now works again!

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [ ] Manual test: Select text with mouse in the TUI - should work
- [ ] Manual test: Shift+Arrow to switch panes - should still work
- [ ] Manual test: Click on task cards in dashboard - should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)