### PR TITLE
fix: ensure Claude MCP settings are shared with worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 # Claude Code
 .claude/
 .crush/
-.mcp.json
 
 # Archives
 *.tar.gz


### PR DESCRIPTION
## Summary
- Add `symlinkMCPConfig` function to symlink project-level `.mcp.json` files to worktrees, ensuring Claude Code has access to the same MCP servers
- Add `symlinkMCPConfig` calls to all worktree setup code paths
- Fix missing `symlinkClaudeConfig` call in "already checked out" code path that was preventing `.claude` directory from being symlinked in certain worktree reuse scenarios
- Add comprehensive tests for `symlinkMCPConfig` function

## Problem
There were two issues with how worktree Claude configuration was handled:

1. **Missing `.mcp.json` support**: Claude Code supports project-level `.mcp.json` files for MCP server configuration, but these weren't being symlinked to worktrees. This meant Claude running in a worktree wouldn't have access to project-level MCP servers.

2. **Missing `symlinkClaudeConfig` in one code path**: When a worktree was reused after an "already checked out" error, the `.claude` directory symlink wasn't being created, potentially causing permission/settings inconsistencies.

## Changes
- Added new `symlinkMCPConfig` function that symlinks `.mcp.json` from project root to worktree (only if it exists)
- Added `symlinkMCPConfig` calls to all 4 worktree setup code paths
- Added missing `symlinkClaudeConfig` call in the "already checked out" code path
- Added comprehensive unit tests for `symlinkMCPConfig`

## Test plan
- [x] All existing tests pass
- [x] New `TestSymlinkMCPConfig` tests pass (5 test cases covering various scenarios)
- [x] Build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)