### PR TITLE
feat: default project selection to last used project

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -149,6 +149,11 @@ func (db *DB) CreateTask(t *Task) error {
 		db.SetLastTaskTypeForProject(t.Project, t.Type)
 	}
 
+	// Save the last used project
+	if t.Project != "" {
+		db.SetLastUsedProject(t.Project)
+	}
+
 	return nil
 }
 
@@ -1160,6 +1165,16 @@ func (db *DB) GetLastTaskTypeForProject(project string) (string, error) {
 // SetLastTaskTypeForProject saves the last used task type for a project.
 func (db *DB) SetLastTaskTypeForProject(project, taskType string) error {
 	return db.SetSetting("last_type_"+project, taskType)
+}
+
+// GetLastUsedProject returns the last used project name.
+func (db *DB) GetLastUsedProject() (string, error) {
+	return db.GetSetting("last_used_project")
+}
+
+// SetLastUsedProject saves the last used project name.
+func (db *DB) SetLastUsedProject(project string) error {
+	return db.SetSetting("last_used_project", project)
 }
 
 // CreateTaskType creates a new task type.

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -303,11 +303,11 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 		}
 	}
 
-	// Default to last task's project, or fall back to 'personal'
+	// Default to last used project, or fall back to 'personal'
 	m.project = "personal"
 	if database != nil {
-		if lastTask, err := database.GetMostRecentlyCreatedTask(); err == nil && lastTask != nil && lastTask.Project != "" {
-			m.project = lastTask.Project
+		if lastProject, err := database.GetLastUsedProject(); err == nil && lastProject != "" {
+			m.project = lastProject
 		}
 	}
 	for i, p := range m.projects {


### PR DESCRIPTION
## Summary
- Adds dedicated settings-based storage for the last used project
- Updates the task form to default to the last used project when creating new tasks
- Persists the project selection when tasks are created for a better user experience

## Test plan
- [ ] Create a task in a non-default project
- [ ] Open the new task form again and verify the project defaults to the last used project
- [ ] Verify the working directory override still takes precedence when applicable
- [ ] Run `go test ./...` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)