### PR TITLE
Add Gemini CLI executor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,6 +375,7 @@ wish.WithPublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
 | `WORKTREE_SESSION_ID` | tmux session ID | - |
 | `WORKTREE_DANGEROUS_MODE` | Skip Claude permissions | - |
 | `WORKTREE_CWD` | Working directory for project detection | - |
+| `GEMINI_DANGEROUS_ARGS` | Overrides the Gemini CLI flags used when dangerous mode is enabled | `--dangerously-allow-run` |
 
 Set `TASK_EXECUTOR` before launching `task -l`/`task daemon` to change the executor label shown in the UI (e.g., `TASK_EXECUTOR=codex`). For compatibility, `WORKFLOW_EXECUTOR`, `TASKYOU_EXECUTOR`, and `WORKTREE_EXECUTOR` are also recognized.
 

--- a/README.md
+++ b/README.md
@@ -167,10 +167,13 @@ backlog → queued → processing → done
 
 Task You supports multiple AI executors for processing tasks. You can choose the executor when creating or editing a task.
 
+> Developers who want to add another backend should read [`docs/executor_interface.md`](docs/executor_interface.md) for the full `TaskExecutor` contract.
+
 | Executor | CLI | Description |
 |----------|-----|-------------|
 | Claude (default) | `claude` | [Claude Code](https://claude.ai/claude-code) - Anthropic's coding agent with session resumption |
 | Codex | `codex` | [OpenAI Codex CLI](https://github.com/openai/codex) - OpenAI's coding assistant |
+| Gemini | `gemini` | [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli) - Google's Gemini-based coding assistant |
 
 Both executors run in tmux windows with the same worktree isolation and environment variables. The main differences:
 
@@ -187,6 +190,9 @@ At least one executor CLI must be installed for tasks to run:
 
 # OpenAI Codex CLI
 npm install -g @openai/codex
+
+# Google Gemini CLI
+# See https://ai.google.dev/gemini-api/docs/cli for installation instructions
 ```
 
 ### How Task Executors Work

--- a/docs/executor_interface.md
+++ b/docs/executor_interface.md
@@ -1,0 +1,31 @@
+# Task Executor Interface
+
+Task executors live in `internal/executor` and implement the `TaskExecutor` interface defined in `task_executor.go`. Every executor is responsible for running an AI CLI inside the Task You tmux daemon while reporting status back to the core `Executor`. This document captures the requirements for any new implementation.
+
+## Interface Summary
+
+| Method | Requirements |
+|--------|--------------|
+| `Name() string` | Return the identifier that will be stored on `db.Task.Executor` (e.g., `claude`, `codex`, `gemini`). |
+| `IsAvailable() bool` | Perform a fast check (typically `exec.LookPath`) to ensure the underlying CLI is installed. Returning `false` prevents the UI/daemon from offering the executor. |
+| `Execute(ctx, task, workDir, prompt)` | Start a brand-new session for the task. This must create/target the tmux daemon (`task-daemon-*`), spawn the CLI, attach the worktree environment variables (`WORKTREE_TASK_ID`, `WORKTREE_PORT`, `WORKTREE_PATH`, `WORKTREE_SESSION_ID`), ensure `ensureShellPane` and `configureTmuxWindow` are called, and then delegate polling to `Executor.pollTmuxSession`. All user-facing errors must be logged via `Executor.logLine`. |
+| `Resume(ctx, task, workDir, prompt, feedback)` | Resume a previous session if the CLI supports it, otherwise rerun using the full prompt + formatted feedback (Codex/Gemini do this). Should follow the same tmux setup as `Execute`. |
+| `BuildCommand(task, sessionID, prompt)` | Produce the exact shell command that the UI runs when a user manually opens the executor pane. This needs to mirror the environment + dangerous-mode behavior of `Execute` so the UI experience matches background execution. Remember to clean up temporary prompt files. |
+| `IsAvailable`/`GetProcessID`/`Kill` | `GetProcessID` must introspect tmux panes and operating-system processes to find the PID tied to the executor pane. `Kill` sends a SIGTERM (or CLI-specific shutdown) and clears any suspension bookkeeping so Task You can reclaim memory. |
+| `Suspend`/`IsSuspended`/`ResumeProcess` | Used by the idle-suspension logic. Implementations typically send SIGTSTP/SIGCONT and track timestamps in a `suspendedTasks` map so the executor knows whether it needs to resume. |
+
+## Common Expectations
+
+- **tmux integration** – Executors must create or reuse the daemon session via `ensureTmuxDaemon`, name windows with `TmuxWindowName(taskID)`, and call `killAllWindowsByNameAllSessions` before launching a new window to avoid duplicates.
+- **Environment variables** – Always export `WORKTREE_TASK_ID`, `WORKTREE_SESSION_ID`, `WORKTREE_PORT`, and `WORKTREE_PATH` when invoking the CLI. Pass along `CLAUDE_CONFIG_DIR` if you rely on shared `.claude` state (this keeps attachments + MCP permissions consistent across worktrees).
+- **Dangerous mode** – Honor both the persisted `task.DangerousMode` flag and the daemon-wide `WORKTREE_DANGEROUS_MODE=1`. If the CLI needs explicit flags, gate them behind helpers (see `buildGeminiDangerousFlag`) so the UI command builder and daemon execution stay in sync. Expose environment overrides (`GEMINI_DANGEROUS_ARGS` for the Gemini CLI) when the CLI uses different switches.
+- **Logging** – Always send user-facing errors to `Executor.logLine` with a helpful message plus remediation link when possible. Silent failures make it hard to debug executor issues.
+- **Shell pane** – Call `ensureShellPane` and `configureTmuxWindow` after launching a window so users always get the split view (executor + shell) with the correct env vars preloaded.
+- **Window tracking** – Save the daemon session and tmux window IDs via `UpdateTaskDaemonSession` and `UpdateTaskWindowID`. This allows later calls (kill, retry, resume) to target the correct panes.
+- **Prompt handling** – When passing prompts/feedback to CLIs, write them to temp files to avoid shell-quoting issues and remember to `defer os.Remove` once the command finishes.
+
+## Gemini CLI Notes
+
+The Gemini executor follows the same pattern as Codex: it starts a fresh CLI process for every run and replays the full prompt with appended feedback during retries. Gemini's dangerous-mode flag defaults to `--dangerously-allow-run` but can be overridden via the `GEMINI_DANGEROUS_ARGS` environment variable if Google updates the CLI syntax.
+
+Review `internal/executor/gemini_executor.go` for a reference implementation that satisfies all of the above requirements.

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -17,7 +17,7 @@ type Task struct {
 	Status          string
 	Type            string
 	Project         string
-	Executor        string // Task executor: "claude" (default), "codex"
+	Executor        string // Task executor: "claude" (default), "codex", "gemini"
 	WorktreePath    string
 	BranchName      string
 	Port            int    // Unique port for running the application in this task's worktree
@@ -67,6 +67,7 @@ const (
 const (
 	ExecutorClaude = "claude" // Claude Code CLI (default)
 	ExecutorCodex  = "codex"  // OpenAI Codex CLI
+	ExecutorGemini = "gemini" // Google Gemini CLI
 )
 
 // DefaultExecutor returns the default executor if none is specified.

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -952,6 +952,27 @@ func TestCreateTaskSavesLastExecutor(t *testing.T) {
 		t.Errorf("expected %q, got %q", ExecutorCodex, lastExecutor)
 	}
 
+	// Create task with gemini executor
+	taskGemini := &Task{
+		Title:    "Test Task Gemini",
+		Status:   StatusBacklog,
+		Type:     "code",
+		Project:  "personal",
+		Executor: ExecutorGemini,
+	}
+	if err := db.CreateTask(taskGemini); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	// Verify last executor was updated to gemini
+	lastExecutor, err = db.GetLastExecutorForProject("personal")
+	if err != nil {
+		t.Fatalf("failed to get last executor: %v", err)
+	}
+	if lastExecutor != ExecutorGemini {
+		t.Errorf("expected %q, got %q", ExecutorGemini, lastExecutor)
+	}
+
 	// Create task with empty executor - should still save the default executor
 	task3 := &Task{
 		Title:    "Test Task 3",

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -99,6 +99,8 @@ func formatExecutorDisplayName(slug, raw string) string {
 		return "Codex"
 	case "claude":
 		return defaultExecutorName
+	case "gemini":
+		return "Gemini"
 	}
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -145,6 +147,7 @@ func New(database *db.DB, cfg *config.Config) *Executor {
 	// Register available executors
 	e.executorFactory.Register(NewClaudeExecutor(e))
 	e.executorFactory.Register(NewCodexExecutor(e))
+	e.executorFactory.Register(NewGeminiExecutor(e))
 
 	return e
 }
@@ -173,6 +176,7 @@ func NewWithLogging(database *db.DB, cfg *config.Config, w io.Writer) *Executor 
 	// Register available executors
 	e.executorFactory.Register(NewClaudeExecutor(e))
 	e.executorFactory.Register(NewCodexExecutor(e))
+	e.executorFactory.Register(NewGeminiExecutor(e))
 
 	return e
 }

--- a/internal/executor/executor_identity_test.go
+++ b/internal/executor/executor_identity_test.go
@@ -28,6 +28,17 @@ func TestDetectExecutorIdentityCodex(t *testing.T) {
 	}
 }
 
+func TestDetectExecutorIdentityGemini(t *testing.T) {
+	t.Setenv("TASK_EXECUTOR", "gemini")
+	slug, display := detectExecutorIdentity()
+	if slug != "gemini" {
+		t.Fatalf("expected slug gemini, got %q", slug)
+	}
+	if display != "Gemini" {
+		t.Fatalf("expected display Gemini, got %q", display)
+	}
+}
+
 func TestDetectExecutorIdentityUnknown(t *testing.T) {
 	t.Setenv("TASK_EXECUTOR", "beta")
 	slug, display := detectExecutorIdentity()

--- a/internal/executor/gemini_executor.go
+++ b/internal/executor/gemini_executor.go
@@ -1,0 +1,290 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/charmbracelet/log"
+)
+
+// GeminiExecutor implements TaskExecutor for Google's Gemini CLI.
+type GeminiExecutor struct {
+	executor       *Executor
+	logger         *log.Logger
+	suspendedTasks map[int64]time.Time
+}
+
+// NewGeminiExecutor creates a new Gemini executor.
+func NewGeminiExecutor(e *Executor) *GeminiExecutor {
+	return &GeminiExecutor{
+		executor:       e,
+		logger:         e.logger,
+		suspendedTasks: make(map[int64]time.Time),
+	}
+}
+
+// Name returns the executor name.
+func (g *GeminiExecutor) Name() string {
+	return db.ExecutorGemini
+}
+
+// IsAvailable checks if the gemini CLI is installed.
+func (g *GeminiExecutor) IsAvailable() bool {
+	_, err := exec.LookPath("gemini")
+	return err == nil
+}
+
+// Execute runs a task using the Gemini CLI.
+func (g *GeminiExecutor) Execute(ctx context.Context, task *db.Task, workDir, prompt string) ExecResult {
+	return g.runGemini(ctx, task, workDir, prompt, "", false)
+}
+
+// Resume runs Gemini again with the full prompt plus feedback since sessions are stateless.
+func (g *GeminiExecutor) Resume(ctx context.Context, task *db.Task, workDir, prompt, feedback string) ExecResult {
+	return g.runGemini(ctx, task, workDir, prompt, feedback, true)
+}
+
+func (g *GeminiExecutor) runGemini(ctx context.Context, task *db.Task, workDir, prompt, feedback string, isResume bool) ExecResult {
+	paths := g.executor.claudePathsForProject(task.Project)
+
+	if !g.IsAvailable() {
+		g.executor.logLine(task.ID, "error", "gemini CLI is not installed - see https://ai.google.dev/gemini-api/docs/cli")
+		return ExecResult{Message: "gemini CLI is not installed"}
+	}
+
+	if _, err := exec.LookPath("tmux"); err != nil {
+		g.executor.logLine(task.ID, "error", "tmux is not installed - required for task execution")
+		return ExecResult{Message: "tmux is not installed"}
+	}
+
+	daemonSession, err := ensureTmuxDaemon()
+	if err != nil {
+		g.logger.Error("could not create task-daemon session", "error", err)
+		g.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux daemon: %s", err.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create tmux daemon: %s", err.Error())}
+	}
+
+	windowName := TmuxWindowName(task.ID)
+	windowTarget := fmt.Sprintf("%s:%s", daemonSession, windowName)
+
+	killAllWindowsByNameAllSessions(windowName)
+
+	promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
+	if err != nil {
+		g.logger.Error("could not create temp file", "error", err)
+		g.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create temp file: %s", err.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create temp file: %s", err.Error())}
+	}
+	fullPrompt := prompt
+	if isResume && feedback != "" {
+		fullPrompt = prompt + "\n\n## User Feedback\n\n" + feedback
+	}
+	promptFile.WriteString(fullPrompt)
+	promptFile.Close()
+	defer os.Remove(promptFile.Name())
+
+	sessionID := os.Getenv("WORKTREE_SESSION_ID")
+	if sessionID == "" {
+		sessionID = fmt.Sprintf("%d", os.Getpid())
+	}
+
+	envPrefix := claudeEnvPrefix(paths.configDir)
+	dangerousFlag := buildGeminiDangerousFlag(task.DangerousMode)
+	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sgemini %s"$(cat %q)"`,
+		task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, promptFile.Name())
+
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script)
+	if tmuxErr != nil {
+		g.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
+		g.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create tmux window: %s", tmuxErr.Error())}
+	}
+
+	if actualSession != daemonSession {
+		windowTarget = fmt.Sprintf("%s:%s", actualSession, windowName)
+		daemonSession = actualSession
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := g.executor.db.UpdateTaskDaemonSession(task.ID, daemonSession); err != nil {
+		g.logger.Warn("failed to save daemon session", "task", task.ID, "error", err)
+	}
+	if windowID := getWindowID(daemonSession, windowName); windowID != "" {
+		if err := g.executor.db.UpdateTaskWindowID(task.ID, windowID); err != nil {
+			g.logger.Warn("failed to save window ID", "task", task.ID, "error", err)
+		}
+	}
+
+	g.executor.ensureShellPane(windowTarget, workDir, task.ID, task.Port, task.WorktreePath, paths.configDir)
+	g.executor.configureTmuxWindow(windowTarget)
+
+	result := g.executor.pollTmuxSession(ctx, task.ID, windowTarget)
+
+	return ExecResult(result)
+}
+
+// GetProcessID returns the PID of the Gemini process for a task.
+func (g *GeminiExecutor) GetProcessID(taskID int64) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	windowName := TmuxWindowName(taskID)
+
+	out, err := exec.CommandContext(ctx, "tmux", "list-panes", "-a", "-F", "#{session_name}:#{window_name}:#{pane_index} #{pane_pid}").Output()
+	if err != nil {
+		return 0
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		target := parts[0]
+		pidStr := parts[1]
+		if !strings.Contains(target, windowName) {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		cmdOut, _ := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+		if strings.Contains(string(cmdOut), "gemini") {
+			return pid
+		}
+		childOut, err := exec.CommandContext(ctx, "pgrep", "-P", strconv.Itoa(pid), "gemini").Output()
+		if err == nil && len(childOut) > 0 {
+			childPid, err := strconv.Atoi(strings.TrimSpace(string(childOut)))
+			if err == nil {
+				return childPid
+			}
+		}
+	}
+	return 0
+}
+
+// Kill terminates the Gemini process for a task.
+func (g *GeminiExecutor) Kill(taskID int64) bool {
+	pid := g.GetProcessID(taskID)
+	if pid == 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		g.logger.Debug("Failed to find Gemini process", "pid", pid, "error", err)
+		return false
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		g.logger.Debug("Failed to terminate Gemini process", "pid", pid, "error", err)
+		return false
+	}
+	g.logger.Info("Terminated Gemini process", "task", taskID, "pid", pid)
+	delete(g.suspendedTasks, taskID)
+	return true
+}
+
+// Suspend pauses the Gemini process for a task.
+func (g *GeminiExecutor) Suspend(taskID int64) bool {
+	pid := g.GetProcessID(taskID)
+	if pid == 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		g.logger.Debug("Failed to find process", "pid", pid, "error", err)
+		return false
+	}
+	if err := proc.Signal(syscall.SIGTSTP); err != nil {
+		g.logger.Debug("Failed to suspend process", "pid", pid, "error", err)
+		return false
+	}
+	g.suspendedTasks[taskID] = time.Now()
+	g.logger.Info("Suspended Gemini process", "task", taskID, "pid", pid)
+	g.executor.logLine(taskID, "system", "Gemini suspended (idle timeout)")
+	return true
+}
+
+// IsSuspended reports whether the Gemini process is suspended for a task.
+func (g *GeminiExecutor) IsSuspended(taskID int64) bool {
+	_, suspended := g.suspendedTasks[taskID]
+	return suspended
+}
+
+// ResumeProcess resumes a previously suspended Gemini process.
+func (g *GeminiExecutor) ResumeProcess(taskID int64) bool {
+	if !g.IsSuspended(taskID) {
+		return false
+	}
+	pid := g.GetProcessID(taskID)
+	if pid == 0 {
+		delete(g.suspendedTasks, taskID)
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		delete(g.suspendedTasks, taskID)
+		return false
+	}
+	if err := proc.Signal(syscall.SIGCONT); err != nil {
+		g.logger.Debug("Failed to resume process", "pid", pid, "error", err)
+		return false
+	}
+	delete(g.suspendedTasks, taskID)
+	g.logger.Info("Resumed Gemini process", "task", taskID, "pid", pid)
+	g.executor.logLine(taskID, "system", "Gemini resumed")
+	return true
+}
+
+// BuildCommand returns the shell command to start an interactive Gemini session.
+func (g *GeminiExecutor) BuildCommand(task *db.Task, sessionID, prompt string) string {
+	dangerousFlag := buildGeminiDangerousFlag(task.DangerousMode)
+
+	worktreeSessionID := os.Getenv("WORKTREE_SESSION_ID")
+	if worktreeSessionID == "" {
+		worktreeSessionID = fmt.Sprintf("%d", os.Getpid())
+	}
+
+	if prompt != "" {
+		promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
+		if err != nil {
+			g.logger.Error("BuildCommand: failed to create temp file", "error", err)
+			return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q gemini %s`,
+				task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag)
+		}
+		promptFile.WriteString(prompt)
+		promptFile.Close()
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q gemini %s"$(cat %q)"; rm -f %q`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, promptFile.Name(), promptFile.Name())
+	}
+
+	return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q gemini %s`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag)
+}
+
+func buildGeminiDangerousFlag(enabled bool) string {
+	useDanger := enabled || os.Getenv("WORKTREE_DANGEROUS_MODE") == "1"
+	if !useDanger {
+		return ""
+	}
+	flag := strings.TrimSpace(os.Getenv("GEMINI_DANGEROUS_ARGS"))
+	if flag == "" {
+		flag = "--dangerously-allow-run"
+	}
+	if !strings.HasSuffix(flag, " ") {
+		flag += " "
+	}
+	return flag
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -345,6 +345,8 @@ func taskExecutorDisplayName(task *db.Task) string {
 		return "Codex"
 	case db.ExecutorClaude:
 		return "Claude"
+	case db.ExecutorGemini:
+		return "Gemini"
 	default:
 		// Unknown executor, capitalize first letter
 		if len(task.Executor) > 0 {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -118,6 +118,8 @@ func (m *DetailModel) executorDisplayName() string {
 			return "Codex"
 		case db.ExecutorClaude:
 			return "Claude"
+		case db.ExecutorGemini:
+			return "Gemini"
 		default:
 			// Unknown executor, capitalize first letter
 			if len(m.task.Executor) > 0 {

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -59,7 +59,7 @@ type FormModel struct {
 	taskType      string
 	typeIdx       int
 	types         []string
-	executor      string // "claude", "codex"
+	executor      string // "claude", "codex", "gemini"
 	executorIdx   int
 	executors     []string
 	queue         bool
@@ -140,7 +140,7 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int) *FormMo
 		project:             task.Project,
 		originalProject:     task.Project, // Track original project for detecting changes
 		executor:            executor,
-		executors:           []string{db.ExecutorClaude, db.ExecutorCodex},
+		executors:           []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini},
 		isEdit:              true,
 		recurrence:          task.Recurrence,
 		recurrences:         []string{"", db.RecurrenceHourly, db.RecurrenceDaily, db.RecurrenceWeekly, db.RecurrenceMonthly},
@@ -272,7 +272,7 @@ func NewFormModel(database *db.DB, width, height int, workingDir string) *FormMo
 		height:              height,
 		focused:             FieldProject,
 		executor:            db.DefaultExecutor(),
-		executors:           []string{db.ExecutorClaude, db.ExecutorCodex},
+		executors:           []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini},
 		recurrences:         []string{"", db.RecurrenceHourly, db.RecurrenceDaily, db.RecurrenceWeekly, db.RecurrenceMonthly},
 		autocompleteSvc:     autocompleteSvc,
 		autocompleteEnabled: autocompleteEnabled,


### PR DESCRIPTION
## Summary
- add a Gemini CLI backend that mirrors the tmux + logging behavior from other executors
- surface the executor interface requirements in docs and update the UI/database to list the new option
- document Gemini setup, configuration, and dangerous-mode flags

## Testing
- go test ./...
