### PR TITLE
fix(ui): break panes before toggling dangerous mode to prevent duplicates

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1615,6 +1615,11 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if key.Matches(keyMsg, m.keys.ToggleDangerous) && m.selectedTask != nil {
 		// Only allow toggling dangerous mode if task is processing or blocked
 		if m.selectedTask.Status == db.StatusProcessing || m.selectedTask.Status == db.StatusBlocked {
+			// Break panes back to daemon BEFORE toggling so the executor can kill them.
+			// If panes are joined to task-ui, killAllWindowsByNameAllSessions won't find them.
+			if m.detailView != nil {
+				m.detailView.Cleanup()
+			}
 			return m, m.toggleDangerousMode(m.selectedTask.ID)
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes duplicate executor panes when toggling dangerous/safe mode while viewing a task
- Root cause: panes joined to `task-ui` weren't killed by `killAllWindowsByNameAllSessions` (which only kills daemon windows)
- Fix: Call `Cleanup()` before toggling to break panes back to daemon first

## Test plan
- [ ] Open a task in detail view (so panes are joined to task-ui)
- [ ] Toggle dangerous mode with `D`
- [ ] Verify only 2 panes exist (1 Claude + 1 Shell), not 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)