### PR TITLE
fix: change task navigation shortcut to Alt+Shift+Up/Down

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ ssh -p 2222 your-server
 | `!` | Toggle dangerous/safe mode |
 | `\` | Toggle shell pane visibility |
 | `Shift+↑/↓` | Switch between panes |
+| `Alt+Shift+↑/↓` | Jump to prev/next task (stays in executor pane) |
 | `c` | Close task |
 | `a` | Archive task |
 | `d` | Delete task |

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -856,18 +856,14 @@ func (m *DetailModel) joinTmuxPanes() {
 	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "S-Up", "select-pane", "-t", ":.-").Run()
 	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "S-Left", "select-pane", "-t", ":.-").Run()
 
-	// Bind Shift+X then Arrow to jump to next/prev task while focusing executor pane
-	// This allows quick task navigation from any pane (especially useful from Claude pane):
-	// 1. Shift+X enters "task-nav" key table
-	// 2. Down/Up navigates to next/prev task and focuses executor pane
+	// Bind Alt+Shift+Up/Down to jump to prev/next task while focusing executor pane
+	// This allows quick task navigation from any pane (especially useful from Claude pane)
+	// Using Alt+Shift mirrors the Shift+Arrow pane switching, and doesn't produce printable chars
 	// The sequence: select TUI pane -> send navigation key -> wait for re-join -> select executor pane
-	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "X", "switch-client", "-T", "task-nav").Run()
-	nextTaskCmd := "tmux select-pane -t :.0 && tmux send-keys Down && sleep 0.3 && tmux select-pane -t :.1"
-	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "task-nav", "Down", "run-shell", nextTaskCmd).Run()
-	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "task-nav", "S-Down", "run-shell", nextTaskCmd).Run()
 	prevTaskCmd := "tmux select-pane -t :.0 && tmux send-keys Up && sleep 0.3 && tmux select-pane -t :.1"
-	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "task-nav", "Up", "run-shell", prevTaskCmd).Run()
-	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "task-nav", "S-Up", "run-shell", prevTaskCmd).Run()
+	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "M-S-Up", "run-shell", prevTaskCmd).Run()
+	nextTaskCmd := "tmux select-pane -t :.0 && tmux send-keys Down && sleep 0.3 && tmux select-pane -t :.1"
+	exec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "M-S-Down", "run-shell", nextTaskCmd).Run()
 
 	// Capture initial dimensions so we can detect user resizing later
 	// This allows us to save only when the user has actually dragged to resize
@@ -947,12 +943,9 @@ func (m *DetailModel) breakTmuxPanes(saveHeight bool) {
 	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "S-Up").Run()
 	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "S-Left").Run()
 
-	// Unbind Shift+X task navigation keybindings
-	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "X").Run()
-	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "task-nav", "Down").Run()
-	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "task-nav", "S-Down").Run()
-	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "task-nav", "Up").Run()
-	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "task-nav", "S-Up").Run()
+	// Unbind Alt+Shift+Arrow task navigation keybindings
+	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "M-S-Up").Run()
+	exec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "M-S-Down").Run()
 
 	// Reset pane title back to main view label
 	exec.CommandContext(ctx, "tmux", "select-pane", "-t", "task-ui:.0", "-T", "Tasks").Run()


### PR DESCRIPTION
## Summary
- Changed the task navigation shortcut from Shift+X+Arrow to Alt+Shift+Up/Down
- Shift+X produces a printable "X" character which gets typed into input fields instead of triggering the keybinding
- Alt+Shift+Arrow mirrors the existing Shift+Arrow shortcut for pane switching

## Shortcuts
- **Alt+Shift+Up** - Jump to previous task (stays in executor pane)
- **Alt+Shift+Down** - Jump to next task (stays in executor pane)

## Test plan
- [ ] Open a task in the executor pane
- [ ] Focus on Claude Code's input field  
- [ ] Press Alt+Shift+Up - should jump to previous task while staying in executor pane
- [ ] Press Alt+Shift+Down - should jump to next task while staying in executor pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)