### PR TITLE
fix: enable TrueColor support for SSH sessions

### DIFF
--- a/internal/server/ssh.go
+++ b/internal/server/ssh.go
@@ -18,6 +18,7 @@ import (
 	"github.com/charmbracelet/wish/activeterm"
 	"github.com/charmbracelet/wish/bubbletea"
 	"github.com/charmbracelet/wish/logging"
+	"github.com/muesli/termenv"
 )
 
 // Server is the SSH server.
@@ -57,7 +58,9 @@ func New(cfg Config) (*Server, error) {
 		wish.WithAddress(s.addr),
 		wish.WithHostKeyPath(s.hostKey),
 		wish.WithMiddleware(
-			bubbletea.Middleware(s.teaHandler),
+			// Use MiddlewareWithColorProfile to ensure colors work over SSH.
+			// TrueColor (24-bit) is the minimum we need for our theme colors.
+			bubbletea.MiddlewareWithColorProfile(s.teaHandler, termenv.TrueColor),
 			activeterm.Middleware(),
 			logging.Middleware(),
 		),


### PR DESCRIPTION
## Summary
- Fix colors not rendering when using `ty -r` (remote mode over SSH)
- Use `MiddlewareWithColorProfile` with TrueColor to ensure proper color support

## Problem
The kanban board was rendering without colors when accessed via SSH, making it hard to distinguish between columns and task states. This happened because `bubbletea.Middleware()` doesn't auto-detect terminal color capabilities properly over SSH.

## Solution
Use `bubbletea.MiddlewareWithColorProfile(s.teaHandler, termenv.TrueColor)` instead of `bubbletea.Middleware(s.teaHandler)` to force 24-bit TrueColor support for SSH sessions.

## Test plan
- [ ] Run `ty` locally - should show colors (unchanged behavior)
- [ ] Run `ty -r` - should now show colors (was broken, now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)