### PR TITLE
fix(ui): prevent Enter in filter field from opening task detail view

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1147,7 +1147,7 @@ func (m *AppModel) renderFilterBar() string {
 			parts = append(parts, helpStyle.Render("  (Tab: select project, ↑↓: navigate)"))
 		} else {
 			navHelp := fmt.Sprintf("%s%s%s%s", IconArrowUp(), IconArrowDown(), IconArrowLeft(), IconArrowRight())
-			parts = append(parts, helpStyle.Render(fmt.Sprintf("  (backspace: clear, Enter: select, %s: navigate, [: project)", navHelp)))
+			parts = append(parts, helpStyle.Render(fmt.Sprintf("  (backspace: clear, Enter: done, %s: navigate, [: project)", navHelp)))
 		}
 	} else if m.filterText != "" {
 		parts = append(parts, helpStyle.Render("  (/: edit, Esc: clear)"))
@@ -1377,14 +1377,11 @@ func (m *AppModel) updateFilterMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if keyMsg.String() == "tab" {
-			return m, nil
+			return m, nil // Tab: do nothing if no dropdown
 		}
-		// Enter: select task or exit
+		// Enter: just exit filter mode (user can press Enter again on kanban to select task)
 		m.filterActive, m.showFilterDropdown = false, false
 		m.filterInput.Blur()
-		if task := m.kanban.SelectedTask(); task != nil {
-			return m, m.loadTask(task.ID)
-		}
 		return m, nil
 
 	case "up", "down", "left", "right":


### PR DESCRIPTION
## Summary
- Pressing Enter while focused in the filter input no longer switches to the task detail view
- Enter now only exits filter mode; users can press Enter again on the kanban to open a task
- Updated filter help text from "Enter: select" to "Enter: done" to reflect the new behavior

## Problem
When the filter field was focused and the user pressed Enter, the UI would unexpectedly switch to the task detail view. This was confusing because users expected Enter to simply confirm/apply the filter, not open the currently selected task.

## Solution
Removed the `loadTask()` call from the Enter key handler in filter mode. Now Enter just exits filter mode without any side effects.

## Test plan
- [x] Build passes
- [x] UI tests pass
- [ ] Manual test: type in filter, press Enter - should stay on dashboard with filter applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)