### PR TITLE
fix: keep badge content stable when detail view is unfocused

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -566,6 +566,8 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if tickerCmd := m.detailView.StartTmuxTicker(); tickerCmd != nil {
 				cmds = append(cmds, tickerCmd)
 			}
+			// Start fast focus tick for responsive dimming
+			cmds = append(cmds, m.focusTick())
 			// Fetch PR info for the task
 			if prCmd := m.fetchPRInfo(msg.task); prCmd != nil {
 				cmds = append(cmds, prCmd)
@@ -704,6 +706,13 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.loadTasks())
 		}
 		cmds = append(cmds, m.tick())
+
+	case focusTickMsg:
+		// Fast tick for responsive focus state changes in detail view
+		if m.currentView == ViewDetail && m.detailView != nil {
+			m.detailView.RefreshFocusState()
+			cmds = append(cmds, m.focusTick())
+		}
 
 	case dbChangeMsg:
 		// Database file changed - reload tasks
@@ -2267,6 +2276,8 @@ type taskEventMsg struct {
 
 type tickMsg time.Time
 
+type focusTickMsg time.Time
+
 type prRefreshTickMsg time.Time
 
 type dbChangeMsg struct{}
@@ -2701,6 +2712,12 @@ func (m *AppModel) waitForTaskEvent() tea.Cmd {
 func (m *AppModel) tick() tea.Cmd {
 	return tea.Tick(1*time.Second, func(t time.Time) tea.Msg {
 		return tickMsg(t)
+	})
+}
+
+func (m *AppModel) focusTick() tea.Cmd {
+	return tea.Tick(200*time.Millisecond, func(t time.Time) tea.Msg {
+		return focusTickMsg(t)
 	})
 }
 

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1130,6 +1130,12 @@ func (m *DetailModel) IsFocused() bool {
 	return m.focused
 }
 
+// RefreshFocusState is a lightweight refresh that only updates focus state.
+// Used by the fast focus tick for responsive dimming without full refresh overhead.
+func (m *DetailModel) RefreshFocusState() {
+	m.checkFocusState()
+}
+
 // checkFocusState checks if the TUI pane is the active pane in tmux.
 func (m *DetailModel) checkFocusState() {
 	// Default to focused if not in tmux or no panes joined
@@ -1274,12 +1280,13 @@ func (m *DetailModel) renderHeader() string {
 		if m.focused {
 			meta.WriteString(PRStatusBadge(m.prInfo))
 		} else {
-			// Dimmed PR badge
+			// Dimmed PR badge - use same icon as focused, just dimmed
 			prBadgeStyle := lipgloss.NewStyle().
-				Padding(0, 1).
+				Padding(0, 0).
 				Background(dimmedBg).
-				Foreground(dimmedFg)
-			meta.WriteString(prBadgeStyle.Render(string(m.prInfo.State)))
+				Foreground(dimmedFg).
+				Bold(true)
+			meta.WriteString(prBadgeStyle.Render(PRStatusIcon(m.prInfo)))
 		}
 		meta.WriteString(" ")
 		prDesc := lipgloss.NewStyle().

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -285,6 +285,42 @@ func PRStatusBadge(pr *github.PRInfo) string {
 	return style.Render(icon)
 }
 
+// PRStatusIcon returns just the icon character for a PR status (without styling).
+// This is useful for creating consistently-sized badges with different color schemes.
+func PRStatusIcon(pr *github.PRInfo) string {
+	if pr == nil {
+		return ""
+	}
+
+	switch pr.State {
+	case github.PRStateMerged:
+		return "M"
+	case github.PRStateClosed:
+		return "X"
+	case github.PRStateDraft:
+		return "D"
+	case github.PRStateOpen:
+		// Check for merge conflicts first - this takes priority over check status
+		if pr.Mergeable == "CONFLICTING" {
+			return "C" // Conflicts
+		}
+		switch pr.CheckState {
+		case github.CheckStatePassing:
+			if pr.Mergeable == "MERGEABLE" {
+				return "R" // Ready to merge
+			}
+			return "P" // Passing
+		case github.CheckStateFailing:
+			return "F" // Failing
+		case github.CheckStatePending:
+			return "W" // Waiting/running
+		default:
+			return "O" // Open, no checks
+		}
+	}
+	return ""
+}
+
 // PRStatusDescription returns a human-readable description of PR status.
 func PRStatusDescription(pr *github.PRInfo) string {
 	if pr == nil {

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -100,6 +100,74 @@ func TestPRStatusBadge(t *testing.T) {
 	}
 }
 
+func TestPRStatusIcon(t *testing.T) {
+	tests := []struct {
+		name     string
+		prInfo   *github.PRInfo
+		expected string
+	}{
+		{
+			name:     "nil PR returns empty",
+			prInfo:   nil,
+			expected: "",
+		},
+		{
+			name:     "merged PR shows M",
+			prInfo:   &github.PRInfo{State: github.PRStateMerged},
+			expected: "M",
+		},
+		{
+			name:     "closed PR shows X",
+			prInfo:   &github.PRInfo{State: github.PRStateClosed},
+			expected: "X",
+		},
+		{
+			name:     "draft PR shows D",
+			prInfo:   &github.PRInfo{State: github.PRStateDraft},
+			expected: "D",
+		},
+		{
+			name:     "open PR ready to merge shows R",
+			prInfo:   &github.PRInfo{State: github.PRStateOpen, CheckState: github.CheckStatePassing, Mergeable: "MERGEABLE"},
+			expected: "R",
+		},
+		{
+			name:     "open PR with conflicts shows C",
+			prInfo:   &github.PRInfo{State: github.PRStateOpen, CheckState: github.CheckStatePassing, Mergeable: "CONFLICTING"},
+			expected: "C",
+		},
+		{
+			name:     "open PR with failing checks shows F",
+			prInfo:   &github.PRInfo{State: github.PRStateOpen, CheckState: github.CheckStateFailing},
+			expected: "F",
+		},
+		{
+			name:     "open PR with pending checks shows W",
+			prInfo:   &github.PRInfo{State: github.PRStateOpen, CheckState: github.CheckStatePending},
+			expected: "W",
+		},
+		{
+			name:     "open PR with passing checks shows P",
+			prInfo:   &github.PRInfo{State: github.PRStateOpen, CheckState: github.CheckStatePassing},
+			expected: "P",
+		},
+		{
+			name:     "open PR with no checks shows O",
+			prInfo:   &github.PRInfo{State: github.PRStateOpen, CheckState: github.CheckStateNone},
+			expected: "O",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PRStatusIcon(tt.prInfo)
+			if got != tt.expected {
+				t.Errorf("PRStatusIcon() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestPRStatusDescription(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- When the detail view is unfocused, PR status badges now only dim (change color) instead of changing their content
- Previously, a merged PR badge would change from "M" to "MERGED" when unfocused
- Also speeds up the dimming response from 1s to 200ms via a separate fast tick

## Changes
- Add `PRStatusIcon` helper function that returns just the icon letter without styling
- Use `PRStatusIcon` for dimmed PR badges instead of `string(m.prInfo.State)`
- Add fast focus tick (200ms) separate from main tick (1s) for responsive dimming without increasing database polling frequency
- Add `RefreshFocusState` method for lightweight focus-only updates
- Add comprehensive tests for `PRStatusIcon` function

## Test plan
- [x] All existing tests pass
- [x] New `TestPRStatusIcon` tests pass
- [ ] Manual verification: Open a task with a PR, switch focus away from detail pane, verify badge shows abbreviated icon (M, X, D, etc.) just dimmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)