### PR TITLE
fix: include attachments info when retrying tasks

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -911,8 +911,14 @@ func (e *Executor) executeTask(ctx context.Context, task *db.Task) {
 	// Run the executor
 	var result execResult
 	if isRetry {
+		// Include attachments info in retry feedback so Claude knows about them
+		// This is important when attachments are added after the initial run or when resuming
+		feedbackWithAttachments := retryFeedback
+		if len(attachmentPaths) > 0 {
+			feedbackWithAttachments = retryFeedback + "\n" + e.getAttachmentsSection(task.ID, attachmentPaths)
+		}
 		e.logLine(task.ID, "system", fmt.Sprintf("Resuming previous session with feedback (executor: %s)", executorName))
-		execResult := taskExecutor.Resume(taskCtx, task, workDir, prompt, retryFeedback)
+		execResult := taskExecutor.Resume(taskCtx, task, workDir, prompt, feedbackWithAttachments)
 		result = execResult.toInternal()
 	} else if isRecurringRun {
 		// Resume session with recurring message that includes full task details

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -297,6 +297,30 @@ func TestAttachmentsInPrompt(t *testing.T) {
 			t.Error("prompt should mention Read tool")
 		}
 	})
+
+	t.Run("retry feedback includes attachments when present", func(t *testing.T) {
+		worktreePath := t.TempDir()
+		paths, cleanup := exec.prepareAttachments(task.ID, worktreePath)
+		defer cleanup()
+
+		// Simulate what happens during retry: attachment section is appended to feedback
+		retryFeedback := "Please fix the bug"
+		feedbackWithAttachments := retryFeedback
+		if len(paths) > 0 {
+			feedbackWithAttachments = retryFeedback + "\n" + exec.getAttachmentsSection(task.ID, paths)
+		}
+
+		// Verify attachments are included in the retry feedback
+		if !strings.Contains(feedbackWithAttachments, "## Attachments") {
+			t.Error("retry feedback should include attachments section")
+		}
+		if !strings.Contains(feedbackWithAttachments, "Read tool") {
+			t.Error("retry feedback should mention Read tool")
+		}
+		if !strings.Contains(feedbackWithAttachments, "Please fix the bug") {
+			t.Error("retry feedback should still contain original feedback")
+		}
+	})
 }
 
 func TestFindClaudeSessionID(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixed bug where task attachments weren't available to Claude when retrying a task
- Attachments are now included in the retry feedback message

## Problem
When a task was retried with an existing Claude session, only the user's feedback was sent to Claude via `--resume`. The attachment information was not included, leaving Claude unaware of the attachment files even though they were properly prepared on disk at `.claude/attachments/task-{id}/`.

## Solution
Modified `executeTask()` to append the attachments section to the retry feedback when attachments are present. This ensures Claude knows about available attachments when resuming a session.

## Test plan
- [x] Added unit test verifying retry feedback includes attachments section
- [x] All existing tests pass
- [ ] Manual test: Create task with attachments, run it, retry it, verify Claude can access attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)