### PR TITLE
feat: add keyboard shortcut to open server URL in browser

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -75,6 +75,8 @@ type KeyMap struct {
 	FocusDone       key.Binding
 	// Shell pane toggle
 	ToggleShellPane key.Binding
+	// Open server URL
+	OpenServer key.Binding
 }
 
 // ShortHelp returns key bindings to show in the mini help.
@@ -208,6 +210,10 @@ func DefaultKeyMap() KeyMap {
 		ToggleShellPane: key.NewBinding(
 			key.WithKeys("\\"),
 			key.WithHelp("\\", "toggle shell"),
+		),
+		OpenServer: key.NewBinding(
+			key.WithKeys("o"),
+			key.WithHelp("o", "open server"),
 		),
 	}
 }
@@ -1313,6 +1319,14 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	if key.Matches(keyMsg, m.keys.ToggleShellPane) && m.detailView != nil {
 		m.detailView.ToggleShellPane()
+		return m, nil
+	}
+	if key.Matches(keyMsg, m.keys.OpenServer) && m.selectedTask != nil {
+		// Open the localhost URL with the task's assigned port
+		if m.selectedTask.Port > 0 {
+			url := fmt.Sprintf("http://localhost:%d", m.selectedTask.Port)
+			osExec.Command("open", url).Start()
+		}
 		return m, nil
 	}
 

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1703,6 +1703,14 @@ func (m *DetailModel) renderHelp() string {
 		}{"\\", toggleDesc})
 	}
 
+	// Show open server shortcut when task has a port assigned
+	if m.task != nil && m.task.Port > 0 {
+		keys = append(keys, struct {
+			key  string
+			desc string
+		}{"o", fmt.Sprintf("open :%d", m.task.Port)})
+	}
+
 	keys = append(keys, []struct {
 		key  string
 		desc string


### PR DESCRIPTION
## Summary
- Adds `o` keyboard shortcut in detail view to open `localhost:PORT` in the default browser
- Shows the shortcut in the help bar when viewing a task with an assigned port (e.g., "o open :3137")
- Uses macOS `open` command to launch the URL in the default browser

## Test plan
- [ ] Open a task in detail view that has a port assigned
- [ ] Verify the help bar shows "o open :XXXX" where XXXX is the port
- [ ] Press `o` to verify it opens the URL in the default browser
- [ ] Verify other keyboard shortcuts still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)