### PR TITLE
feat(ui): keep kanban column context in task view

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -644,6 +644,11 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			var initCmd tea.Cmd
 			m.detailView, initCmd = NewDetailModel(msg.task, m.db, m.executor, m.width, m.height, msg.focusExecutor)
+			// Set origin column for navigation if entering from dashboard
+			// (preserve existing origin when navigating between tasks in detail view)
+			if !m.kanban.HasOriginColumn() {
+				m.kanban.SetOriginColumn()
+			}
 			// Set task position in column for display
 			pos, total := m.kanban.GetTaskPosition()
 			m.detailView.SetPosition(pos, total)
@@ -1480,6 +1485,8 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.currentView = ViewDashboard
+		// Clear origin column when exiting detail view
+		m.kanban.ClearOriginColumn()
 		if m.detailView != nil {
 			m.detailView.Cleanup()
 			m.detailView = nil
@@ -1497,6 +1504,8 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.detailView.CleanupWithoutSaving()
 				m.detailView = nil
 			}
+			// Clear origin column since we're jumping to a different task
+			m.kanban.ClearOriginColumn()
 			m.kanban.SelectTask(taskID)
 			// Clear notification after jumping
 			m.notification = ""


### PR DESCRIPTION
## Summary

- Adds origin column tracking to preserve the source Kanban column when entering task detail view
- Navigation (up/down arrows) stays within the original column even if the viewed task moves to a different column
- Origin column is cleared when exiting detail view or jumping to a notification

## Test plan

- [x] All existing tests pass
- [x] Added 5 new tests for origin column functionality:
  - `TestKanbanBoard_OriginColumn` - basic set/clear/has operations
  - `TestKanbanBoard_OriginColumnPreservesColumnOnTaskMove` - column stays same when task moves
  - `TestKanbanBoard_NoOriginColumnFollowsTask` - normal dashboard behavior still works
  - `TestKanbanBoard_OriginColumnClampsSelection` - row is clamped when tasks are removed
  - `TestKanbanBoard_OriginColumnEmptyColumn` - handles empty column case

🤖 Generated with [Claude Code](https://claude.com/claude-code)