### PR TITLE
fix(ui): prevent task detail pane title from dimming in tmux

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -1552,7 +1552,10 @@ func execInTmux() error {
 
 	// Enable pane border labels
 	osexec.Command("tmux", "set-option", "-t", sessionName, "pane-border-status", "top").Run()
-	osexec.Command("tmux", "set-option", "-t", sessionName, "pane-border-format", " #{pane_title} ").Run()
+	// Use conditional formatting: pane 0 (task detail) always uses bright color, others follow border style
+	// This prevents the task detail title from being dimmed when other panes are focused
+	osexec.Command("tmux", "set-option", "-t", sessionName, "pane-border-format",
+		"#{?#{==:#{pane_index},0},#[fg=#9CA3AF] #{pane_title} , #{pane_title} }").Run()
 	osexec.Command("tmux", "set-option", "-t", sessionName, "pane-border-style", "fg=#374151").Run()
 	osexec.Command("tmux", "set-option", "-t", sessionName, "pane-active-border-style", "fg=#61AFEF").Run()
 


### PR DESCRIPTION
## Summary

- Fix the task detail view Tmux label (pane 0) to never be dimmed when other panes are focused
- Use conditional formatting in `pane-border-format` to always display pane 0's title in a visible gray color (`#9CA3AF`)
- Other panes continue to follow the normal border style behavior

## Technical Details

The Tmux `pane-border-format` now uses conditional formatting:
```
#{?#{==:#{pane_index},0},#[fg=#9CA3AF] #{pane_title} , #{pane_title} }
```

This checks if the current pane is index 0 (the task detail pane). If so, it applies a bright gray foreground color inline. Otherwise, it uses the default border style.

## Test plan

- [ ] Open the task UI in tmux mode
- [ ] Select a pane other than the task detail pane (e.g., the executor pane)
- [ ] Verify the task detail title at the top remains visible and is not dimmed


🤖 Generated with [Claude Code](https://claude.com/claude-code)