### PR TITLE
fix: TUI resizes when window/display updates

### DIFF
--- a/internal/ui/attachments.go
+++ b/internal/ui/attachments.go
@@ -44,6 +44,12 @@ func (m *AttachmentsModel) loadAttachments() {
 	m.attachments = attachments
 }
 
+// SetSize updates the model dimensions for window resize handling.
+func (m *AttachmentsModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
 // Init initializes the model.
 func (m *AttachmentsModel) Init() tea.Cmd {
 	return nil


### PR DESCRIPTION
## Summary

- Adds periodic terminal size polling (every 1s tick) to detect and respond to display/window size changes
- The TUI now updates all components when a size change is detected, even if SIGWINCH signal is not sent
- This handles cases like moving the window between displays or display configuration changes
- Also adds missing `SetSize()` method to `AttachmentsModel` for complete resize handling

## Test plan

- [ ] Resize the terminal window - TUI should adapt to new size
- [ ] Move the terminal window to a different display with different resolution
- [ ] Change display configuration (e.g., disconnect/reconnect external monitor)
- [ ] Verify all views (kanban, detail, settings, forms) resize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)