### PR TITLE
feat: add keyboard shortcuts for jump to top/bottom of kanban column

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -77,6 +77,9 @@ type KeyMap struct {
 	FocusInProgress key.Binding
 	FocusBlocked    key.Binding
 	FocusDone       key.Binding
+	// Jump to top/bottom of column
+	JumpTop    key.Binding
+	JumpBottom key.Binding
 }
 
 // ShortHelp returns key bindings to show in the mini help.
@@ -87,7 +90,7 @@ func (k KeyMap) ShortHelp() []key.Binding {
 // FullHelp returns keybindings for the expanded help view.
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Left, k.Right, k.Up, k.Down},
+		{k.Left, k.Right, k.Up, k.Down, k.JumpTop, k.JumpBottom},
 		{k.FocusBacklog, k.FocusInProgress, k.FocusBlocked, k.FocusDone},
 		{k.Enter, k.New, k.Queue, k.Close},
 		{k.Retry, k.Archive, k.Delete, k.OpenWorktree},
@@ -219,6 +222,14 @@ func DefaultKeyMap() KeyMap {
 		FocusDone: key.NewBinding(
 			key.WithKeys("D"),
 			key.WithHelp("D", "done"),
+		),
+		JumpTop: key.NewBinding(
+			key.WithKeys("home"),
+			key.WithHelp("home", "top"),
+		),
+		JumpBottom: key.NewBinding(
+			key.WithKeys("end"),
+			key.WithHelp("end", "bottom"),
 		),
 	}
 }
@@ -1115,6 +1126,14 @@ func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.notifyTaskID = 0
 			return m, m.loadTask(taskID)
 		}
+
+	// Jump to top/bottom of column
+	case key.Matches(msg, m.keys.JumpTop):
+		m.kanban.MoveToTop()
+		return m, nil
+
+	case key.Matches(msg, m.keys.JumpBottom):
+		m.kanban.MoveToBottom()
 		return m, nil
 
 	case key.Matches(msg, m.keys.Enter):

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -274,6 +274,26 @@ func (k *KanbanBoard) MoveDown() {
 	k.ensureSelectedVisible()
 }
 
+// MoveToTop jumps to the first task in the current column.
+func (k *KanbanBoard) MoveToTop() {
+	col := k.columns[k.selectedCol]
+	if len(col.Tasks) == 0 {
+		return
+	}
+	k.selectedRow = 0
+	k.ensureSelectedVisible()
+}
+
+// MoveToBottom jumps to the last task in the current column.
+func (k *KanbanBoard) MoveToBottom() {
+	col := k.columns[k.selectedCol]
+	if len(col.Tasks) == 0 {
+		return
+	}
+	k.selectedRow = len(col.Tasks) - 1
+	k.ensureSelectedVisible()
+}
+
 // ensureSelectedVisible adjusts scroll offset so the selected task is visible.
 func (k *KanbanBoard) ensureSelectedVisible() {
 	if k.selectedCol < 0 || k.selectedCol >= len(k.columns) {

--- a/internal/ui/kanban_test.go
+++ b/internal/ui/kanban_test.go
@@ -207,6 +207,83 @@ func TestKanbanBoard_MoveDownWrapsAround(t *testing.T) {
 	}
 }
 
+func TestKanbanBoard_MoveToTop(t *testing.T) {
+	board := NewKanbanBoard(100, 50)
+
+	// Set up tasks in the first column
+	tasks := []*db.Task{
+		{ID: 1, Title: "Task 1", Status: db.StatusBacklog},
+		{ID: 2, Title: "Task 2", Status: db.StatusBacklog},
+		{ID: 3, Title: "Task 3", Status: db.StatusBacklog},
+	}
+	board.SetTasks(tasks)
+
+	// Move to the last task
+	board.MoveDown() // row 1
+	board.MoveDown() // row 2
+
+	if board.selectedRow != 2 {
+		t.Fatalf("Expected to be at row 2, got %d", board.selectedRow)
+	}
+
+	// MoveToTop should jump to first task
+	board.MoveToTop()
+	if board.selectedRow != 0 {
+		t.Errorf("MoveToTop: selectedRow = %d, want 0", board.selectedRow)
+	}
+
+	// MoveToTop at top should stay at top
+	board.MoveToTop()
+	if board.selectedRow != 0 {
+		t.Errorf("MoveToTop at top: selectedRow = %d, want 0", board.selectedRow)
+	}
+}
+
+func TestKanbanBoard_MoveToBottom(t *testing.T) {
+	board := NewKanbanBoard(100, 50)
+
+	// Set up tasks in the first column
+	tasks := []*db.Task{
+		{ID: 1, Title: "Task 1", Status: db.StatusBacklog},
+		{ID: 2, Title: "Task 2", Status: db.StatusBacklog},
+		{ID: 3, Title: "Task 3", Status: db.StatusBacklog},
+	}
+	board.SetTasks(tasks)
+
+	// Verify we start at row 0
+	if board.selectedRow != 0 {
+		t.Fatalf("Expected to start at row 0, got %d", board.selectedRow)
+	}
+
+	// MoveToBottom should jump to last task
+	board.MoveToBottom()
+	if board.selectedRow != 2 {
+		t.Errorf("MoveToBottom: selectedRow = %d, want 2", board.selectedRow)
+	}
+
+	// MoveToBottom at bottom should stay at bottom
+	board.MoveToBottom()
+	if board.selectedRow != 2 {
+		t.Errorf("MoveToBottom at bottom: selectedRow = %d, want 2", board.selectedRow)
+	}
+}
+
+func TestKanbanBoard_MoveToTopBottomEmptyColumn(t *testing.T) {
+	board := NewKanbanBoard(100, 50)
+
+	// No tasks - all columns empty
+	board.SetTasks([]*db.Task{})
+
+	// These should not panic
+	board.MoveToTop()
+	board.MoveToBottom()
+
+	// Selection should stay at 0
+	if board.selectedRow != 0 {
+		t.Errorf("selectedRow = %d, want 0", board.selectedRow)
+	}
+}
+
 func TestKanbanBoard_MoveUpDownEmptyColumn(t *testing.T) {
 	board := NewKanbanBoard(100, 50)
 


### PR DESCRIPTION
## Summary
- Add `Home` key shortcut to jump to the first task in the current kanban column
- Add `End` key shortcut to jump to the last task in the current kanban column
- Standard keyboard navigation that complements existing `j`/`k` movement

## Test plan
- [x] Build compiles successfully
- [x] All UI tests pass
- [x] Added unit tests for `MoveToTop` and `MoveToBottom` methods
- [x] Added test for empty column edge case
- [ ] Manual testing: Press `End` to jump to bottom, `Home` to jump to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)