### PR TITLE
fix: disable up/down navigation arrows when no prev/next task

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1439,6 +1439,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(keyMsg, m.keys.Up) {
+		// Ignore if no previous task exists
+		if !m.kanban.HasPrevTask() {
+			return m, nil
+		}
 		// Ignore if transition already in progress to prevent duplicate panes
 		if m.taskTransitionInProgress {
 			return m, nil
@@ -1459,6 +1463,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(keyMsg, m.keys.Down) {
+		// Ignore if no next task exists
+		if !m.kanban.HasNextTask() {
+			return m, nil
+		}
 		// Ignore if transition already in progress to prevent duplicate panes
 		if m.taskTransitionInProgress {
 			return m, nil

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1981,50 +1981,41 @@ func (m *DetailModel) renderContent() string {
 }
 
 func (m *DetailModel) renderHelp() string {
-	keys := []struct {
-		key  string
-		desc string
-	}{
-		{"↑/↓", "prev/next task"},
+	type helpKey struct {
+		key      string
+		desc     string
+		disabled bool // When disabled, always show grayed out
+	}
+
+	// Check if navigation is available (more than 1 task in column)
+	hasNavigation := m.totalInColumn > 1
+
+	keys := []helpKey{
+		{"↑/↓", "prev/next task", !hasNavigation},
 	}
 
 	// Show scroll hint when content is scrollable
 	if m.viewport.TotalLineCount() > m.viewport.VisibleLineCount() {
-		keys = append(keys, struct {
-			key  string
-			desc string
-		}{"PgUp/Dn", "scroll"})
+		keys = append(keys, helpKey{"PgUp/Dn", "scroll", false})
 	}
 
 	// Only show execute/retry when Claude is not running
 	claudeRunning := m.claudeMemoryMB > 0
 	if !claudeRunning {
-		keys = append(keys, struct {
-			key  string
-			desc string
-		}{"x", "execute"})
+		keys = append(keys, helpKey{"x", "execute", false})
 	}
 
 	hasPanes := m.claudePaneID != "" || m.workdirPaneID != ""
 
-	keys = append(keys, struct {
-		key  string
-		desc string
-	}{"e", "edit"})
+	keys = append(keys, helpKey{"e", "edit", false})
 
 	// Only show retry when Claude is not running
 	if !claudeRunning {
-		keys = append(keys, struct {
-			key  string
-			desc string
-		}{"r", "retry"})
+		keys = append(keys, helpKey{"r", "retry", false})
 	}
 
 	// Always show status change option
-	keys = append(keys, struct {
-		key  string
-		desc string
-	}{"S", "status"})
+	keys = append(keys, helpKey{"S", "status", false})
 
 	// Show dangerous mode toggle when task is processing or blocked
 	if m.task != nil && (m.task.Status == db.StatusProcessing || m.task.Status == db.StatusBlocked) {
@@ -2032,36 +2023,24 @@ func (m *DetailModel) renderHelp() string {
 		if m.task.DangerousMode {
 			toggleDesc = "safe mode"
 		}
-		keys = append(keys, struct {
-			key  string
-			desc string
-		}{"!", toggleDesc})
+		keys = append(keys, helpKey{"!", toggleDesc, false})
 	}
 
 	// Show executor resume shortcut only when the agent is not running but has a session
 	if m.task != nil && m.task.ClaudeSessionID != "" && m.claudeMemoryMB == 0 {
-		keys = append(keys, struct {
-			key  string
-			desc string
-		}{"R", fmt.Sprintf("resume %s", m.executorDisplayName())})
+		keys = append(keys, helpKey{"R", fmt.Sprintf("resume %s", m.executorDisplayName()), false})
 	}
 
 	// Show pane navigation shortcut when panes are visible
 	if hasPanes && os.Getenv("TMUX") != "" {
-		keys = append(keys, struct {
-			key  string
-			desc string
-		}{"shift+↑↓", "switch pane"})
+		keys = append(keys, helpKey{"shift+↑↓", "switch pane", false})
 	}
 
-	keys = append(keys, []struct {
-		key  string
-		desc string
-	}{
-		{"c", "close"},
-		{"a", "archive"},
-		{"d", "delete"},
-		{"esc", "back"},
+	keys = append(keys, []helpKey{
+		{"c", "close", false},
+		{"a", "archive", false},
+		{"d", "delete", false},
+		{"esc", "back", false},
 	}...)
 
 	var help string
@@ -2072,10 +2051,11 @@ func (m *DetailModel) renderHelp() string {
 		if i > 0 {
 			help += "  "
 		}
-		if m.focused {
-			help += HelpKey.Render(k.key) + " " + HelpDesc.Render(k.desc)
-		} else {
+		// Disabled keys are always dimmed, regardless of focus
+		if k.disabled || !m.focused {
 			help += dimmedKeyStyle.Render(k.key) + " " + dimmedDescStyle.Render(k.desc)
+		} else {
+			help += HelpKey.Render(k.key) + " " + HelpDesc.Render(k.desc)
 		}
 	}
 

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -829,6 +829,32 @@ func (k *KanbanBoard) GetTaskPosition() (int, int) {
 	return k.selectedRow + 1, len(col.Tasks) // 1-indexed position
 }
 
+// HasPrevTask returns true if there is a previous task in the current column.
+// Returns false if already at the first task or no tasks exist.
+func (k *KanbanBoard) HasPrevTask() bool {
+	if k.selectedCol < 0 || k.selectedCol >= len(k.columns) {
+		return false
+	}
+	col := k.columns[k.selectedCol]
+	if len(col.Tasks) <= 1 {
+		return false // Only one or no tasks, no prev
+	}
+	return k.selectedRow > 0
+}
+
+// HasNextTask returns true if there is a next task in the current column.
+// Returns false if already at the last task or no tasks exist.
+func (k *KanbanBoard) HasNextTask() bool {
+	if k.selectedCol < 0 || k.selectedCol >= len(k.columns) {
+		return false
+	}
+	col := k.columns[k.selectedCol]
+	if len(col.Tasks) <= 1 {
+		return false // Only one or no tasks, no next
+	}
+	return k.selectedRow < len(col.Tasks)-1
+}
+
 // HandleClick handles a mouse click at the given coordinates.
 // Returns the clicked task if a task card was clicked, nil otherwise.
 // Also updates the selection to the clicked task.

--- a/internal/ui/kanban_test.go
+++ b/internal/ui/kanban_test.go
@@ -244,6 +244,77 @@ func TestKanbanBoard_MoveUpDownSingleTask(t *testing.T) {
 	}
 }
 
+func TestKanbanBoard_HasPrevNextTask(t *testing.T) {
+	board := NewKanbanBoard(100, 50)
+
+	// Multiple tasks in column
+	tasks := []*db.Task{
+		{ID: 1, Title: "Task 1", Status: db.StatusBacklog},
+		{ID: 2, Title: "Task 2", Status: db.StatusBacklog},
+		{ID: 3, Title: "Task 3", Status: db.StatusBacklog},
+	}
+	board.SetTasks(tasks)
+
+	// At first position: no prev, has next
+	if board.HasPrevTask() {
+		t.Error("At first task: HasPrevTask() = true, want false")
+	}
+	if !board.HasNextTask() {
+		t.Error("At first task: HasNextTask() = false, want true")
+	}
+
+	// Move to middle: has both
+	board.MoveDown()
+	if !board.HasPrevTask() {
+		t.Error("At middle task: HasPrevTask() = false, want true")
+	}
+	if !board.HasNextTask() {
+		t.Error("At middle task: HasNextTask() = false, want true")
+	}
+
+	// Move to last: has prev, no next
+	board.MoveDown()
+	if !board.HasPrevTask() {
+		t.Error("At last task: HasPrevTask() = false, want true")
+	}
+	if board.HasNextTask() {
+		t.Error("At last task: HasNextTask() = true, want false")
+	}
+}
+
+func TestKanbanBoard_HasPrevNextTaskSingleTask(t *testing.T) {
+	board := NewKanbanBoard(100, 50)
+
+	// Single task in column
+	tasks := []*db.Task{
+		{ID: 1, Title: "Task 1", Status: db.StatusBacklog},
+	}
+	board.SetTasks(tasks)
+
+	// With only one task: no prev, no next
+	if board.HasPrevTask() {
+		t.Error("With single task: HasPrevTask() = true, want false")
+	}
+	if board.HasNextTask() {
+		t.Error("With single task: HasNextTask() = true, want false")
+	}
+}
+
+func TestKanbanBoard_HasPrevNextTaskEmptyColumn(t *testing.T) {
+	board := NewKanbanBoard(100, 50)
+
+	// No tasks
+	board.SetTasks([]*db.Task{})
+
+	// With empty column: no prev, no next
+	if board.HasPrevTask() {
+		t.Error("With empty column: HasPrevTask() = true, want false")
+	}
+	if board.HasNextTask() {
+		t.Error("With empty column: HasNextTask() = true, want false")
+	}
+}
+
 func TestKanbanBoard_HandleClickUpdatesSelection(t *testing.T) {
 	board := NewKanbanBoard(100, 50)
 


### PR DESCRIPTION
## Summary
- When viewing a task and there's only one task in the column, up/down arrows now do nothing instead of wrapping around
- The navigation hint "↑/↓ prev/next task" is grayed out when there are no other tasks to navigate to
- Added `HasPrevTask()` and `HasNextTask()` methods to KanbanBoard to check navigation availability

## Test plan
- [ ] Open a task that is the only task in its column - verify arrows are grayed out and pressing up/down does nothing
- [ ] Open a task with multiple tasks in the column - verify arrows work normally
- [ ] At the first task in a multi-task column - verify up arrow does nothing, down works
- [ ] At the last task in a multi-task column - verify down arrow does nothing, up works

🤖 Generated with [Claude Code](https://claude.com/claude-code)