### PR TITLE
fix: let tmux handle pane title truncation for maximum visibility

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -670,7 +670,8 @@ func (m *DetailModel) ensureTmuxPanesJoined() {
 	}
 }
 
-// getPaneTitle returns the title for the detail pane (e.g., "Task 123: some task title... (2/5)").
+// getPaneTitle returns the title for the detail pane (e.g., "Task 123: some task title (2/5)").
+// We don't truncate the title - tmux will handle truncation based on pane width.
 func (m *DetailModel) getPaneTitle() string {
 	if m.task == nil {
 		return "Task"
@@ -682,29 +683,15 @@ func (m *DetailModel) getPaneTitle() string {
 		positionSuffix = fmt.Sprintf(" (%d/%d)", m.positionInColumn, m.totalInColumn)
 	}
 
-	// Calculate available space for title
-	// Format: "Task {id}: {title}{positionSuffix}"
 	prefix := fmt.Sprintf("Task %d", m.task.ID)
 	if m.task.Title == "" {
 		return prefix + positionSuffix
-	}
-
-	// Max pane title length (reasonable for most terminal widths)
-	const maxPaneTitle = 60
-	// Reserve space for prefix ": " and position suffix
-	availableForTitle := maxPaneTitle - len(prefix) - 2 - len(positionSuffix)
-	if availableForTitle < 10 {
-		availableForTitle = 10 // Minimum title length
 	}
 
 	taskTitle := m.task.Title
 	// Replace newlines with spaces for single-line display
 	taskTitle = strings.ReplaceAll(taskTitle, "\n", " ")
 	taskTitle = strings.ReplaceAll(taskTitle, "\r", "")
-
-	if len(taskTitle) > availableForTitle {
-		taskTitle = taskTitle[:availableForTitle-3] + "..."
-	}
 
 	return fmt.Sprintf("%s: %s%s", prefix, taskTitle, positionSuffix)
 }


### PR DESCRIPTION
## Summary
- Remove the artificial 60-character truncation limit on pane titles
- Let tmux naturally truncate titles based on actual pane width
- Users with wider terminals will now see more of the task title

## Test plan
- [ ] Open a task detail view with a long title
- [ ] Verify the title displays without artificial truncation
- [ ] Verify tmux properly truncates when the terminal is narrow


🤖 Generated with [Claude Code](https://claude.com/claude-code)