### PR TITLE
feat(ui): add project-only filter with [ prefix in kanban

### DIFF
--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -461,6 +461,49 @@ func TestScoreTaskForFilter(t *testing.T) {
 			wantMin: -1,
 			wantMax: -1,
 		},
+		// Project-only filter tests (using [ prefix)
+		{
+			name:    "project-only filter matches project",
+			task:    &db.Task{ID: 1, Title: "Some task", Project: "workflow"},
+			query:   "[workflow",
+			wantMin: 100,
+			wantMax: 500,
+		},
+		{
+			name:    "project-only filter with fuzzy match",
+			task:    &db.Task{ID: 1, Title: "Some task", Project: "offerlab"},
+			query:   "[ol",
+			wantMin: 100,
+			wantMax: 500,
+		},
+		{
+			name:    "project-only filter excludes title matches",
+			task:    &db.Task{ID: 1, Title: "workflow improvements", Project: ""},
+			query:   "[workflow",
+			wantMin: -1,
+			wantMax: -1,
+		},
+		{
+			name:    "project-only filter with trailing bracket",
+			task:    &db.Task{ID: 1, Title: "Task", Project: "influencekit"},
+			query:   "[influencekit]",
+			wantMin: 100,
+			wantMax: 700, // exact match gets high score
+		},
+		{
+			name:    "just bracket shows tasks with project",
+			task:    &db.Task{ID: 1, Title: "Task", Project: "myproject"},
+			query:   "[",
+			wantMin: 100,
+			wantMax: 100,
+		},
+		{
+			name:    "just bracket hides tasks without project",
+			task:    &db.Task{ID: 1, Title: "Task", Project: ""},
+			query:   "[",
+			wantMin: -1,
+			wantMax: -1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add project-only filter using `[` prefix in the kanban filter
- When typing `[project` in the filter, it only matches against the project field (not title or other text)
- Typing just `[` shows all tasks that have a project set
- Supports fuzzy matching: `[ol` will match projects like `offerlab`
- Updated filter placeholder to indicate available prefixes: `Filter text, #id, or [project...`

## Test plan
- [x] Run `go test ./internal/ui/...` - all tests pass
- [x] Added 6 new test cases for project-only filtering
- [ ] Manual testing: type `/` to open filter, then:
  - Type `[workflow` - should show only tasks with project matching "workflow"
  - Type `[` alone - should show only tasks that have a project set
  - Type `[ol` - should match projects like "offerlab" via fuzzy matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)