### PR TITLE
fix: show correct executor name in task view pane

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -326,6 +326,26 @@ func (m *AppModel) executorDisplayName() string {
 	return executor.DefaultExecutorName()
 }
 
+// taskExecutorDisplayName returns the display name for a task's executor.
+// Uses the task's Executor field to determine the correct name.
+func taskExecutorDisplayName(task *db.Task) string {
+	if task == nil || task.Executor == "" {
+		return executor.DefaultExecutorName()
+	}
+	switch task.Executor {
+	case db.ExecutorCodex:
+		return "Codex"
+	case db.ExecutorClaude:
+		return "Claude"
+	default:
+		// Unknown executor, capitalize first letter
+		if len(task.Executor) > 0 {
+			return strings.ToUpper(task.Executor[:1]) + task.Executor[1:]
+		}
+		return executor.DefaultExecutorName()
+	}
+}
+
 // updateTaskInList updates a task in the tasks list and refreshes the kanban.
 func (m *AppModel) updateTaskInList(task *db.Task) {
 	for i, t := range m.tasks {
@@ -2694,7 +2714,7 @@ func (m *AppModel) toggleDangerousMode(id int64) tea.Cmd {
 			return taskDangerousModeToggledMsg{err: fmt.Errorf("failed to get task")}
 		}
 
-		executorName := m.executorDisplayName()
+		executorName := taskExecutorDisplayName(task)
 		var success bool
 		if task.DangerousMode {
 			// Currently in dangerous mode, switch to safe mode
@@ -2721,7 +2741,7 @@ func (m *AppModel) resumeClaude(id int64, claudePaneID string) tea.Cmd {
 			return taskClaudeToggledMsg{err: fmt.Errorf("failed to get task")}
 		}
 
-		executorName := m.executorDisplayName()
+		executorName := taskExecutorDisplayName(task)
 
 		// Check if Claude is already running
 		if claudePaneID != "" {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -97,6 +97,21 @@ type spinnerTickMsg struct{}
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
 func (m *DetailModel) executorDisplayName() string {
+	// Use the task's executor field if available (each task can have a different executor)
+	if m.task != nil && m.task.Executor != "" {
+		switch m.task.Executor {
+		case db.ExecutorCodex:
+			return "Codex"
+		case db.ExecutorClaude:
+			return "Claude"
+		default:
+			// Unknown executor, capitalize first letter
+			if len(m.task.Executor) > 0 {
+				return strings.ToUpper(m.task.Executor[:1]) + m.task.Executor[1:]
+			}
+		}
+	}
+	// Fallback to the global executor's display name
 	if m.executor != nil {
 		return m.executor.DisplayName()
 	}


### PR DESCRIPTION
## Summary
- Updated `executorDisplayName()` in `DetailModel` (detail.go) to use the task's `Executor` field instead of the global executor name
- Added `taskExecutorDisplayName()` helper function in app.go for task-specific executor name resolution
- Updated error messages in `toggleDangerousMode()` and `resumeClaude()` to show the correct executor name for each task

## Test plan
- [ ] Create a task with "codex" executor, open task view, verify pane title shows "Codex"
- [ ] Create a task with "claude" executor, open task view, verify pane title shows "Claude"
- [ ] Toggle dangerous mode on a codex task, verify error messages mention "Codex" not "Claude"
- [ ] Resume executor on a codex task, verify error messages mention "Codex" not "Claude"

🤖 Generated with [Claude Code](https://claude.com/claude-code)