### PR TITLE
feat: add --executor flag to task create command

### DIFF
--- a/cmd/task/cli_test.go
+++ b/cmd/task/cli_test.go
@@ -62,6 +62,17 @@ func TestCLICreateTask(t *testing.T) {
 				Project: "",
 			},
 		},
+		{
+			name: "task with executor",
+			task: &db.Task{
+				Title:    "Task with codex",
+				Body:     "Use codex executor",
+				Status:   db.StatusBacklog,
+				Type:     db.TypeCode,
+				Executor: db.ExecutorCodex,
+				Project:  "",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -85,6 +96,14 @@ func TestCLICreateTask(t *testing.T) {
 				}
 				if fetched.Status != tt.task.Status {
 					t.Errorf("Status = %v, want %v", fetched.Status, tt.task.Status)
+				}
+				// Check executor (defaults to claude if empty)
+				expectedExecutor := tt.task.Executor
+				if expectedExecutor == "" {
+					expectedExecutor = db.ExecutorClaude
+				}
+				if fetched.Executor != expectedExecutor {
+					t.Errorf("Executor = %v, want %v", fetched.Executor, expectedExecutor)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- Add `-e/--executor` flag to `task create` CLI command to allow users to select which executor runs their tasks
- Validate executor against valid options: claude, codex, gemini, pi, opencode, openclaw
- Include executor in JSON output when using `--json` flag
- Add test for executor field in task creation

The TUI already had executor selection in the task form - this adds parity to the CLI interface.

## Test plan
- [x] Build compiles successfully
- [x] All existing tests pass
- [x] New test for executor field passes
- [x] Verify `task create --help` shows the new flag
- [x] Verify invalid executor values are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)