### PR TITLE
fix: blur filter input on navigation

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1240,15 +1240,23 @@ func (m *AppModel) updateFilterMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "up":
 			// Navigate while in filter mode (arrow keys only, not hjkl)
+			m.filterActive = false
+			m.filterInput.Blur()
 			m.kanban.MoveUp()
 			return m, nil
 		case "down":
+			m.filterActive = false
+			m.filterInput.Blur()
 			m.kanban.MoveDown()
 			return m, nil
 		case "left":
+			m.filterActive = false
+			m.filterInput.Blur()
 			m.kanban.MoveLeft()
 			return m, nil
 		case "right":
+			m.filterActive = false
+			m.filterInput.Blur()
 			m.kanban.MoveRight()
 			return m, nil
 		case "ctrl+c":


### PR DESCRIPTION
## Summary
- blur the filter input and exit filter mode when arrow navigation begins so focus transfers to the task list

## Testing
- go test ./internal/ui
