### PR TITLE
fix(ui): remove non-functional 'R' resume shortcut from detail view

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2466,11 +2466,6 @@ func (m *DetailModel) renderHelp() string {
 		keys = append(keys, helpKey{"!", toggleDesc, false})
 	}
 
-	// Show executor resume shortcut only when the agent is not running but has a session
-	if m.task != nil && m.task.ClaudeSessionID != "" && m.claudeMemoryMB == 0 {
-		keys = append(keys, helpKey{"R", fmt.Sprintf("resume %s", m.executorDisplayName()), false})
-	}
-
 	// Show pane navigation shortcut when panes are visible
 	if hasPanes && os.Getenv("TMUX") != "" {
 		keys = append(keys, helpKey{"shift+" + IconArrowUp() + IconArrowDown(), "switch pane", false})


### PR DESCRIPTION
## Summary
- Removed the 'R' keyboard shortcut help text from the detail view that was supposed to "resume" Claude
- The shortcut was displayed in the help bar when a task had a Claude session but the agent wasn't running
- However, no handler was ever implemented for this key binding, making it non-functional

## Details
The help key was added with the intent to allow users to resume a paused Claude session using the 'R' key. However, the `updateDetail` function in `app.go` never had a corresponding key handler for this shortcut, so pressing 'R' did nothing.

This cleanup removes the confusing help text that suggested a feature that didn't exist.

## Test plan
- [x] Build passes (`go build ./...`)
- [x] UI tests pass (`go test ./internal/ui/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)