### PR TITLE
feat: add keyboard command to open worktree in editor

### DIFF
--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -26,6 +26,10 @@ func TestDefaultKeyMap(t *testing.T) {
 	if keys.ChangeStatus.Help().Key != "S" {
 		t.Error("ChangeStatus key should have help text 'S'")
 	}
+
+	if keys.OpenWorktree.Help().Key != "o" {
+		t.Error("OpenWorktree key should have help text 'o'")
+	}
 }
 
 func TestShowChangeStatus_OnlyIncludesKanbanStatuses(t *testing.T) {
@@ -191,5 +195,51 @@ func TestShowCloseConfirm_DifferentTasks(t *testing.T) {
 				t.Error("pendingCloseTask was not set correctly")
 			}
 		})
+	}
+}
+
+func TestOpenWorktreeInEditor_NoWorktreePath(t *testing.T) {
+	m := &AppModel{}
+
+	// Test task with no worktree path
+	task := &db.Task{
+		ID:           1,
+		Title:        "Test Task",
+		WorktreePath: "",
+	}
+
+	cmd := m.openWorktreeInEditor(task)
+	msg := cmd()
+
+	result, ok := msg.(worktreeOpenedMsg)
+	if !ok {
+		t.Fatal("expected worktreeOpenedMsg")
+	}
+
+	if result.err == nil {
+		t.Error("expected error for task with no worktree path")
+	}
+}
+
+func TestOpenWorktreeInEditor_NonexistentPath(t *testing.T) {
+	m := &AppModel{}
+
+	// Test task with non-existent worktree path
+	task := &db.Task{
+		ID:           1,
+		Title:        "Test Task",
+		WorktreePath: "/nonexistent/path/that/does/not/exist",
+	}
+
+	cmd := m.openWorktreeInEditor(task)
+	msg := cmd()
+
+	result, ok := msg.(worktreeOpenedMsg)
+	if !ok {
+		t.Fatal("expected worktreeOpenedMsg")
+	}
+
+	if result.err == nil {
+		t.Error("expected error for non-existent worktree path")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a new keyboard binding `o` that opens the selected task's worktree directory in the default editor
- Uses `VISUAL` environment variable first, then `EDITOR`, falling back to the `open` command on macOS
- Works from both the dashboard (kanban) and detail views
- Shows notifications for success or error (no worktree, path not found)

## Test plan
- [x] Verified code compiles with `go build ./...`
- [x] All existing tests pass with `go test ./...`
- [x] Added tests for key binding definition and error handling
- [ ] Manual testing: Press `o` on a task with a worktree to open it in editor
- [ ] Manual testing: Press `o` on a task without a worktree to see error notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)