### PR TITLE
fix: prevent remote from syncing to itself by clearing cloud settings on push

### DIFF
--- a/cmd/task/cloud.go
+++ b/cmd/task/cloud.go
@@ -822,6 +822,17 @@ func pushToCloud(force bool) error {
 		fmt.Println(cloudCheckStyle.Render("done"))
 	}
 
+	// Clear cloud settings on the remote so it doesn't try to sync to itself
+	fmt.Print("Clearing remote cloud settings... ")
+	clearCloudSQL := fmt.Sprintf(`DELETE FROM settings WHERE key IN ('%s', '%s', '%s', '%s', '%s')`,
+		SettingCloudServer, SettingCloudSSHPort, SettingCloudTaskPort, SettingCloudRemoteUser, SettingCloudRemoteDir)
+	_, err = sshRun(server, fmt.Sprintf("sqlite3 '%s' \"%s\"", fullRemoteDBPath, clearCloudSQL))
+	if err != nil {
+		fmt.Println(cloudPendingStyle.Render("warning"))
+	} else {
+		fmt.Println(cloudCheckStyle.Render("done"))
+	}
+
 	// Update project paths to remote paths
 	fmt.Print("Updating project paths... ")
 	projects, err := database.ListProjects()


### PR DESCRIPTION
## Summary
- After pushing the local database to the remote server, cloud settings are now cleared from the remote database
- This prevents the remote server from thinking it has a cloud server configured (which would be pointing to itself)
- Fixes circular sync issues that could occur when running `ty` on the remote

## Test plan
- [ ] Run `task cloud push` to push local database to remote
- [ ] SSH to remote and verify cloud settings are cleared: `sqlite3 ~/.local/share/task/tasks.db "SELECT * FROM settings WHERE key LIKE 'cloud_%'"`
- [ ] Run `ty` on the remote and verify it doesn't prompt for cloud sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)