### PR TITLE
feat(install): download both ty and taskd binaries

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,14 +2,20 @@
 # TaskYou Installation Script
 # Usage: curl -fsSL taskyou.dev/install.sh | bash
 #
-# This script downloads and installs the 'ty' CLI tool.
+# This script downloads and installs the 'ty' CLI tool and optionally the 'taskd' SSH server.
 # It detects your OS and architecture automatically.
+#
+# Options:
+#   --no-ssh-server    Skip installing taskd (the SSH server daemon)
+#
+# Environment variables:
+#   INSTALL_DIR        Installation directory (default: ~/.local/bin)
 
 set -e
 
 REPO="bborn/taskyou"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
-BINARY_NAME="ty"
+INSTALL_TASKD=true
 
 # Colors for output
 RED='\033[0;31m'
@@ -28,6 +34,36 @@ warn() {
 error() {
     echo -e "${RED}Error:${NC} $1" >&2
     exit 1
+}
+
+# Parse arguments
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --no-ssh-server)
+                INSTALL_TASKD=false
+                shift
+                ;;
+            --help|-h)
+                echo "TaskYou Installation Script"
+                echo ""
+                echo "Usage: curl -fsSL taskyou.dev/install.sh | bash [-s -- OPTIONS]"
+                echo "   or: ./install.sh [OPTIONS]"
+                echo ""
+                echo "Options:"
+                echo "  --no-ssh-server    Skip installing taskd (the SSH server daemon)"
+                echo "  --help, -h         Show this help message"
+                echo ""
+                echo "Environment variables:"
+                echo "  INSTALL_DIR        Installation directory (default: ~/.local/bin)"
+                exit 0
+                ;;
+            *)
+                warn "Unknown option: $1"
+                shift
+                ;;
+        esac
+    done
 }
 
 # Detect OS
@@ -62,48 +98,96 @@ get_latest_version() {
     echo "$version"
 }
 
-# Download and install the binary
-install_binary() {
+# Create install directory if needed
+ensure_install_dir() {
+    if [ ! -d "$INSTALL_DIR" ]; then
+        mkdir -p "$INSTALL_DIR" 2>/dev/null || sudo mkdir -p "$INSTALL_DIR"
+    fi
+}
+
+# Install a file to INSTALL_DIR (handles sudo if needed)
+install_file() {
+    local src=$1
+    local dest_name=$2
+
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "$src" "${INSTALL_DIR}/${dest_name}"
+    else
+        warn "${INSTALL_DIR} is not writable. Using sudo..."
+        sudo mv "$src" "${INSTALL_DIR}/${dest_name}"
+    fi
+}
+
+# Create a symlink in INSTALL_DIR (handles sudo if needed)
+create_symlink() {
+    local target=$1
+    local link_name=$2
+
+    if [ -w "$INSTALL_DIR" ]; then
+        ln -sf "$target" "${INSTALL_DIR}/${link_name}"
+    else
+        sudo ln -sf "$target" "${INSTALL_DIR}/${link_name}"
+    fi
+}
+
+# Download and install the ty CLI
+install_ty() {
     local os=$1
     local arch=$2
     local version=$3
+    local tmp_dir=$4
 
     local filename="ty-${os}-${arch}"
     local url="https://github.com/${REPO}/releases/download/${version}/${filename}"
 
-    info "Downloading ${BINARY_NAME} ${version} for ${os}/${arch}..."
-
-    # Create temp directory
-    local tmp_dir
-    tmp_dir=$(mktemp -d)
-    trap "rm -rf $tmp_dir" EXIT
+    info "Downloading ty ${version} for ${os}/${arch}..."
 
     # Download binary
-    if ! curl -fsSL "$url" -o "${tmp_dir}/${BINARY_NAME}"; then
+    if ! curl -fsSL "$url" -o "${tmp_dir}/ty"; then
         error "Failed to download from ${url}"
     fi
 
-    chmod +x "${tmp_dir}/${BINARY_NAME}"
+    chmod +x "${tmp_dir}/ty"
 
     # Install binary
-    info "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
+    info "Installing to ${INSTALL_DIR}/ty..."
+    install_file "${tmp_dir}/ty" "ty"
+    create_symlink "ty" "taskyou"
 
-    # Create directory if it doesn't exist
-    if [ ! -d "$INSTALL_DIR" ]; then
-        mkdir -p "$INSTALL_DIR" 2>/dev/null || sudo mkdir -p "$INSTALL_DIR"
-    fi
-
-    if [ -w "$INSTALL_DIR" ]; then
-        mv "${tmp_dir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
-        ln -sf "${BINARY_NAME}" "${INSTALL_DIR}/taskyou"
-    else
-        warn "${INSTALL_DIR} is not writable. Using sudo..."
-        sudo mv "${tmp_dir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
-        sudo ln -sf "${BINARY_NAME}" "${INSTALL_DIR}/taskyou"
-    fi
-
-    info "Successfully installed ${BINARY_NAME} ${version} to ${INSTALL_DIR}/${BINARY_NAME}"
+    info "Successfully installed ty ${version}"
     info "Also available as 'taskyou' (symlink)"
+}
+
+# Download and install the taskd SSH server (Linux only)
+install_taskd() {
+    local os=$1
+    local arch=$2
+    local version=$3
+    local tmp_dir=$4
+
+    # taskd is only available on Linux
+    if [ "$os" != "linux" ]; then
+        info "Skipping taskd (SSH server) - only available on Linux"
+        return 0
+    fi
+
+    local filename="taskd-${os}-${arch}"
+    local url="https://github.com/${REPO}/releases/download/${version}/${filename}"
+
+    info "Downloading taskd ${version} for ${os}/${arch}..."
+
+    # Download binary
+    if ! curl -fsSL "$url" -o "${tmp_dir}/taskd"; then
+        error "Failed to download taskd from ${url}"
+    fi
+
+    chmod +x "${tmp_dir}/taskd"
+
+    # Install binary
+    info "Installing to ${INSTALL_DIR}/taskd..."
+    install_file "${tmp_dir}/taskd" "taskd"
+
+    info "Successfully installed taskd ${version}"
 }
 
 # Check if install directory is in PATH
@@ -119,12 +203,15 @@ check_path() {
 
 # Main installation
 main() {
+    # Parse command line arguments
+    parse_args "$@"
+
     echo ""
     echo "  TaskYou Installer"
     echo "  =================="
     echo ""
 
-    local os arch version
+    local os arch version tmp_dir
 
     os=$(detect_os)
     arch=$(detect_arch)
@@ -134,12 +221,31 @@ main() {
     version=$(get_latest_version)
     info "Latest version: ${version}"
 
-    install_binary "$os" "$arch" "$version"
+    # Create temp directory for downloads
+    tmp_dir=$(mktemp -d)
+    trap "rm -rf $tmp_dir" EXIT
+
+    # Ensure install directory exists
+    ensure_install_dir
+
+    # Install ty CLI
+    install_ty "$os" "$arch" "$version" "$tmp_dir"
+
+    # Install taskd SSH server (unless --no-ssh-server was specified)
+    if [ "$INSTALL_TASKD" = true ]; then
+        install_taskd "$os" "$arch" "$version" "$tmp_dir"
+    else
+        info "Skipping taskd installation (--no-ssh-server)"
+    fi
+
     check_path
 
     echo ""
     info "Run 'ty' to get started!"
+    if [ "$INSTALL_TASKD" = true ] && [ "$os" = "linux" ]; then
+        info "Run 'taskd' to start the SSH server"
+    fi
     echo ""
 }
 
-main
+main "$@"


### PR DESCRIPTION
## Summary
- Update the install script to download and install both `ty` CLI and `taskd` SSH server
- Add `--no-ssh-server` flag to optionally skip taskd installation
- taskd is only installed on Linux (since it's only built for that platform)

## Changes
- Added argument parsing with `--no-ssh-server` and `--help` flags
- Refactored install logic into separate `install_ty` and `install_taskd` functions
- Added helper functions for directory creation, file installation, and symlink creation
- Shows taskd usage hint on Linux after successful installation

## Usage

Default (installs both ty and taskd on Linux):
```bash
curl -fsSL taskyou.dev/install.sh | bash
```

Skip taskd installation:
```bash
curl -fsSL taskyou.dev/install.sh | bash -s -- --no-ssh-server
```

## Test plan
- [ ] Test installation on Linux with default flags (should install both ty and taskd)
- [ ] Test installation on Linux with `--no-ssh-server` (should skip taskd)
- [ ] Test installation on macOS (should install ty only, skip taskd with message)
- [ ] Test `--help` flag shows usage information

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)