### PR TITLE
fix: truncate long task titles in detail panel header

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1605,11 +1605,21 @@ func (m *DetailModel) renderHeader() string {
 	dimmedTextFg := lipgloss.Color("#6B7280") // Even more muted for text
 
 	// Task title (ID and position are shown in the panel border)
+	// Truncate title if it's too long for the panel width
+	title := t.Title
+	maxTitleLen := m.width - 4 // Account for border and padding
+	if maxTitleLen < 10 {
+		maxTitleLen = 10
+	}
+	if len(title) > maxTitleLen {
+		title = title[:maxTitleLen-1] + "…"
+	}
+
 	var subtitle string
 	if m.focused {
-		subtitle = Bold.Render(t.Title)
+		subtitle = Bold.Render(title)
 	} else {
-		subtitle = lipgloss.NewStyle().Foreground(dimmedTextFg).Render(t.Title)
+		subtitle = lipgloss.NewStyle().Foreground(dimmedTextFg).Render(title)
 	}
 
 	var meta strings.Builder


### PR DESCRIPTION
## Summary
- Fixed task title truncation issue in the task view details panel
- Task titles that exceed the available panel width are now truncated with an ellipsis (…)
- Uses the same truncation pattern as the kanban view for consistency

## Test plan
- [ ] Open a task with a long title in the detail view
- [ ] Verify the title is truncated to fit within the panel width
- [ ] Verify the truncation shows an ellipsis at the end
- [ ] Resize the terminal and verify the title adjusts appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)