### PR TITLE
fix(daemon): pass --dangerous flag to Claude sessions

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -97,6 +97,11 @@ func main() {
 		Short: "Run the task executor daemon",
 		Long:  "Runs the background executor that processes queued tasks.",
 		Run: func(cmd *cobra.Command, args []string) {
+			// Set dangerous mode env var if flag is enabled
+			// This is checked by executors when spawning Claude sessions
+			if dangerous {
+				os.Setenv("WORKTREE_DANGEROUS_MODE", "1")
+			}
 			if err := runDaemon(); err != nil {
 				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
 				os.Exit(1)
@@ -2233,6 +2238,15 @@ func runDaemon() error {
 		return fmt.Errorf("write pid file: %w", err)
 	}
 	defer os.Remove(pidFile)
+
+	// Write mode file so we know what mode the daemon is running in
+	modeFile := pidFile + ".mode"
+	modeStr := "safe"
+	if os.Getenv("WORKTREE_DANGEROUS_MODE") == "1" {
+		modeStr = "dangerous"
+	}
+	os.WriteFile(modeFile, []byte(modeStr), 0644)
+	defer os.Remove(modeFile)
 
 	// Setup logger
 	logger := log.NewWithOptions(os.Stderr, log.Options{


### PR DESCRIPTION
## Summary
- Fixed bug where `ty daemon --dangerous` was not passing the dangerous mode to Claude sessions
- Set `WORKTREE_DANGEROUS_MODE=1` env var in daemon command when `--dangerous` flag is passed
- Write mode file in `runDaemon()` so subsequent runs know the daemon's mode

## Test plan
- [x] All existing tests pass
- [x] Code compiles successfully
- [ ] Manual test: Run `ty daemon --dangerous`, queue a task, verify Claude runs with `--dangerously-skip-permissions`

Fixes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)