### PR TITLE
Add Pi as a supported executor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@ Guide for AI agents working in this repository.
 This is **Task You** - a personal task management system with:
 - **SQLite storage** for tasks and projects
 - **SSH-accessible TUI** via Wish
-- **Background executor** running Claude Code for task processing
+- **Background executor** with support for multiple AI coding agents (Claude, Codex, Gemini, Pi, OpenClaw, OpenCode)
 - **Beautiful terminal UI** built with Charm libraries (Kanban board)
 - **Git worktree isolation** for parallel task execution
-- **Claude Code hooks** for real-time task state tracking
+- **Task lifecycle hooks** for real-time task state tracking
 
 ## Architecture
 
@@ -269,15 +269,28 @@ Recurring scheduling has been removed from TaskYou. Use external schedulers (cro
 The background executor (`internal/executor/executor.go`):
 - Polls for `queued` tasks every 2 seconds
 - Creates isolated git worktrees for each task
-- Runs Claude Code in tmux windows with hooks
+- Runs AI coding agents in tmux windows with hooks
 - Streams output to `task_logs` table
 - Supports real-time watching via subscriptions
 - Handles task suspension and resumption
 - Manages scheduled tasks (recurring runs must now be handled externally via CLI automation)
 
-### Claude Code Integration
+### Supported Executors
 
-Tasks run in tmux windows with Claude Code hooks that track state:
+TaskYou supports multiple AI coding agent backends:
+
+- **claude** (default) - Claude Code CLI with hooks and session resume
+- **codex** - OpenAI Codex CLI with dangerous mode support
+- **gemini** - Google Gemini CLI with configurable dangerous mode flags
+- **pi** - Pi coding agent with session continuity
+- **openclaw** - OpenClaw AI assistant
+- **opencode** - OpenCode AI assistant
+
+Each task can specify its executor in the task form. The executor runs in an isolated git worktree with environment variables for task context.
+
+### Executor Integration (Claude Example)
+
+Tasks run in tmux windows with hooks that track state:
 
 - **PreToolUse** - Before tool execution, ensures task is "processing"
 - **PostToolUse** - After tool completes, ensures task stays "processing"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Task You
 
-A personal task management system with a beautiful terminal UI, SQLite storage, and background task execution via pluggable AI agents (Claude Code, OpenAI Codex, Gemini, or OpenClaw).
+A personal task management system with a beautiful terminal UI, SQLite storage, and background task execution via pluggable AI agents (Claude Code, OpenAI Codex, Gemini, Pi, OpenClaw, or OpenCode).
 
 ## Screenshots
 
@@ -24,7 +24,7 @@ A personal task management system with a beautiful terminal UI, SQLite storage, 
 
 - **Kanban Board** - Visual task management with 4 columns (Backlog, In Progress, Blocked, Done)
 - **Git Worktrees** - Each task runs in an isolated worktree, no conflicts between parallel tasks
-- **Pluggable Executors** - Choose between Claude Code, OpenAI Codex, Gemini, or OpenClaw per task
+- **Pluggable Executors** - Choose between Claude Code, OpenAI Codex, Gemini, Pi, OpenClaw, or OpenCode per task
 - **Ghost Text Autocomplete** - LLM-powered suggestions for task titles and descriptions as you type
 - **VS Code-style Fuzzy Search** - Quick task navigation with smart matching (e.g., "dsno" matches "diseno website")
 - **Markdown Rendering** - Task descriptions render with proper formatting in the detail view
@@ -227,13 +227,15 @@ Task You supports multiple AI executors for processing tasks. You can choose the
 | Claude (default) | `claude` | [Claude Code](https://claude.ai/claude-code) - Anthropic's coding agent with session resumption |
 | Codex | `codex` | [OpenAI Codex CLI](https://github.com/openai/codex) - OpenAI's coding assistant |
 | Gemini | `gemini` | [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli) - Google's Gemini-based coding assistant |
+| Pi | `pi` | [Pi Coding Agent](https://github.com/mariozechner/pi-coding-agent) - Multi-provider AI coding agent with session continuity |
 | OpenCode | `opencode` | [OpenCode](https://opencode.ai) - Open-source AI coding assistant with multi-LLM support |
 | OpenClaw | `openclaw` | [OpenClaw](https://openclaw.ai) - Open-source personal AI assistant with session resumption |
 
 All executors run in tmux windows with the same worktree isolation and environment variables. The main differences:
 
-- **Claude Code** and **OpenClaw** support session resumption - when you retry a task, they continue with full conversation history
+- **Claude Code**, **Pi**, and **OpenClaw** support session resumption - when you retry a task, they continue with full conversation history
 - **Codex** and **Gemini** start fresh on each execution but receive the full prompt with any feedback
+- **OpenCode** does not support session resumption
 
 ### Installing Executors
 
@@ -248,6 +250,9 @@ npm install -g @openai/codex
 
 # Google Gemini CLI
 # See https://ai.google.dev/gemini-api/docs/cli for installation instructions
+
+# Pi Coding Agent
+npm install -g @mariozechner/pi-coding-agent
 
 # OpenClaw
 npm install -g openclaw@latest

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -69,6 +69,7 @@ const (
 	ExecutorGemini   = "gemini"   // Google Gemini CLI
 	ExecutorOpenClaw = "openclaw" // OpenClaw AI assistant (https://openclaw.ai)
 	ExecutorOpenCode = "opencode" // OpenCode AI assistant (https://opencode.ai)
+	ExecutorPi       = "pi"       // Pi coding agent (https://github.com/mariozechner/pi-coding-agent)
 )
 
 // DefaultExecutor returns the default executor if none is specified.

--- a/internal/executor/dangerous_mode_test.go
+++ b/internal/executor/dangerous_mode_test.go
@@ -73,6 +73,13 @@ func TestExecutorInterfaceImplementation(t *testing.T) {
 			supportsDangerousMode: false, // OpenCode does not support dangerous mode
 			dangerousFlag:         "",
 		},
+		{
+			name:                  "Pi executor",
+			executorName:          db.ExecutorPi,
+			supportsSessionResume: true,  // Pi supports session resume via --continue
+			supportsDangerousMode: false, // Pi does not support dangerous mode
+			dangerousFlag:         "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/executor/pi_executor.go
+++ b/internal/executor/pi_executor.go
@@ -1,0 +1,211 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/charmbracelet/log"
+)
+
+// PiExecutor implements TaskExecutor for Pi coding agent.
+type PiExecutor struct {
+	executor *Executor
+	logger   *log.Logger
+}
+
+// NewPiExecutor creates a new Pi executor.
+func NewPiExecutor(e *Executor) *PiExecutor {
+	return &PiExecutor{
+		executor: e,
+		logger:   e.logger,
+	}
+}
+
+// Name returns the executor name.
+func (p *PiExecutor) Name() string {
+	return db.ExecutorPi
+}
+
+// IsAvailable checks if the pi CLI is installed.
+func (p *PiExecutor) IsAvailable() bool {
+	_, err := exec.LookPath("pi")
+	return err == nil
+}
+
+// Execute runs a task using Pi.
+func (p *PiExecutor) Execute(ctx context.Context, task *db.Task, workDir, prompt string) ExecResult {
+	result := p.executor.runPi(ctx, task, workDir, prompt)
+	return ExecResult(result)
+}
+
+// Resume resumes a previous Pi session with feedback.
+func (p *PiExecutor) Resume(ctx context.Context, task *db.Task, workDir, prompt, feedback string) ExecResult {
+	result := p.executor.runPiResume(ctx, task, workDir, prompt, feedback)
+	return ExecResult(result)
+}
+
+// GetProcessID returns the PID of the Pi process for a task.
+func (p *PiExecutor) GetProcessID(taskID int64) int {
+	return p.executor.getPiPID(taskID)
+}
+
+// Kill terminates the Pi process for a task.
+func (p *PiExecutor) Kill(taskID int64) bool {
+	return p.executor.KillPiProcess(taskID)
+}
+
+// Suspend pauses the Pi process for a task.
+func (p *PiExecutor) Suspend(taskID int64) bool {
+	return p.executor.SuspendTask(taskID)
+}
+
+// IsSuspended checks if a task's Pi process is suspended.
+func (p *PiExecutor) IsSuspended(taskID int64) bool {
+	return p.executor.IsSuspended(taskID)
+}
+
+// BuildCommand returns the shell command to start an interactive Pi session.
+func (p *PiExecutor) BuildCommand(task *db.Task, sessionID, prompt string) string {
+	// Get session ID for environment
+	worktreeSessionID := os.Getenv("WORKTREE_SESSION_ID")
+	if worktreeSessionID == "" {
+		worktreeSessionID = fmt.Sprintf("%d", os.Getpid())
+	}
+
+	// Build system prompt flag
+	systemPromptFlag := ""
+	systemFile, err := os.CreateTemp("", "task-system-*.txt")
+	if err == nil {
+		systemFile.WriteString(p.executor.buildSystemInstructions())
+		systemFile.Close()
+		systemPromptFlag = fmt.Sprintf(`--append-system-prompt %q `, systemFile.Name())
+	}
+
+	// Build command - resume if we have a session ID, otherwise start fresh
+	if sessionID != "" {
+		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi %s--continue`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, systemPromptFlag)
+		if systemFile != nil {
+			cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
+		}
+		return cmd
+	}
+
+	// Start fresh - if prompt is provided, write to temp file and pass it
+	if prompt != "" {
+		// Create temp file for prompt (avoids shell quoting issues)
+		promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
+		if err != nil {
+			p.logger.Error("BuildCommand: failed to create temp file", "error", err)
+			cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi %s`,
+				task.ID, worktreeSessionID, task.Port, task.WorktreePath, systemPromptFlag)
+			if systemFile != nil {
+				cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
+			}
+			return cmd
+		}
+		promptFile.WriteString(prompt)
+		promptFile.Close()
+
+		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi %s"$(cat %q)"; rm -f %q`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, systemPromptFlag, promptFile.Name(), promptFile.Name())
+		if systemFile != nil {
+			cmd += fmt.Sprintf(` %q`, systemFile.Name())
+		}
+		return cmd
+	}
+
+	cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi %s`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath, systemPromptFlag)
+	if systemFile != nil {
+		cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
+	}
+	return cmd
+}
+
+// ---- Session and Dangerous Mode Support ----
+
+// SupportsSessionResume returns true - Pi supports session resume via --continue.
+func (p *PiExecutor) SupportsSessionResume() bool {
+	return true
+}
+
+// SupportsDangerousMode returns false - Pi doesn't have a dangerous mode flag.
+func (p *PiExecutor) SupportsDangerousMode() bool {
+	return false
+}
+
+// FindSessionID discovers the most recent Pi session ID for the given workDir.
+func (p *PiExecutor) FindSessionID(workDir string) string {
+	return findPiSessionID(workDir)
+}
+
+// ResumeDangerous is not supported for Pi.
+func (p *PiExecutor) ResumeDangerous(task *db.Task, workDir string) bool {
+	p.executor.logLine(task.ID, "system", "Pi executor does not support dangerous mode")
+	return false
+}
+
+// ResumeSafe is not supported for Pi.
+func (p *PiExecutor) ResumeSafe(task *db.Task, workDir string) bool {
+	p.executor.logLine(task.ID, "system", "Pi executor does not support dangerous mode")
+	return false
+}
+
+// findPiSessionID finds the most recent Pi session ID for a workDir.
+// Pi stores sessions in ~/.pi/agent/sessions/<escaped-path>/
+func findPiSessionID(workDir string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	// Pi escapes the path similar to Claude: /Users/bruno/foo -> --Users-bruno-foo--
+	escapedPath := "--" + strings.ReplaceAll(workDir, "/", "-") + "--"
+	sessionDir := filepath.Join(home, ".pi", "agent", "sessions", escapedPath)
+
+	// Find the most recent .jsonl file
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		return ""
+	}
+
+	var latestTime time.Time
+	var latestSession string
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		if info.ModTime().After(latestTime) {
+			latestTime = info.ModTime()
+			// Session file format: 2026-01-31T16-56-49-866Z_aa857952-4ced-4fcc-a8c9-53966931221d.jsonl
+			// We just need the path to use with --continue
+			latestSession = filepath.Join(sessionDir, name)
+		}
+	}
+
+	return latestSession
+}
+
+// piSessionExists checks if a Pi session file exists.
+func piSessionExists(sessionPath string) bool {
+	if sessionPath == "" {
+		return false
+	}
+	_, err := os.Stat(sessionPath)
+	return err == nil
+}

--- a/internal/executor/pi_executor_test.go
+++ b/internal/executor/pi_executor_test.go
@@ -1,0 +1,386 @@
+package executor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+func TestPiExecutor_Name(t *testing.T) {
+	// Create temp database
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	cfg := &config.Config{}
+	exec := New(database, cfg)
+	piExec := exec.GetExecutor("pi")
+
+	if piExec == nil {
+		t.Fatal("pi executor not found")
+	}
+
+	if piExec.Name() != db.ExecutorPi {
+		t.Errorf("expected name %q, got %q", db.ExecutorPi, piExec.Name())
+	}
+}
+
+func TestPiExecutor_IsAvailable(t *testing.T) {
+	// Create temp database
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	cfg := &config.Config{}
+	exec := New(database, cfg)
+	piExec := exec.GetExecutor("pi")
+
+	if piExec == nil {
+		t.Fatal("pi executor not found")
+	}
+
+	// Check if pi is in PATH
+	_, pathErr := os.Stat("/usr/local/bin/pi")
+	piInPath := pathErr == nil
+
+	// IsAvailable should match whether pi is in PATH
+	available := piExec.IsAvailable()
+	if available != piInPath {
+		t.Logf("pi availability: %v (pi in path: %v)", available, piInPath)
+	}
+}
+
+func TestPiExecutor_SupportsSessionResume(t *testing.T) {
+	// Create temp database
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	cfg := &config.Config{}
+	exec := New(database, cfg)
+	piExec := exec.GetExecutor("pi")
+
+	if piExec == nil {
+		t.Fatal("pi executor not found")
+	}
+
+	if !piExec.SupportsSessionResume() {
+		t.Error("pi executor should support session resume")
+	}
+}
+
+func TestPiExecutor_DangerousMode(t *testing.T) {
+	// Create temp database
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	cfg := &config.Config{}
+	exec := New(database, cfg)
+	piExec := exec.GetExecutor("pi")
+
+	if piExec == nil {
+		t.Fatal("pi executor not found")
+	}
+
+	// Pi doesn't support dangerous mode
+	if piExec.SupportsDangerousMode() {
+		t.Error("pi executor should not support dangerous mode")
+	}
+}
+
+func TestPiExecutor_BuildCommand(t *testing.T) {
+	// Create temp database
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	cfg := &config.Config{}
+	exec := New(database, cfg)
+	piExec := exec.GetExecutor("pi")
+
+	if piExec == nil {
+		t.Fatal("pi executor not found")
+	}
+
+	task := &db.Task{
+		ID:           123,
+		Title:        "Test Task",
+		WorktreePath: "/tmp/test-worktree",
+		Port:         3100,
+	}
+
+	// Test building command without session ID
+	cmd := piExec.BuildCommand(task, "", "test prompt")
+	if cmd == "" {
+		t.Error("expected non-empty command")
+	}
+
+	// Should contain task environment variables
+	if !containsString(cmd, "WORKTREE_TASK_ID=123") {
+		t.Error("command should contain WORKTREE_TASK_ID")
+	}
+	if !containsString(cmd, "WORKTREE_PORT=3100") {
+		t.Error("command should contain WORKTREE_PORT")
+	}
+	if !containsString(cmd, "pi") {
+		t.Error("command should contain 'pi'")
+	}
+
+	// Test building command with session ID (resume)
+	cmdResume := piExec.BuildCommand(task, "session-123", "")
+	if cmdResume == "" {
+		t.Error("expected non-empty resume command")
+	}
+
+	// Should contain --continue flag for resume
+	if !containsString(cmdResume, "--continue") {
+		t.Error("resume command should contain --continue flag")
+	}
+}
+
+func TestFindPiSessionID(t *testing.T) {
+	// Create a temporary session directory structure
+	tmpDir := t.TempDir()
+	home := os.Getenv("HOME")
+	
+	// Save original HOME and restore after test
+	defer os.Setenv("HOME", home)
+	os.Setenv("HOME", tmpDir)
+
+	workDir := "/test/work/dir"
+	escapedPath := "--" + strings.ReplaceAll(workDir, "/", "-") + "--"
+	
+	sessionDir := filepath.Join(tmpDir, ".pi", "agent", "sessions", escapedPath)
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+
+	// Create some test session files with different timestamps
+	sessions := []struct {
+		name    string
+		age     time.Duration
+		content string
+	}{
+		{"2026-01-01T10-00-00-000Z_old-session.jsonl", 2 * time.Hour, "old"},
+		{"2026-01-01T12-00-00-000Z_recent-session.jsonl", 1 * time.Hour, "recent"},
+		{"2026-01-01T11-00-00-000Z_middle-session.jsonl", 90 * time.Minute, "middle"},
+	}
+
+	for _, s := range sessions {
+		path := filepath.Join(sessionDir, s.name)
+		if err := os.WriteFile(path, []byte(s.content), 0644); err != nil {
+			t.Fatalf("failed to write session file: %v", err)
+		}
+		// Set modification time
+		mtime := time.Now().Add(-s.age)
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatalf("failed to set mtime: %v", err)
+		}
+	}
+
+	// Find the most recent session
+	sessionID := findPiSessionID(workDir)
+	if sessionID == "" {
+		t.Fatal("expected to find a session")
+	}
+
+	// Should be the most recent one
+	expectedPath := filepath.Join(sessionDir, "2026-01-01T12-00-00-000Z_recent-session.jsonl")
+	if sessionID != expectedPath {
+		t.Errorf("expected most recent session %q, got %q", expectedPath, sessionID)
+	}
+}
+
+func TestPiSessionExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	// Test non-existent session
+	if piSessionExists("") {
+		t.Error("empty session path should not exist")
+	}
+
+	if piSessionExists("/nonexistent/session.jsonl") {
+		t.Error("nonexistent session should return false")
+	}
+
+	// Test existing session
+	sessionPath := filepath.Join(tmpDir, "test-session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create test session: %v", err)
+	}
+
+	if !piSessionExists(sessionPath) {
+		t.Error("existing session should return true")
+	}
+}
+
+func TestPiExecutor_ResumeDangerous(t *testing.T) {
+	// Create temp database
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	cfg := &config.Config{}
+	exec := New(database, cfg)
+	piExec := exec.GetExecutor("pi")
+
+	if piExec == nil {
+		t.Fatal("pi executor not found")
+	}
+
+	task := &db.Task{
+		ID:           123,
+		WorktreePath: "/tmp/test",
+	}
+
+	// Pi doesn't support dangerous mode, should return false
+	if piExec.ResumeDangerous(task, "/tmp/test") {
+		t.Error("pi executor should not support ResumeDangerous")
+	}
+}
+
+func TestPiExecutor_ResumeSafe(t *testing.T) {
+	// Create temp database
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	cfg := &config.Config{}
+	exec := New(database, cfg)
+	piExec := exec.GetExecutor("pi")
+
+	if piExec == nil {
+		t.Fatal("pi executor not found")
+	}
+
+	task := &db.Task{
+		ID:           123,
+		WorktreePath: "/tmp/test",
+	}
+
+	// Pi doesn't support dangerous mode, should return false
+	if piExec.ResumeSafe(task, "/tmp/test") {
+		t.Error("pi executor should not support ResumeSafe")
+	}
+}
+
+func TestPiExecutor_Execute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// Create temp database
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	cfg := &config.Config{}
+	exec := New(database, cfg)
+	piExec := exec.GetExecutor("pi")
+
+	if piExec == nil {
+		t.Fatal("pi executor not found")
+	}
+
+	if !piExec.IsAvailable() {
+		t.Skip("pi CLI not available, skipping integration test")
+	}
+
+	// This is an integration test that would require tmux and actual Pi execution
+	// We'll skip it in normal test runs but it's here as a placeholder
+	t.Skip("integration test - requires tmux and pi setup")
+}
+
+// Helper function to check if a string contains a substring
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && 
+		(s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || 
+		indexString(s, substr) >= 0))
+}
+
+func indexString(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -166,7 +166,7 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int, availab
 	}
 
 	// Build executor list: show available ones first, then unavailable ones marked
-	allExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorOpenCode, db.ExecutorOpenClaw}
+	allExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw}
 	executors := buildExecutorList(allExecutors, availableExecutors)
 
 	// Find the executor index and check if it's available
@@ -301,7 +301,7 @@ func NewFormModel(database *db.DB, width, height int, workingDir string, availab
 	}
 
 	// Build executor list: show available ones first, then unavailable ones marked
-	allExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorOpenCode, db.ExecutorOpenClaw}
+	allExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw}
 	executors := buildExecutorList(allExecutors, availableExecutors)
 
 	// Find the first available executor for default selection


### PR DESCRIPTION
## Summary

Adds Pi coding agent (https://github.com/mariozechner/pi-coding-agent) as a supported executor in TaskYou.

## Changes

### Backend
- ✅ Created `PiExecutor` implementing the `TaskExecutor` interface
- ✅ Supports session resume via `--continue` flag 
- ✅ Handles session discovery in `~/.pi/agent/sessions/`
- ✅ Manages process lifecycle (execute, resume, kill, suspend)
- ✅ Registered in executor factory

### UI
- ✅ Added Pi to executor dropdown in task forms
- ✅ Displays as "Pi" in the UI with proper formatting

### Testing
- ✅ Comprehensive unit tests for Pi executor
- ✅ Added to executor interface compliance tests
- ✅ All existing tests pass
- ✅ Linter passes with 0 issues

### Documentation
- ✅ Updated README.md with Pi in supported executors list
- ✅ Added installation instructions for Pi
- ✅ Updated AGENTS.md with executor details

## How It Works

- Pi sessions are stored in `~/.pi/agent/sessions/<escaped-path>/` with `.jsonl` files
- TaskYou uses `--continue` to resume previous sessions (similar to Claude's `--resume`)
- The executor creates tmux windows with Pi running interactively
- Environment variables (`WORKTREE_TASK_ID`, `WORKTREE_PORT`, `WORKTREE_PATH`) are passed to the Pi session
- System instructions are passed via `--append-system-prompt` to keep the conversation clean

## Testing

```bash
go test ./...                    # All tests pass
make lint                        # 0 issues
go test -v ./internal/executor   # Pi executor tests pass
```

## Notes

- Pi does not support dangerous mode (no equivalent flag)
- Session resume is fully supported via `--continue`
- Compatible with existing worktree isolation and environment variable setup