### PR TITLE
Document external orchestrator workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A personal task management system with a beautiful terminal UI, SQLite storage, 
 - **Real-time Updates** - Watch tasks execute live
 - **Running Process Indicator** - Green dot (`●`) shows which tasks have active shell processes (servers, watchers, etc.)
 - **Auto-cleanup** - Automatic cleanup of Claude processes and config entries for completed tasks
+- **Automation-Ready CLI** - Every Kanban action is also exposed via the `task` CLI, making it trivial to script or plug in your own orchestrator (see [external orchestration docs](docs/orchestrator.md))
 - **SSH Access** - Connect from anywhere via `ssh -p 2222 server`
 
 ## Prerequisites
@@ -94,6 +95,14 @@ ssh -p 2222 your-server
 ./bin/task purge-claude-config --dry-run  # Preview what would be removed
 ./bin/task claudes cleanup                # Kill orphaned Claude processes
 ```
+
+### External orchestration
+
+Need an always-on supervisor or LLM agent? Keep it outside Task You and use the CLI instead:
+
+- `task board --json` surfaces the full Kanban snapshot
+- `task pin`, `task status`, `task execute`, `task retry`, etc. mirror every interaction from the TUI
+- See [docs/orchestrator.md](docs/orchestrator.md) for a step-by-step Claude example
 
 **Auto-cleanup:** The daemon automatically cleans up Claude processes for tasks that have been done for more than 30 minutes, preventing memory bloat from orphaned processes.
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,0 +1,56 @@
+# External Orchestration with Task You
+
+Task You's Kanban UI is great for humans, but every action it performs is also available through the `task` CLI. That means you can run your own always-on supervisor (Claude, Codex, bash scripts, etc.) completely outside the app by shelling into these commands.
+
+## CLI Coverage for Automation
+
+| Need | Command(s) |
+|------|-----------|
+| Snapshot the entire board | `task board` or `task board --json` |
+| List/filter cards | `task list [--status <status>] [--json]` |
+| Inspect a task (project, logs, attachments) | `task show <id> --json --logs` |
+| Create or edit | `task create`, `task update` |
+| Queue/execute or retry | `task execute <id>`, `task retry <id>` |
+| Mark blocked/done/backlog/etc. | `task status <id> <status>` |
+| Pin/unpin priorities | `task pin <id> [--unpin|--toggle]` |
+| Close/delete | `task close <id>`, `task delete <id>` |
+| Tail executor output | `task logs` |
+
+Statuses accepted by `task status` are: `backlog`, `queued`, `processing`, `blocked`, `done`, `archived`.
+
+## Example: Running Claude as an Orchestrator
+
+1. **Start the daemon / UI** (locally or via SSH):
+   ```bash
+   task -l   # launches the TUI + daemon locally
+   ```
+2. **Open a second tmux pane/window** and launch Claude Code inside your project root:
+   ```bash
+   cd ~/Projects/workflow
+   claude code
+   ```
+3. **Prime Claude with the following system prompt** (paste at the top of the session):
+   ```text
+   You are an autonomous operator that controls Task You via its CLI.
+   Only interact with tasks by running shell commands that start with "task".
+   Available tools:
+     • task board --json            # get the full Kanban snapshot
+     • task list --json --status X  # list cards in a column
+     • task show --json --logs ID   # inspect a card deeply
+     • task execute|retry|close ID  # run or finish cards
+     • task status ID <status>      # move cards between columns
+     • task pin ID [--unpin]        # prioritize/deprioritize
+   Workflow:
+     1. Periodically run `task board --json` to understand the queue.
+     2. Decide what should happen next and run the appropriate CLI command.
+     3. After taking an action, summarize what you changed before continuing.
+     4. Ask the human for input when you cannot proceed.
+   ```
+4. **Let Claude drive**. It will now issue `task …` commands the same way the TUI would, so it can start/retry/close/pin tasks, inspect logs, or re-order the backlog – all while living completely outside Task You.
+
+### Tips
+- Use `task board --json | jq` to feed structured snapshots directly into an LLM or script.
+- Combine `task board` with `watch -n30` for a rolling dashboard.
+- When scripting, prefer JSON flags (`--json`, `--logs`) so the output is machine-readable.
+
+With these primitives, you can plug in any agent or automation stack you like—all without adding bespoke orchestrators inside Task You itself.


### PR DESCRIPTION
## Summary
- expose CLI commands to mirror Kanban actions (`task board`, `task status`, `task pin`) so automation can run entirely outside the TUI
- document how to use those commands + provide a Claude orchestration example

## Testing
- GOCACHE=$(pwd)/.gocache go test ./cmd/task ./internal/db
  - (Full go test ./... still can’t run here because executor integration tests need Claude Code; run locally with Claude installed.)