### PR TITLE
docs: add exe.dev cloud option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ cd taskyou
 make build
 ```
 
+### Run on exe.dev (cloud)
+
+Spin up TaskYou instantly on [exe.dev](https://exe.dev):
+
+```bash
+ssh exe.dev 'new --name=tasks --prompt="Run: curl -fsSL taskyou.dev/install.sh | bash"'
+ssh tasks.exe.xyz
+~/.local/bin/task
+```
+
 ## Usage
 
 ### Run locally (default)

--- a/docs/index.html
+++ b/docs/index.html
@@ -126,8 +126,15 @@
 
         <div class="install-box">
             <div class="install-label">Install with one command</div>
-            <div class="install-cmd" onclick="copyInstall(this)">
+            <div class="install-cmd" onclick="copyInstall(this, 'curl -fsSL taskyou.dev/install.sh | bash')">
                 curl -fsSL taskyou.dev/install.sh | bash
+            </div>
+        </div>
+
+        <div class="install-box">
+            <div class="install-label">Or run instantly on <a href="https://exe.dev" style="color: var(--cyan-glow); text-decoration: none;">exe.dev</a></div>
+            <div class="install-cmd" onclick="copyInstall(this, 'ssh exe.dev \'new --name=tasks --prompt=\"Run: curl -fsSL taskyou.dev/install.sh | bash\"\'')">
+                ssh exe.dev 'new --name=tasks --prompt="Run: curl -fsSL taskyou.dev/install.sh | bash"'
             </div>
         </div>
 
@@ -149,13 +156,14 @@
                 video.pause();
             }
         }
-        function copyInstall(el) {
-            navigator.clipboard.writeText(el.textContent.trim());
+        function copyInstall(el, cmd) {
+            navigator.clipboard.writeText(cmd);
             el.classList.add('copied');
+            const original = el.textContent;
             el.textContent = 'Copied!';
             setTimeout(() => {
                 el.classList.remove('copied');
-                el.textContent = 'curl -fsSL taskyou.dev/install.sh | bash';
+                el.textContent = original;
             }, 2000);
         }
     </script>


### PR DESCRIPTION
## Summary

- Adds exe.dev as a cloud deployment option for TaskYou
- Updates README with installation instructions
- Adds exe.dev command to taskyou.dev website

## One-liner

```bash
ssh exe.dev 'new --name=tasks --prompt="Run: curl -fsSL taskyou.dev/install.sh | bash"'
```

## Test plan

- [ ] Verify README renders correctly
- [ ] Verify taskyou.dev shows both install options
- [ ] Test the exe.dev command creates a working VM

🤖 Generated with [Claude Code](https://claude.ai/claude-code)