### PR TITLE
feat: default project field to last task's project in new task form

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -301,10 +301,15 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 		}
 	}
 
-	// Default to 'personal' project
+	// Default to last task's project, or fall back to 'personal'
 	m.project = "personal"
+	if database != nil {
+		if lastTask, err := database.GetMostRecentlyCreatedTask(); err == nil && lastTask != nil && lastTask.Project != "" {
+			m.project = lastTask.Project
+		}
+	}
 	for i, p := range m.projects {
-		if p == "personal" {
+		if p == m.project {
 			m.projectIdx = i
 			break
 		}


### PR DESCRIPTION
## Summary
- When creating a new task, the Project field now defaults to the project from the most recently created task
- Falls back to "personal" only when no tasks exist or the last task has no project
- Working directory path detection still takes priority when available

## Test plan
- [x] Added test `TestGetMostRecentlyCreatedTask` covering:
  - Empty database returns nil
  - Returns most recently created task
  - Returns correct project from last task
  - Works correctly with completed tasks
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)