### PR TITLE
feat: preselect task executor based on last task in same project

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -150,6 +150,11 @@ func (db *DB) CreateTask(t *Task) error {
 		db.SetLastTaskTypeForProject(t.Project, t.Type)
 	}
 
+	// Save the last used executor for this project
+	if t.Executor != "" {
+		db.SetLastExecutorForProject(t.Project, t.Executor)
+	}
+
 	// Save the last used project
 	if t.Project != "" {
 		db.SetLastUsedProject(t.Project)
@@ -1200,6 +1205,16 @@ func (db *DB) GetLastUsedProject() (string, error) {
 // SetLastUsedProject saves the last used project name.
 func (db *DB) SetLastUsedProject(project string) error {
 	return db.SetSetting("last_used_project", project)
+}
+
+// GetLastExecutorForProject returns the last used executor for a project.
+func (db *DB) GetLastExecutorForProject(project string) (string, error) {
+	return db.GetSetting("last_executor_" + project)
+}
+
+// SetLastExecutorForProject saves the last used executor for a project.
+func (db *DB) SetLastExecutorForProject(project, executor string) error {
+	return db.SetSetting("last_executor_"+project, executor)
 }
 
 // CreateTaskType creates a new task type.

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -333,6 +333,9 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 	// Load last used task type for the selected project
 	m.loadLastTaskTypeForProject()
 
+	// Load last used executor for the selected project
+	m.loadLastExecutorForProject()
+
 	// Title input
 	m.titleInput = textinput.New()
 	m.titleInput.Placeholder = "What needs to be done?"
@@ -582,6 +585,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.projectIdx = (m.projectIdx - 1 + len(m.projects)) % len(m.projects)
 				m.project = m.projects[m.projectIdx]
 				m.loadLastTaskTypeForProject()
+				m.loadLastExecutorForProject()
 				return m, nil
 			}
 			if m.focused == FieldType {
@@ -605,6 +609,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.projectIdx = (m.projectIdx + 1) % len(m.projects)
 				m.project = m.projects[m.projectIdx]
 				m.loadLastTaskTypeForProject()
+				m.loadLastExecutorForProject()
 				return m, nil
 			}
 			if m.focused == FieldType {
@@ -830,6 +835,7 @@ func (m *FormModel) selectByPrefix(prefix string) {
 				m.projectIdx = i
 				m.project = p
 				m.loadLastTaskTypeForProject()
+				m.loadLastExecutorForProject()
 				return
 			}
 		}
@@ -884,6 +890,27 @@ func (m *FormModel) loadLastTaskTypeForProject() {
 		if t == lastType {
 			m.typeIdx = i
 			m.taskType = t
+			return
+		}
+	}
+}
+
+// loadLastExecutorForProject loads and sets the last used executor for the current project.
+func (m *FormModel) loadLastExecutorForProject() {
+	if m.db == nil || m.project == "" {
+		return
+	}
+
+	lastExecutor, err := m.db.GetLastExecutorForProject(m.project)
+	if err != nil || lastExecutor == "" {
+		return
+	}
+
+	// Find the executor in the list and set it
+	for i, e := range m.executors {
+		if e == lastExecutor {
+			m.executorIdx = i
+			m.executor = e
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- When creating a new task, the executor (claude/codex) is now preselected based on the last task created in the same project
- Follows the existing pattern used for task types, improving workflow consistency
- Users who consistently use a specific executor for certain projects will benefit from automatic preselection

## Test plan
- [x] Create a task with "codex" executor in a project
- [x] Create a new task in the same project - verify "codex" is preselected
- [x] Switch to a different project - verify executor changes to that project's last used
- [x] All existing tests pass
- [x] New tests added for `TestLastExecutorForProject` and `TestCreateTaskSavesLastExecutor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)