### PR TITLE
feat: add worktree teardown script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ worktree:
 | Field | Description | Example |
 |-------|-------------|---------|
 | `worktree.init_script` | Path to script that runs after worktree creation (relative or absolute) | `bin/worktree-setup` |
+| `worktree.teardown_script` | Path to script that runs before worktree deletion (relative or absolute) | `bin/worktree-teardown` |
 
 ### Projects
 
@@ -289,6 +290,31 @@ worktree:
 ```
 
 The script runs in the worktree directory and has access to all worktree environment variables (`WORKTREE_TASK_ID`, `WORKTREE_PORT`, `WORKTREE_PATH`).
+
+#### Worktree Teardown Script
+
+You can configure a script to run automatically before a worktree is deleted. This is useful for:
+- Dropping task-specific databases
+- Stopping background services
+- Cleaning up docker containers
+- Removing temporary files
+
+**Two ways to configure:**
+
+1. **Conventional location** - Create an executable script at `bin/worktree-teardown`:
+```bash
+#!/bin/bash
+# Example: bin/worktree-teardown
+bin/rails db:drop
+```
+
+2. **Custom location** - Specify in `.taskyou.yml`:
+```yaml
+worktree:
+  teardown_script: scripts/my-teardown.sh
+```
+
+The teardown script runs when you delete a task through the app. If you manually remove a worktree via `git worktree remove` or `rm -rf`, the teardown script will not run.
 
 ### Running Applications in Worktrees
 
@@ -332,6 +358,13 @@ bundle install
 
 # Create isolated database for this task
 bin/rails db:create db:migrate
+```
+
+**bin/worktree-teardown:**
+```bash
+#!/bin/bash
+# Drop the task-specific database
+bin/rails db:drop
 ```
 
 Now the AI executor (Claude or Codex) can:

--- a/internal/executor/project_config.go
+++ b/internal/executor/project_config.go
@@ -17,6 +17,9 @@ type WorktreeConfig struct {
 	// InitScript is the path to a script that runs after worktree creation.
 	// Can be relative to the project root (e.g., "bin/worktree-setup").
 	InitScript string `yaml:"init_script"`
+	// TeardownScript is the path to a script that runs before worktree deletion.
+	// Can be relative to the project root (e.g., "bin/worktree-teardown").
+	TeardownScript string `yaml:"teardown_script"`
 }
 
 // ConfigFileNames are the supported configuration file names, in order of precedence.
@@ -25,6 +28,10 @@ var ConfigFileNames = []string{".taskyou.yml", ".taskyou.yaml", "taskyou.yml", "
 // ConventionalInitScript is the conventional location for a worktree init script.
 // If no config file exists but this script is present and executable, it will be used.
 const ConventionalInitScript = "bin/worktree-setup"
+
+// ConventionalTeardownScript is the conventional location for a worktree teardown script.
+// If no config file exists but this script is present and executable, it will be used.
+const ConventionalTeardownScript = "bin/worktree-teardown"
 
 // LoadProjectConfig loads the project configuration from the given directory.
 // It returns nil if no configuration file exists.
@@ -75,6 +82,38 @@ func GetWorktreeInitScript(projectDir string) string {
 
 	// Fall back to conventional location
 	conventionalPath := filepath.Join(projectDir, ConventionalInitScript)
+	if info, err := os.Stat(conventionalPath); err == nil {
+		// Check if executable (on Unix-like systems)
+		if info.Mode()&0111 != 0 {
+			return conventionalPath
+		}
+	}
+
+	return ""
+}
+
+// GetWorktreeTeardownScript returns the path to the worktree teardown script for a project.
+// It checks:
+// 1. The teardown_script configured in .taskyou.yml
+// 2. The conventional bin/worktree-teardown script if it exists and is executable
+// Returns empty string if no teardown script is configured or found.
+func GetWorktreeTeardownScript(projectDir string) string {
+	// Check configuration file first
+	config, err := LoadProjectConfig(projectDir)
+	if err == nil && config != nil && config.Worktree.TeardownScript != "" {
+		scriptPath := config.Worktree.TeardownScript
+		// Make relative paths absolute
+		if !filepath.IsAbs(scriptPath) {
+			scriptPath = filepath.Join(projectDir, scriptPath)
+		}
+		// Verify the script exists
+		if _, err := os.Stat(scriptPath); err == nil {
+			return scriptPath
+		}
+	}
+
+	// Fall back to conventional location
+	conventionalPath := filepath.Join(projectDir, ConventionalTeardownScript)
 	if info, err := os.Stat(conventionalPath); err == nil {
 		// Check if executable (on Unix-like systems)
 		if info.Mode()&0111 != 0 {


### PR DESCRIPTION
## Summary

- Add support for running a teardown script before worktree deletion
- Useful for cleaning up task-specific databases, docker containers, or temp files
- Configure via `bin/worktree-teardown` (conventional) or `worktree.teardown_script` in `.taskyou.yml`

## Changes

- `project_config.go`: Added `TeardownScript` field and `GetWorktreeTeardownScript()` function
- `executor.go`: Added `runWorktreeTeardownScript()` and integrated into `CleanupWorktree()`
- `README.md`: Documented the teardown script feature with examples

## Test plan

- [ ] Create a project with `bin/worktree-teardown` script
- [ ] Create a task and verify worktree is created
- [ ] Delete task and verify teardown script runs before removal
- [ ] Test with custom path via `.taskyou.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)