### PR TITLE
fix: don't auto-start executor for tasks in backlog state

### DIFF
--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// TestNewDetailModel_BacklogTaskDoesNotStartExecutor verifies that when a task
+// is in backlog status, viewing it in the TUI should NOT automatically start
+// the executor session. This prevents unwanted execution of tasks that the user
+// has explicitly chosen not to start yet.
+func TestNewDetailModel_BacklogTaskDoesNotStartExecutor(t *testing.T) {
+	// Create a task in backlog status (not meant to be executed yet)
+	task := &db.Task{
+		ID:     1,
+		Title:  "Test backlog task",
+		Status: db.StatusBacklog,
+	}
+
+	// Create DetailModel - when not in tmux (TMUX env var not set),
+	// it returns nil command, so we can't test that path easily.
+	// But when task is in backlog, we should never start the executor
+	// regardless of tmux state.
+
+	// For now, test that backlog tasks are properly identified
+	if !shouldSkipAutoExecutor(task) {
+		t.Error("backlog tasks should skip auto-executor")
+	}
+}
+
+// TestNewDetailModel_QueuedTaskCanStartExecutor verifies that tasks in
+// queued status CAN start the executor automatically when viewed.
+func TestNewDetailModel_QueuedTaskCanStartExecutor(t *testing.T) {
+	task := &db.Task{
+		ID:     1,
+		Title:  "Test queued task",
+		Status: db.StatusQueued,
+	}
+
+	if shouldSkipAutoExecutor(task) {
+		t.Error("queued tasks should NOT skip auto-executor")
+	}
+}
+
+// TestNewDetailModel_ProcessingTaskCanStartExecutor verifies that tasks in
+// processing status CAN reconnect to the executor automatically when viewed.
+func TestNewDetailModel_ProcessingTaskCanStartExecutor(t *testing.T) {
+	task := &db.Task{
+		ID:     1,
+		Title:  "Test processing task",
+		Status: db.StatusProcessing,
+	}
+
+	if shouldSkipAutoExecutor(task) {
+		t.Error("processing tasks should NOT skip auto-executor")
+	}
+}
+
+// TestNewDetailModel_BlockedTaskCanStartExecutor verifies that tasks in
+// blocked status CAN reconnect to the executor automatically when viewed.
+func TestNewDetailModel_BlockedTaskCanStartExecutor(t *testing.T) {
+	task := &db.Task{
+		ID:     1,
+		Title:  "Test blocked task",
+		Status: db.StatusBlocked,
+	}
+
+	if shouldSkipAutoExecutor(task) {
+		t.Error("blocked tasks should NOT skip auto-executor")
+	}
+}
+
+// TestNewDetailModel_DoneTaskSkipsAutoExecutor verifies that completed tasks
+// should NOT auto-start the executor (they're done).
+func TestNewDetailModel_DoneTaskSkipsAutoExecutor(t *testing.T) {
+	task := &db.Task{
+		ID:     1,
+		Title:  "Test done task",
+		Status: db.StatusDone,
+	}
+
+	if !shouldSkipAutoExecutor(task) {
+		t.Error("done tasks should skip auto-executor")
+	}
+}
+
+// TestNewDetailModel_ArchivedTaskSkipsAutoExecutor verifies that archived tasks
+// should NOT auto-start the executor.
+func TestNewDetailModel_ArchivedTaskSkipsAutoExecutor(t *testing.T) {
+	task := &db.Task{
+		ID:     1,
+		Title:  "Test archived task",
+		Status: db.StatusArchived,
+	}
+
+	if !shouldSkipAutoExecutor(task) {
+		t.Error("archived tasks should skip auto-executor")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed bug where the executor would start automatically when viewing tasks in backlog state
- Added `shouldSkipAutoExecutor()` helper function to determine when to skip auto-starting the executor
- Tasks in backlog, done, and archived states no longer auto-start the executor when viewed in the TUI

## Problem
When creating a task without the `--execute` flag (or with "don't start executing"), the task is created in backlog state. However, when viewing this task in the TUI, the executor would automatically start, which contradicts the user's explicit choice not to start execution.

## Solution
Added a check in `NewDetailModel` that skips the async pane setup (which starts the executor) for:
- `backlog` tasks - not yet queued for execution
- `done` tasks - already completed
- `archived` tasks - no longer active

## Test plan
- [x] Added unit tests in `internal/ui/detail_test.go` to verify the behavior
- [x] Tests verify backlog/done/archived tasks skip auto-executor
- [x] Tests verify queued/processing/blocked tasks can auto-start executor
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)