### PR TITLE
feat(ui): add shell pane toggle with backslash key

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ const (
 	SettingTheme              = "theme"
 	SettingDetailPaneHeight   = "detail_pane_height"
 	SettingShellPaneWidth     = "shell_pane_width"
+	SettingShellPaneHidden    = "shell_pane_hidden"
 	SettingIdleSuspendTimeout = "idle_suspend_timeout"
 )
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -69,6 +69,7 @@ type KeyMap struct {
 	Filter          key.Binding
 	ResumeClaude             key.Binding
 	OpenWorktree             key.Binding
+	ToggleShellPane          key.Binding
 	JumpToNotification       key.Binding
 	JumpToNotificationDetail key.Binding // For detail view (uses Ctrl+g to avoid conflicting with text input)
 	// Column focus shortcuts
@@ -94,7 +95,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.FocusBacklog, k.FocusInProgress, k.FocusBlocked, k.FocusDone},
 		{k.Enter, k.New, k.Queue, k.Close},
 		{k.Retry, k.Archive, k.Delete, k.OpenWorktree},
-		{k.Filter, k.CommandPalette, k.Settings},
+		{k.Filter, k.CommandPalette, k.Settings, k.ToggleShellPane},
 		{k.ChangeStatus, k.TogglePin, k.Refresh, k.Help},
 		{k.Quit},
 	}
@@ -198,6 +199,10 @@ func DefaultKeyMap() KeyMap {
 		OpenWorktree: key.NewBinding(
 			key.WithKeys("o"),
 			key.WithHelp("o", "open in editor"),
+		),
+		ToggleShellPane: key.NewBinding(
+			key.WithKeys("\\"),
+			key.WithHelp("\\", "toggle shell"),
 		),
 		JumpToNotification: key.NewBinding(
 			key.WithKeys("g"),
@@ -1567,6 +1572,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	if key.Matches(keyMsg, m.keys.OpenWorktree) && m.selectedTask != nil {
 		return m, m.openWorktreeInEditor(m.selectedTask)
+	}
+	if key.Matches(keyMsg, m.keys.ToggleShellPane) && m.detailView != nil {
+		m.detailView.ToggleShellPane()
+		return m, nil
 	}
 
 	// Arrow key navigation to prev/next task in the same column


### PR DESCRIPTION
## Summary

- Add ability to collapse/expand the shell pane in task detail view without losing its state
- Press `\` (backslash) to toggle shell pane visibility
- Preference is persisted across sessions via settings
- When hidden, shell pane is moved to daemon window and Claude expands to full width
- When shown, shell pane is restored from daemon or a new one is created

## Test plan

- [ ] Open a task in detail view with shell pane visible
- [ ] Press `\` to hide the shell pane - Claude should expand to full width
- [ ] Press `\` again to show the shell pane - it should reappear at previous width
- [ ] Navigate away and back - shell visibility state should persist
- [ ] Toggle shell, exit task, return - shell state should be remembered
- [ ] Verify help menu (?) shows the new toggle shell keybinding

🤖 Generated with [Claude Code](https://claude.com/claude-code)