### PR TITLE
fix(ui): preserve shell pane process when toggled or leaving detail view

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -96,9 +96,9 @@ type DetailModel struct {
 	paneError        string    // user-visible error when panes fail to open
 
 	// Notification state (passed from app)
-	notification   string // current notification message
-	notifyTaskID   int64  // task that triggered the notification
-	notifyUntil    time.Time
+	notification string // current notification message
+	notifyTaskID int64  // task that triggered the notification
+	notifyUntil  time.Time
 
 	// Focus executor pane after joining (e.g., when jumping from notification)
 	focusExecutorOnJoin bool


### PR DESCRIPTION
## Summary
- Fixes shell pane process being killed when hiding/unhiding or leaving detail view
- When shell is hidden, leaves it in the hidden window to preserve the running process
- Removes aggressive process killing when pane operations fail
- Preserves shell pane ID when re-entering tasks with hidden shell

## Problem
When the user hides the shell pane (with `\` key) and then leaves the detail view, the running process (e.g., a dev server) would be killed. This happened because:

1. `breakTmuxPanes()` tried to join the hidden shell pane to the daemon window
2. If the join failed, it would call `killPaneWithProcess()` which killed the running process
3. When re-entering the task, `joinTmuxPanes()` would clear the shell pane ID, losing the reference

## Solution
1. **In `breakTmuxPanes()`**: When shell is hidden, skip joining it to daemon and leave it in the hidden window
2. **In `breakTmuxPanes()`**: When join fails for visible shell, don't kill the process - just log and leave it
3. **In `joinTmuxPanes()`**: When shell is hidden, preserve the stored pane ID for later restoration

## Test plan
- [ ] Start a long-running process in the shell pane (e.g., `sleep 1000`)
- [ ] Press `\` to hide the shell pane
- [ ] Press `Escape` to leave the detail view
- [ ] Re-enter the task detail view
- [ ] Press `\` to show the shell pane
- [ ] Verify the process is still running (`ps aux | grep sleep`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)