### PR TITLE
fix: ensure task title is visible in detail panel

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1605,11 +1605,28 @@ func (m *DetailModel) renderHeader() string {
 	dimmedTextFg := lipgloss.Color("#6B7280") // Even more muted for text
 
 	// Task title (ID and position are shown in the panel border)
+	// Use title if available, otherwise show first line of body as fallback
+	titleText := t.Title
+	if titleText == "" && t.Body != "" {
+		// Extract first line of body as title fallback
+		if idx := strings.Index(t.Body, "\n"); idx > 0 {
+			titleText = t.Body[:idx]
+		} else {
+			titleText = t.Body
+		}
+		// Truncate long body text used as title
+		if len(titleText) > 100 {
+			titleText = titleText[:97] + "..."
+		}
+	}
+
 	var subtitle string
-	if m.focused {
-		subtitle = Bold.Render(t.Title)
-	} else {
-		subtitle = lipgloss.NewStyle().Foreground(dimmedTextFg).Render(t.Title)
+	if titleText != "" {
+		if m.focused {
+			subtitle = Title.Render(titleText)
+		} else {
+			subtitle = lipgloss.NewStyle().Foreground(dimmedTextFg).Render(titleText)
+		}
 	}
 
 	var meta strings.Builder


### PR DESCRIPTION
## Summary
- Fixed task title not showing in the task view details panel
- Changed title rendering to use the `Title` style with explicit foreground color (`ColorPrimary`) instead of plain `Bold` which had no color
- Added fallback to display the first line of task body if title is empty
- Added truncation for long fallback text to prevent overflow

## Root Cause
The task title was rendered using `Bold.Render()` which only sets bold=true without an explicit foreground color. Combined with certain terminal configurations or the panel state, this could result in invisible or nearly invisible text.

## Test plan
- [ ] Open a task in the detail view
- [ ] Verify the title is now visible with the primary color (yellow/gold)
- [ ] Test with a task that has an empty title - should show first line of body as fallback
- [ ] Test with long task titles to ensure they display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)