### PR TITLE
feat(skill): add Claude Code skill for AI-driven task orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,26 @@ Need an always-on supervisor or LLM agent? Keep it outside Task You and use the 
 
 **Auto-cleanup:** The daemon automatically cleans up Claude processes for tasks that have been done for more than 30 minutes, preventing memory bloat from orphaned processes.
 
+### AI Agent Skill
+
+Task You includes a `/taskyou` skill that teaches any AI agent how to orchestrate your task queue via CLI.
+
+**Automatic availability:** The skill is automatically available when working inside the Task You project directory (via `skills/taskyou/`).
+
+**Global installation:** To use the skill from any project:
+
+```bash
+./scripts/install-skill.sh
+```
+
+Once available, you can ask Claude things like:
+- "Show me my task board"
+- "Execute the top priority task"
+- "What's blocked right now?"
+- "Create a task to fix the login bug"
+
+The skill works with Claude Code, Codex, Gemini, or any agent that can execute shell commands. It provides structured guidance for common orchestration patterns without needing to memorize CLI flags.
+
 ## Keyboard Shortcuts
 
 ### Kanban Board

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Install the Task You skill for Claude Code (personal/global installation)
+#
+# The skill is already available when working inside the Task You project
+# (at skills/taskyou/SKILL.md). This script installs it globally
+# so you can use /taskyou from any project.
+#
+# Usage:
+#   ./scripts/install-skill.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+SKILL_SOURCE="$PROJECT_DIR/skills/taskyou"
+SKILL_TARGET="$HOME/.claude/skills/taskyou"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo "Installing Task You skill for Claude Code..."
+
+# Check if skill source exists
+if [ ! -d "$SKILL_SOURCE" ]; then
+    echo -e "${RED}Error: Skill source not found at $SKILL_SOURCE${NC}"
+    exit 1
+fi
+
+# Create skills directory if it doesn't exist
+mkdir -p "$HOME/.claude/skills"
+
+# Remove existing symlink or directory
+if [ -L "$SKILL_TARGET" ]; then
+    echo -e "${YELLOW}Removing existing symlink...${NC}"
+    rm "$SKILL_TARGET"
+elif [ -d "$SKILL_TARGET" ]; then
+    echo -e "${YELLOW}Removing existing directory...${NC}"
+    rm -rf "$SKILL_TARGET"
+fi
+
+# Create symlink
+ln -s "$SKILL_SOURCE" "$SKILL_TARGET"
+
+echo -e "${GREEN}Success!${NC} Task You skill installed globally."
+echo ""
+echo -e "${BLUE}Usage:${NC}"
+echo "  Type /taskyou in Claude Code to invoke the skill"
+echo "  Or ask Claude to 'manage my task queue' and it will use the skill automatically"
+echo ""
+echo -e "${BLUE}CLI commands:${NC}"
+echo "  Use 'ty' or 'taskyou' to interact with Task You from the command line"
+echo ""
+echo -e "${BLUE}Note:${NC}"
+echo "  The skill is also available automatically when working inside the Task You project."
+echo "  This global install lets you use /taskyou from any directory."

--- a/skills/taskyou/SKILL.md
+++ b/skills/taskyou/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: taskyou
+description: "Orchestrate Task You from any AI agent via CLI. Manage tasks, view the Kanban board, execute work, and track progress without touching the TUI."
+homepage: https://github.com/bborn/taskyou
+metadata: {"requires":{"anyBins":["ty","taskyou"]}}
+---
+
+# Task You Orchestrator
+
+You are an autonomous orchestrator for **Task You**, a personal task management system with a Kanban board, background execution, and git worktree isolation.
+
+**Your role:** Drive Task You via CLI commands to manage the task queue, execute work, and report progress. The user can always jump into the TUI (`ty` or `taskyou`) when they need direct control.
+
+**CLI commands:** Use `ty` (short) or `taskyou` (full) - both work identically.
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| See all tasks | `ty board --json` |
+| List by status | `ty list --status <status> --json` |
+| View task details | `ty show <id> --json --logs` |
+| Create task | `ty create "title" --body "description"` |
+| Execute task | `ty execute <id>` |
+| Retry with feedback | `ty retry <id> --feedback "..."` |
+| Change status | `ty status <id> <status>` |
+| Pin/prioritize | `ty pin <id>` |
+| Close/complete | `ty close <id>` |
+| Delete | `ty delete <id>` |
+
+**Statuses:** `backlog`, `queued`, `processing`, `blocked`, `done`, `archived`
+
+## Core Workflow
+
+### 1. Survey the Board
+
+Always start by understanding the current state:
+
+```bash
+ty board --json | jq
+```
+
+This returns all columns and their tasks. Use it to:
+- See what's in progress
+- Find blocked tasks needing input
+- Identify the next priority in backlog
+
+### 2. Execute Tasks
+
+Queue a task for execution:
+
+```bash
+ty execute <id>
+```
+
+The executor (Claude Code, Codex, or Gemini) runs in an isolated git worktree. Monitor progress:
+
+```bash
+ty show <id> --json --logs
+```
+
+### 3. Handle Blocked Tasks
+
+When tasks are `blocked`, they need user input. Check why:
+
+```bash
+ty show <id> --json --logs
+```
+
+Then retry with feedback:
+
+```bash
+ty retry <id> --feedback "Here's the clarification you need..."
+```
+
+### 4. Create New Tasks
+
+```bash
+ty create "Implement feature X" --body "Detailed description here..."
+```
+
+Optional flags:
+- `--project <name>` - Associate with a project
+- `--type <type>` - Task type (bug, feature, etc.)
+- `--dangerous` - Skip permission prompts in executor
+
+### 5. Manage Priority
+
+Pin important tasks to the top:
+
+```bash
+ty pin <id>           # Pin
+ty pin <id> --unpin   # Unpin
+ty pin <id> --toggle  # Toggle
+```
+
+### 6. Change Status Manually
+
+Move tasks between columns:
+
+```bash
+ty status <id> backlog     # Move to backlog
+ty status <id> queued      # Queue for execution
+ty status <id> done        # Mark complete
+```
+
+### 7. Close and Cleanup
+
+```bash
+ty close <id>    # Mark as done
+ty delete <id>   # Permanently remove
+```
+
+## JSON Output for Automation
+
+All commands support `--json` for machine-readable output:
+
+```bash
+ty board --json              # Full board snapshot
+ty list --status blocked --json  # Filtered list
+ty show 42 --json --logs     # Task with execution logs
+```
+
+Pipe to `jq` for processing:
+
+```bash
+ty board --json | jq '.columns.backlog.tasks[:3]'  # First 3 backlog items
+ty list --json | jq '.[] | select(.pinned == true)'  # Pinned tasks only
+```
+
+## Orchestration Patterns
+
+### Continuous Monitoring Loop
+
+```bash
+while true; do
+  ty board --json | jq -r '.columns.blocked.tasks[].id' | while read id; do
+    echo "Task $id is blocked - needs attention"
+  done
+  sleep 30
+done
+```
+
+### Auto-Execute Queued Tasks
+
+```bash
+ty list --status queued --json | jq -r '.[0].id' | xargs -I{} ty execute {}
+```
+
+### Batch Status Updates
+
+```bash
+ty list --status backlog --json | jq -r '.[].id' | xargs -n1 ty status {} queued
+```
+
+## Best Practices
+
+1. **Always check the board first** - Understand context before acting
+2. **Use JSON output** - Structured data is easier to process and reason about
+3. **Provide meaningful feedback** - When retrying blocked tasks, give clear context
+4. **Monitor execution** - Use `ty show <id> --logs` to track progress
+5. **Respect priorities** - Check pinned tasks first
+6. **Create focused tasks** - One clear objective per task works best
+
+## Task Lifecycle
+
+```
+backlog → queued → processing → done
+                 ↘ blocked (needs input)
+```
+
+- **backlog**: Created but not started
+- **queued**: Waiting for executor pickup
+- **processing**: Actively being worked on
+- **blocked**: Waiting for user input/clarification
+- **done**: Completed successfully
+
+## Integration Tips
+
+### With External Schedulers
+
+Task You doesn't have built-in recurring tasks. Use cron or external schedulers:
+
+```bash
+# Run daily standup at 9am
+0 9 * * * ty create "Daily standup review" && ty execute $(ty list --status backlog --json | jq -r '.[0].id')
+```
+
+### With Other AI Agents
+
+This skill works with any agent that can execute shell commands:
+- **Claude Code**: Native integration via hooks
+- **Codex**: Use `codex exec "ty board --json && ..."`
+- **Gemini**: Use `gemini code "Run ty board --json and summarize"`
+- **OpenCode/Pi**: Same pattern - shell out to `ty` CLI
+
+### Dashboard Mode
+
+For a rolling view of the board:
+
+```bash
+watch -n30 "ty board"
+```
+
+## Troubleshooting
+
+### Task stuck in processing?
+
+Check if the executor is running:
+```bash
+ty show <id> --logs
+```
+
+### No tasks executing?
+
+Ensure the daemon is running:
+```bash
+ty daemon status
+ty daemon restart  # If needed
+```
+
+### Can't find a task?
+
+Search by status:
+```bash
+ty list --status done --json | jq '.[] | select(.title | contains("keyword"))'
+```
+
+## MCP Tools (When Running Inside Task You)
+
+If you're running as the task executor, you have access to MCP tools:
+
+- `workflow_complete` - Mark your task complete
+- `workflow_needs_input` - Request user input (blocks task)
+- `workflow_show_task` - Get your task details
+- `workflow_create_task` - Create follow-up tasks
+- `workflow_list_tasks` - See other active tasks
+
+Use these instead of CLI when executing inside a Task You worktree.


### PR DESCRIPTION
## Summary
- Add a Claude Code skill (`/tasky`) that teaches any AI agent how to orchestrate Task You via CLI
- Create install script (`scripts/install-skill.sh`) for easy setup
- Update docs to reference the new skill approach

## What This Enables

Instead of manually copying system prompts or memorizing CLI flags, users can now:

1. Install the skill with `./scripts/install-skill.sh`
2. Use natural language with any AI agent:
   - "Show me my task board"
   - "Execute the top priority task"
   - "What's blocked right now?"
   - "Create a task to fix the login bug"

The skill works with Claude Code, Codex, Gemini, or any agent that can execute shell commands.

## Files Changed

| File | Purpose |
|------|---------|
| `skills/tasky/SKILL.md` | The skill that teaches agents Task You CLI orchestration |
| `scripts/install-skill.sh` | Symlinks skill to `~/.claude/skills/tasky` |
| `README.md` | Added section about installing the AI agent skill |
| `docs/orchestrator.md` | Updated to reference the skill as the recommended approach |

## Skill Contents

The skill provides:
- Quick reference table for all CLI commands
- Core workflow patterns (survey board → execute → handle blocked)
- JSON output examples for automation
- Orchestration patterns (monitoring loops, batch updates)
- Integration tips for different AI agents
- MCP tools reference for when running inside Task You

## Test plan
- [x] All existing tests pass (`make test`)
- [x] Install script creates valid symlink
- [ ] Manual testing: Install skill and ask Claude to manage tasks