### PR TITLE
fix(executor): handle repos without main/master branch in worktree creation

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4072,7 +4072,19 @@ func (e *Executor) getDefaultBranch(projectDir string) string {
 		}
 	}
 
-	return "main" // Default to main
+	// Fallback: get current branch name (whatever branch HEAD points to)
+	cmd = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = projectDir
+	if output, err := cmd.Output(); err == nil {
+		branch := strings.TrimSpace(string(output))
+		if branch != "" && branch != "HEAD" {
+			return branch
+		}
+	}
+
+	// Last resort: use HEAD directly (works even for detached HEAD or unnamed branches)
+	// This ensures worktree creation succeeds as long as there's at least one commit
+	return "HEAD"
 }
 
 // updateTaskPRInfo fetches and updates PR information for a task if a PR exists for the branch.


### PR DESCRIPTION
## Summary

- Fix worktree creation failing with `fatal: not a valid object name: 'main'` when the project doesn't have a `main` or `master` branch
- Add fallback to use current branch name before defaulting to HEAD

## Root Cause

The `getDefaultBranch` function would return `"main"` even when that branch doesn't exist, causing worktree creation to fail for projects like "personal" that only have task branches.

## Test plan

- [x] Build succeeds
- [x] All executor tests pass
- [ ] Create a task in the "personal" project to verify worktree creation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)