### PR TITLE
fix: kanban column scrolling loses selection at bottom

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -246,9 +246,13 @@ func (k *KanbanBoard) ensureSelectedVisible() {
 	}
 
 	// Calculate how many tasks fit in the visible area
-	colHeight := k.height
+	// Must match viewDesktop()/viewMobile() calculation
+	colHeight := k.height - 2 // -2 for column borders
+	if k.IsMobileMode() {
+		colHeight = k.height - 4 // -2 for tab bar, -2 for column borders
+	}
 	cardHeight := 3                            // Most cards are 3 lines (2 content + 1 border)
-	maxVisible := (colHeight - 3) / cardHeight // -3 for header bar and minimal padding
+	maxVisible := (colHeight - 3) / cardHeight // -3 for header bar and scroll indicators
 	if maxVisible < 1 {
 		maxVisible = 1
 	}


### PR DESCRIPTION
## Summary
- Fixed `ensureSelectedVisible()` using wrong height calculation causing selected task to fall outside visible range when scrolling down
- Now matches `viewDesktop()`/`viewMobile()` height calculations (accounting for borders and tab bar)

## Test plan
- [x] Navigate to a kanban column with more tasks than visible
- [x] Arrow down to the last visible task
- [x] Continue pressing down - selection should remain visible as it scrolls
- [x] Verify wrap-around still works (down at bottom goes to top)
- [x] Test in mobile mode (narrow terminal < 80 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)