### PR TITLE
fix: exclude .claude symlink from git to prevent accidental commits

### DIFF
--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1096,3 +1096,108 @@ func TestSymlinkMCPConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestEnsureGitExclude(t *testing.T) {
+	t.Run("creates exclude file and adds entry", func(t *testing.T) {
+		projectDir := t.TempDir()
+		gitDir := filepath.Join(projectDir, ".git")
+		if err := os.MkdirAll(gitDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		ensureGitExclude(projectDir, ".claude")
+
+		excludePath := filepath.Join(gitDir, "info", "exclude")
+		content, err := os.ReadFile(excludePath)
+		if err != nil {
+			t.Fatalf("expected exclude file to exist: %v", err)
+		}
+		if !strings.Contains(string(content), ".claude") {
+			t.Error("expected .claude entry in exclude file")
+		}
+	})
+
+	t.Run("does not duplicate existing entry", func(t *testing.T) {
+		projectDir := t.TempDir()
+		infoDir := filepath.Join(projectDir, ".git", "info")
+		if err := os.MkdirAll(infoDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		excludePath := filepath.Join(infoDir, "exclude")
+		if err := os.WriteFile(excludePath, []byte(".claude\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ensureGitExclude(projectDir, ".claude")
+
+		content, err := os.ReadFile(excludePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Count(string(content), ".claude") != 1 {
+			t.Errorf("expected exactly one .claude entry, got content: %q", string(content))
+		}
+	})
+
+	t.Run("adds multiple different entries", func(t *testing.T) {
+		projectDir := t.TempDir()
+		gitDir := filepath.Join(projectDir, ".git")
+		if err := os.MkdirAll(gitDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		ensureGitExclude(projectDir, ".claude")
+		ensureGitExclude(projectDir, ".envrc")
+		ensureGitExclude(projectDir, ".mcp.json")
+
+		excludePath := filepath.Join(gitDir, "info", "exclude")
+		content, err := os.ReadFile(excludePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, entry := range []string{".claude", ".envrc", ".mcp.json"} {
+			if !strings.Contains(string(content), entry) {
+				t.Errorf("expected %s entry in exclude file", entry)
+			}
+		}
+	})
+}
+
+func TestSymlinkClaudeConfigExcludesFromGit(t *testing.T) {
+	// symlinkClaudeConfig uses projectDir for git exclude because
+	// worktree .git is a file, not a directory
+	projectDir := t.TempDir()
+	worktreePath := t.TempDir()
+
+	// Create .git dir in projectDir (the main repo has the actual .git directory)
+	gitDir := filepath.Join(projectDir, ".git")
+	if err := os.MkdirAll(gitDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := symlinkClaudeConfig(projectDir, worktreePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify symlink was created
+	worktreeClaudeDir := filepath.Join(worktreePath, ".claude")
+	target, err := os.Readlink(worktreeClaudeDir)
+	if err != nil {
+		t.Fatalf("expected symlink: %v", err)
+	}
+	mainClaudeDir := filepath.Join(projectDir, ".claude")
+	if target != mainClaudeDir {
+		t.Errorf("symlink target = %s, want %s", target, mainClaudeDir)
+	}
+
+	// Verify .claude is in the project's git exclude (not the worktree's)
+	excludePath := filepath.Join(gitDir, "info", "exclude")
+	content, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("expected exclude file to exist: %v", err)
+	}
+	if !strings.Contains(string(content), ".claude") {
+		t.Error("expected .claude entry in git exclude file to prevent symlink from being committed")
+	}
+}


### PR DESCRIPTION
## Summary
- When creating worktrees, taskyou symlinks `.claude` → `project/.claude` to share Claude config. The `.gitignore` entry `.claude/` (with trailing slash) only matches directories, not symlinks — so the symlink showed as untracked and could be accidentally committed.
- Extracted `ensureGitExclude()` from the inline `.envrc` exclude logic in `writeWorktreeEnvFile` and reused it to also exclude `.claude` and `.mcp.json` symlinks via `.git/info/exclude`.
- Uses `projectDir` (not `worktreePath`) for the exclude path since worktree `.git` is a file pointing to the main repo's git dir.

## Test plan
- [x] New `TestEnsureGitExclude` tests (creates file, deduplication, multiple entries)
- [x] New `TestSymlinkClaudeConfigExcludesFromGit` test verifying `.claude` is added to git exclude
- [x] Existing `TestSymlinkMCPConfig` tests still pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)