### PR TITLE
fix: enable mouse wheel scrolling in task detail pane

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -482,6 +482,12 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.MouseMsg:
+		// Handle mouse events in detail view (for scroll wheel)
+		if m.currentView == ViewDetail && m.detailView != nil {
+			var cmd tea.Cmd
+			m.detailView, cmd = m.detailView.Update(msg)
+			return m, cmd
+		}
 		// Handle mouse clicks on dashboard view
 		if m.currentView == ViewDashboard && msg.Action == tea.MouseActionRelease && msg.Button == tea.MouseButtonLeft {
 			// Check if clicking on a task card
@@ -567,8 +573,6 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.detailView.SetPosition(pos, total)
 			m.previousView = m.currentView
 			m.currentView = ViewDetail
-			// Disable mouse to allow native text selection in detail view
-			cmds = append(cmds, tea.DisableMouse)
 			// Start tmux output ticker if session is active
 			if tickerCmd := m.detailView.StartTmuxTicker(); tickerCmd != nil {
 				cmds = append(cmds, tickerCmd)
@@ -1221,8 +1225,7 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.detailView.Cleanup()
 			m.detailView = nil
 		}
-		// Re-enable mouse for dashboard click-to-select
-		return m, tea.EnableMouseCellMotion
+		return m, nil
 	}
 
 	// Handle queue/close/retry from detail view

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1179,28 +1179,8 @@ func (m *DetailModel) View() string {
 		Width(m.width-2).
 		Padding(0, 1)
 
-	// Add scroll indicator if content is scrollable
-	var scrollIndicator string
-	if m.viewport.TotalLineCount() > m.viewport.VisibleLineCount() {
-		scrollPercent := 0
-		if m.viewport.TotalLineCount() > 0 {
-			scrollPercent = int(float64(m.viewport.YOffset+m.viewport.VisibleLineCount()) / float64(m.viewport.TotalLineCount()) * 100)
-			if scrollPercent > 100 {
-				scrollPercent = 100
-			}
-		}
-		indicatorStyle := lipgloss.NewStyle().Foreground(ColorMuted)
-		if !m.focused {
-			indicatorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#4B5563"))
-		}
-		scrollIndicator = indicatorStyle.Render(fmt.Sprintf(" %d%% ", scrollPercent))
-	}
-
 	help := m.renderHelp()
 	boxContent := lipgloss.JoinVertical(lipgloss.Left, header, content)
-	if scrollIndicator != "" {
-		boxContent = lipgloss.JoinVertical(lipgloss.Left, header, content, scrollIndicator)
-	}
 	return lipgloss.JoinVertical(lipgloss.Left,
 		box.Render(boxContent),
 		help,


### PR DESCRIPTION
## Summary
- Enable mouse wheel scrolling in the task detail pane by routing mouse events to the detail view
- Remove the scroll percentage indicator display as it was not needed
- Keep mouse enabled throughout the application (no longer disable/enable when switching views)

## Test plan
- [ ] Open a task detail view with enough content to scroll
- [ ] Verify mouse wheel scrolling works in the detail pane
- [ ] Verify clicking on tasks in the dashboard still works
- [ ] Verify navigating between tasks with arrow keys still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)