### PR TITLE
fix: show PR status in kanban view on initial load

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,0 +1,1 @@
+/Users/bruno/Projects/workflow/.claude

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -244,7 +244,8 @@ type AppModel struct {
 	dbChangeCh chan struct{}
 
 	// PR status cache
-	prCache *github.PRCache
+	prCache              *github.PRCache
+	initialPRRefreshDone bool // Track if initial PR refresh after load is done
 
 	// Detail view state
 	selectedTask *db.Task
@@ -395,7 +396,7 @@ func (m *AppModel) Init() tea.Cmd {
 		osExec.Command("tmux", "set-option", "-t", "task-ui", "mouse", "on").Run()
 	}
 
-	return tea.Batch(m.loadTasks(), m.waitForTaskEvent(), m.waitForDBChange(), m.tick(), m.prRefreshTick(), m.refreshAllPRs())
+	return tea.Batch(m.loadTasks(), m.waitForTaskEvent(), m.waitForDBChange(), m.tick(), m.prRefreshTick())
 }
 
 // Update handles messages.
@@ -550,7 +551,11 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.applyFilter()
 		m.kanban.SetHiddenDoneCount(msg.hiddenDoneCount)
 
-		// PR info is fetched separately via prRefreshTick, not on every task load
+		// Trigger initial PR refresh after first task load (subsequent refreshes via prRefreshTick)
+		if !m.initialPRRefreshDone {
+			m.initialPRRefreshDone = true
+			cmds = append(cmds, m.refreshAllPRs())
+		}
 
 	case taskLoadedMsg:
 		// Reset transition flag now that task is loaded


### PR DESCRIPTION
## Summary
- Fixed PR status not showing in kanban view on initial load
- The issue was that `refreshAllPRs()` ran before tasks were loaded
- Now triggers PR refresh after the first task load completes

## Root Cause
In `Init()`, `refreshAllPRs()` was running in parallel with `loadTasks()`, but `refreshAllPRs()` iterates over `m.tasks` which was still empty at that point. The PR refresh tick only fires every 30 seconds, so users had to either wait or view a task's details (which fetches PR info directly) before seeing PR status.

## Test plan
- [ ] Start the app fresh and verify PR status badges appear in kanban view immediately after tasks load
- [ ] Verify PR status still updates when viewing task details
- [ ] Verify PR status still refreshes every 30 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)