### PR TITLE
feat: add keyboard shortcut to kill shell pane process

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -191,6 +191,11 @@ func (m *DetailModel) ClaudePaneID() string {
 	return m.claudePaneID
 }
 
+// WorkdirPaneID returns the tmux pane ID of the shell pane.
+func (m *DetailModel) WorkdirPaneID() string {
+	return m.workdirPaneID
+}
+
 // NewDetailModel creates a new detail model.
 // Returns the model and an optional command for async pane setup.
 func NewDetailModel(t *db.Task, database *db.DB, exec *executor.Executor, width, height int) (*DetailModel, tea.Cmd) {
@@ -2030,6 +2035,14 @@ func (m *DetailModel) renderHelp() string {
 			key  string
 			desc string
 		}{"shift+↑↓", "switch pane"})
+	}
+
+	// Show kill shell process shortcut when shell pane exists
+	if m.workdirPaneID != "" && os.Getenv("TMUX") != "" {
+		keys = append(keys, struct {
+			key  string
+			desc string
+		}{"K", "kill shell proc"})
 	}
 
 	keys = append(keys, []struct {


### PR DESCRIPTION
## Summary
- Adds `K` keyboard shortcut in detail view to send Ctrl+C to the shell pane
- Uses `tmux send-keys C-c` to send the interrupt signal, which works even when direct Ctrl+C presses aren't captured properly
- Shows notification when interrupt signal is sent

## Problem
When running processes like Rails servers in the shell pane, pressing Ctrl+C directly sometimes doesn't work to stop the process (possibly due to tmux capturing the key press).

## Solution
Added a workaround that sends Ctrl+C via `tmux send-keys`, which reliably sends the interrupt signal to the foreground process in the shell pane.

## Test plan
- [ ] Open a task with a shell pane
- [ ] Start a long-running process (e.g., `rails server`, `sleep 100`)
- [ ] Press `K` in the TUI
- [ ] Verify the process is interrupted
- [ ] Verify notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)