### PR TITLE
feat(ui): add project autocomplete to filter with Tab support

### DIFF
--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -504,6 +504,56 @@ func TestScoreTaskForFilter(t *testing.T) {
 			wantMin: -1,
 			wantMax: -1,
 		},
+		// [project] keyword tests (combined project + keyword filtering)
+		{
+			name:    "project with keyword matches task in project",
+			task:    &db.Task{ID: 1, Title: "Fix authentication bug", Project: "offerlab"},
+			query:   "[offerlab] auth",
+			wantMin: 100,
+			wantMax: 500,
+		},
+		{
+			name:    "project with keyword excludes task in different project",
+			task:    &db.Task{ID: 1, Title: "Fix authentication bug", Project: "workflow"},
+			query:   "[offerlab] auth",
+			wantMin: -1,
+			wantMax: -1,
+		},
+		{
+			name:    "project with keyword excludes task with no project",
+			task:    &db.Task{ID: 1, Title: "Fix authentication bug", Project: ""},
+			query:   "[offerlab] auth",
+			wantMin: -1,
+			wantMax: -1,
+		},
+		{
+			name:    "project with keyword no match for keyword",
+			task:    &db.Task{ID: 1, Title: "Setup database", Project: "offerlab"},
+			query:   "[offerlab] auth",
+			wantMin: -1,
+			wantMax: -1,
+		},
+		{
+			name:    "project bracket with space but no keyword shows all in project",
+			task:    &db.Task{ID: 1, Title: "Any task", Project: "offerlab"},
+			query:   "[offerlab] ",
+			wantMin: 100,
+			wantMax: 100,
+		},
+		{
+			name:    "project with ID keyword match",
+			task:    &db.Task{ID: 42, Title: "Task", Project: "offerlab"},
+			query:   "[offerlab] 42",
+			wantMin: 1000,
+			wantMax: 1000,
+		},
+		{
+			name:    "project filter case insensitive",
+			task:    &db.Task{ID: 1, Title: "Task", Project: "OfferLab"},
+			query:   "[offerlab] task",
+			wantMin: 100,
+			wantMax: 500,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/filter_autocomplete.go
+++ b/internal/ui/filter_autocomplete.go
@@ -1,0 +1,128 @@
+package ui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// FilterAutocompleteModel provides project name autocomplete for the filter.
+type FilterAutocompleteModel struct {
+	db        *db.DB
+	projects  []*db.Project // filtered results
+	selected  int
+	maxShow   int
+}
+
+// NewFilterAutocompleteModel creates a new filter autocomplete model.
+func NewFilterAutocompleteModel(database *db.DB) *FilterAutocompleteModel {
+	return &FilterAutocompleteModel{db: database, maxShow: 5}
+}
+
+// SetQuery filters projects based on query and resets selection.
+func (m *FilterAutocompleteModel) SetQuery(query string) {
+	if m.db == nil {
+		return
+	}
+	all, _ := m.db.ListProjects()
+	if query == "" {
+		m.projects = all
+	} else {
+		m.projects = nil
+		type scored struct {
+			p *db.Project
+			s int
+		}
+		var results []scored
+		for _, p := range all {
+			if s := fuzzyScore(p.Name, strings.ToLower(query)); s > 0 {
+				results = append(results, scored{p, s})
+			}
+		}
+		sort.Slice(results, func(i, j int) bool { return results[i].s > results[j].s })
+		for _, r := range results {
+			m.projects = append(m.projects, r.p)
+		}
+	}
+	if len(m.projects) > 10 {
+		m.projects = m.projects[:10]
+	}
+	m.selected = 0
+}
+
+func (m *FilterAutocompleteModel) MoveUp() {
+	if m.selected > 0 {
+		m.selected--
+	} else if len(m.projects) > 0 {
+		m.selected = len(m.projects) - 1
+	}
+}
+
+func (m *FilterAutocompleteModel) MoveDown() {
+	if m.selected < len(m.projects)-1 {
+		m.selected++
+	} else {
+		m.selected = 0
+	}
+}
+
+// Select returns the selected project name.
+func (m *FilterAutocompleteModel) Select() string {
+	if m.selected < len(m.projects) {
+		return m.projects[m.selected].Name
+	}
+	return ""
+}
+
+func (m *FilterAutocompleteModel) HasResults() bool { return len(m.projects) > 0 }
+func (m *FilterAutocompleteModel) Reset()           { m.projects = nil; m.selected = 0 }
+
+// View renders the dropdown.
+func (m *FilterAutocompleteModel) View() string {
+	if len(m.projects) == 0 {
+		return ""
+	}
+
+	// Calculate visible window around selection
+	start, end := 0, len(m.projects)
+	if end > m.maxShow {
+		start = m.selected - m.maxShow/2
+		if start < 0 {
+			start = 0
+		}
+		end = start + m.maxShow
+		if end > len(m.projects) {
+			end = len(m.projects)
+			start = end - m.maxShow
+		}
+	}
+
+	var lines []string
+	if start > 0 {
+		lines = append(lines, lipgloss.NewStyle().Foreground(ColorMuted).Render("  ↑"))
+	}
+	for i := start; i < end; i++ {
+		p := m.projects[i]
+		prefix, style := "  ", lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+		if i == m.selected {
+			prefix = "> "
+			style = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary)
+		}
+		name := "[" + p.Name + "]"
+		if p.Color != "" {
+			name = lipgloss.NewStyle().Foreground(lipgloss.Color(p.Color)).Render("●") + " " + name
+		}
+		lines = append(lines, prefix+style.Render(name))
+	}
+	if end < len(m.projects) {
+		lines = append(lines, lipgloss.NewStyle().Foreground(ColorMuted).Render("  ↓"))
+	}
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary).
+		Padding(0, 1).
+		Render(strings.Join(lines, "\n"))
+}

--- a/internal/ui/filter_autocomplete_test.go
+++ b/internal/ui/filter_autocomplete_test.go
@@ -1,0 +1,118 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func TestFilterAutocomplete(t *testing.T) {
+	projects := []*db.Project{
+		{ID: 1, Name: "personal"},
+		{ID: 2, Name: "offerlab"},
+		{ID: 3, Name: "workflow"},
+	}
+
+	tests := []struct {
+		name     string
+		query    string
+		expected int
+	}{
+		{"empty shows all", "", 3},
+		{"prefix match", "off", 1},
+		{"fuzzy match", "wfl", 1},
+		{"no match", "xyz", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &FilterAutocompleteModel{projects: projects, maxShow: 5}
+			// Manually set filtered for test (SetQuery requires db)
+			if tt.query == "" {
+				m.projects = projects
+			} else {
+				m.projects = nil
+				for _, p := range projects {
+					if fuzzyScore(p.Name, tt.query) > 0 {
+						m.projects = append(m.projects, p)
+					}
+				}
+			}
+			if len(m.projects) != tt.expected {
+				t.Errorf("got %d, want %d", len(m.projects), tt.expected)
+			}
+		})
+	}
+}
+
+func TestFilterAutocompleteNavigation(t *testing.T) {
+	m := &FilterAutocompleteModel{
+		projects: []*db.Project{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+		maxShow:  5,
+	}
+
+	if m.selected != 0 {
+		t.Errorf("initial = %d, want 0", m.selected)
+	}
+
+	m.MoveDown()
+	if m.selected != 1 {
+		t.Errorf("after down = %d, want 1", m.selected)
+	}
+
+	m.MoveDown()
+	m.MoveDown() // wraps
+	if m.selected != 0 {
+		t.Errorf("after wrap = %d, want 0", m.selected)
+	}
+
+	m.MoveUp() // wraps to end
+	if m.selected != 2 {
+		t.Errorf("after up wrap = %d, want 2", m.selected)
+	}
+}
+
+func TestFilterAutocompleteSelect(t *testing.T) {
+	m := &FilterAutocompleteModel{
+		projects: []*db.Project{{Name: "offerlab"}, {Name: "workflow"}},
+		maxShow:  5,
+	}
+
+	if name := m.Select(); name != "offerlab" {
+		t.Errorf("Select() = %q, want offerlab", name)
+	}
+
+	m.MoveDown()
+	if name := m.Select(); name != "workflow" {
+		t.Errorf("Select() = %q, want workflow", name)
+	}
+}
+
+func TestFilterAutocompleteReset(t *testing.T) {
+	m := &FilterAutocompleteModel{
+		projects: []*db.Project{{Name: "test"}},
+		selected: 1,
+		maxShow:  5,
+	}
+
+	m.Reset()
+
+	if m.projects != nil || m.selected != 0 {
+		t.Error("Reset did not clear state")
+	}
+}
+
+func TestFilterAutocompleteView(t *testing.T) {
+	m := &FilterAutocompleteModel{
+		projects: []*db.Project{{Name: "offerlab"}},
+		maxShow:  5,
+	}
+
+	view := m.View()
+	if view == "" {
+		t.Error("expected non-empty view")
+	}
+	if !contains(view, "[offerlab]") {
+		t.Error("view should contain [offerlab]")
+	}
+}


### PR DESCRIPTION
## Summary

- Add project autocomplete dropdown to filter field when typing `[`
- Tab key accepts the selected project and allows continued keyword filtering
- Support `[project] keyword` syntax for filtering within a specific project

## User Flow

1. Press `/` to focus the filter field
2. Type `[off` to see autocomplete suggestions for projects starting with "off"
3. Use up/down arrows to navigate suggestions
4. Press Tab or Enter to accept the selection (e.g., becomes `[offerlab] `)
5. Continue typing to filter by keyword within that project (e.g., `[offerlab] auth`)

## Changes

- **New file**: `internal/ui/filter_autocomplete.go` - FilterAutocompleteModel for project suggestions
- **Modified**: `internal/ui/app.go` - Integrate autocomplete into filter mode
- **Modified**: `internal/ui/app_test.go` - Add tests for `[project] keyword` syntax
- **New file**: `internal/ui/filter_autocomplete_test.go` - Tests for autocomplete model

## Test plan

- [ ] Type `/` and then `[` - verify dropdown appears with project list
- [ ] Type `[off` - verify matching projects are shown
- [ ] Press Tab - verify project is inserted with trailing `] `
- [ ] Continue typing after project - verify filtering works within project
- [ ] Press arrow keys - verify dropdown navigation works
- [ ] Press Esc - verify filter is cleared and dropdown dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)