### PR TITLE
fix: use proper rounding for pane height percentage calculations

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -803,8 +803,9 @@ func (m *DetailModel) getCurrentDetailPaneHeight(tuiPaneID string) int {
 		return 0
 	}
 
-	// Calculate the percentage
-	return (paneHeight * 100) / totalHeight
+	// Calculate the percentage with proper rounding to avoid truncation errors
+	// that cause the pane to progressively shrink over time
+	return (paneHeight*100 + totalHeight/2) / totalHeight
 }
 
 // getActualPaneHeight returns the actual pane height in lines.
@@ -868,7 +869,8 @@ func (m *DetailModel) getCurrentShellPaneWidth() int {
 
 	// Calculate total width and shell percentage
 	totalWidth := shellWidth + claudeWidth
-	return (shellWidth * 100) / totalWidth
+	// Use proper rounding to avoid truncation errors
+	return (shellWidth*100 + totalWidth/2) / totalWidth
 }
 
 // saveDetailPaneHeight saves the current detail pane height to settings.
@@ -900,8 +902,9 @@ func (m *DetailModel) saveDetailPaneHeight(tuiPaneID string) {
 		return
 	}
 
-	// Calculate the percentage
-	percentage := (paneHeight * 100) / totalHeight
+	// Calculate the percentage with proper rounding to avoid truncation errors
+	// that cause the pane to progressively shrink over time
+	percentage := (paneHeight*100 + totalHeight/2) / totalHeight
 	if percentage >= 1 && percentage <= 50 {
 		heightStr := fmt.Sprintf("%d%%", percentage)
 		m.database.SetSetting(config.SettingDetailPaneHeight, heightStr)
@@ -941,9 +944,9 @@ func (m *DetailModel) saveShellPaneWidth() {
 		return
 	}
 
-	// Calculate total width and shell percentage
+	// Calculate total width and shell percentage with proper rounding
 	totalWidth := shellWidth + claudeWidth
-	percentage := (shellWidth * 100) / totalWidth
+	percentage := (shellWidth*100 + totalWidth/2) / totalWidth
 	if percentage >= 10 && percentage <= 90 {
 		widthStr := fmt.Sprintf("%d%%", percentage)
 		m.database.SetSetting(config.SettingShellPaneWidth, widthStr)

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -100,6 +100,44 @@ func TestNewDetailModel_ArchivedTaskSkipsAutoExecutor(t *testing.T) {
 	}
 }
 
+// TestPercentageCalculationRounding verifies that percentage calculations
+// use proper rounding to avoid the progressive shrinking bug.
+// Without rounding, integer division truncates: (16 * 100) / 81 = 19 instead of 20
+// With rounding: (16*100 + 81/2) / 81 = (1600 + 40) / 81 = 20
+func TestPercentageCalculationRounding(t *testing.T) {
+	tests := []struct {
+		paneSize    int
+		totalSize   int
+		wantRounded int
+	}{
+		// Case where truncation would cause shrinking
+		{paneSize: 16, totalSize: 81, wantRounded: 20}, // Without rounding: 19
+		{paneSize: 15, totalSize: 80, wantRounded: 19}, // Without rounding: 18
+		{paneSize: 20, totalSize: 100, wantRounded: 20},
+		{paneSize: 16, totalSize: 80, wantRounded: 20},
+		// Edge cases
+		{paneSize: 1, totalSize: 100, wantRounded: 1},
+		{paneSize: 50, totalSize: 100, wantRounded: 50},
+		// Cases where rounding changes outcome
+		{paneSize: 7, totalSize: 40, wantRounded: 18}, // 17.5 rounds to 18
+		{paneSize: 9, totalSize: 50, wantRounded: 18}, // 18.0 stays 18
+	}
+
+	for _, tt := range tests {
+		// This is the rounding formula used in the actual code
+		got := (tt.paneSize*100 + tt.totalSize/2) / tt.totalSize
+		if got != tt.wantRounded {
+			t.Errorf("percentage(%d, %d) = %d, want %d", tt.paneSize, tt.totalSize, got, tt.wantRounded)
+		}
+
+		// Verify the old truncation formula would have been different for problematic cases
+		truncated := (tt.paneSize * 100) / tt.totalSize
+		if tt.paneSize == 16 && tt.totalSize == 81 && truncated >= tt.wantRounded {
+			t.Errorf("truncation case should differ: truncated=%d, rounded=%d", truncated, tt.wantRounded)
+		}
+	}
+}
+
 func TestExecutorFailureMessage(t *testing.T) {
 	m := &DetailModel{task: &db.Task{Executor: db.ExecutorCodex}}
 	msgWithDetail := m.executorFailureMessage("tmux new-window failed")


### PR DESCRIPTION
## Summary

- Fixes the task detail pane progressively shrinking over time
- The root cause was integer division truncation when converting between pane heights (lines) and percentages
- Applied proper rounding formula `(paneHeight*100 + totalHeight/2) / totalHeight` to all four percentage calculation locations
- Added unit test to verify the rounding formula

## Problem

When converting pane heights from lines to percentages, the formula `(paneHeight * 100) / totalHeight` truncates the result. For example:
- 16-line pane in 81-line window: `(16 * 100) / 81 = 19%` (truncated from 19.75%)
- Each time the user navigated between tasks, this could lose 1-2% of height

## Solution

Use proper rounding by adding half the divisor before dividing:
- `(paneHeight*100 + totalHeight/2) / totalHeight`
- 16-line pane in 81-line window: `(1600 + 40) / 81 = 20%` (properly rounded)

## Test plan

- [x] Unit test added for rounding formula
- [x] All existing tests pass
- [ ] Manual testing: Navigate between tasks repeatedly and verify pane height stays consistent

Fixes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)