### PR TITLE
fix(cli): handle newline characters correctly in CLI input

### DIFF
--- a/cmd/task/cli_test.go
+++ b/cmd/task/cli_test.go
@@ -1117,3 +1117,67 @@ func TestFormatToolLogMessage(t *testing.T) {
 		})
 	}
 }
+
+// TestUnescapeNewlines tests the unescapeNewlines function for CLI input handling.
+func TestUnescapeNewlines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no newlines",
+			input:    "simple text",
+			expected: "simple text",
+		},
+		{
+			name:     "single literal newline",
+			input:    "line1\\nline2",
+			expected: "line1\nline2",
+		},
+		{
+			name:     "multiple literal newlines",
+			input:    "line1\\nline2\\nline3",
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "newline at start",
+			input:    "\\nline2",
+			expected: "\nline2",
+		},
+		{
+			name:     "newline at end",
+			input:    "line1\\n",
+			expected: "line1\n",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only newlines",
+			input:    "\\n\\n\\n",
+			expected: "\n\n\n",
+		},
+		{
+			name:     "actual newlines preserved",
+			input:    "line1\nline2",
+			expected: "line1\nline2",
+		},
+		{
+			name:     "mixed literal and actual newlines",
+			input:    "line1\\nline2\nline3",
+			expected: "line1\nline2\nline3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := unescapeNewlines(tt.input)
+			if result != tt.expected {
+				t.Errorf("unescapeNewlines(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -370,6 +370,7 @@ Examples:
 				title = args[0]
 			}
 			body, _ := cmd.Flags().GetString("body")
+			body = unescapeNewlines(body) // Convert literal \n to actual newlines
 			taskType, _ := cmd.Flags().GetString("type")
 			project, _ := cmd.Flags().GetString("project")
 			taskExecutor, _ := cmd.Flags().GetString("executor")
@@ -986,6 +987,7 @@ Examples:
 
 			title, _ := cmd.Flags().GetString("title")
 			body, _ := cmd.Flags().GetString("body")
+			body = unescapeNewlines(body) // Convert literal \n to actual newlines
 			taskType, _ := cmd.Flags().GetString("type")
 			project, _ := cmd.Flags().GetString("project")
 
@@ -2969,6 +2971,12 @@ func formatLogEntry(entry map[string]interface{}) string {
 	}
 
 	return ""
+}
+
+// unescapeNewlines converts literal "\n" sequences to actual newline characters
+// in CLI input. This allows users to enter multi-line text from the command line.
+func unescapeNewlines(s string) string {
+	return strings.ReplaceAll(s, "\\n", "\n")
 }
 
 // truncate shortens a string to maxLen, adding ellipsis if needed.


### PR DESCRIPTION
## Summary

- Add `unescapeNewlines` helper function to convert literal `\n` sequences to actual newline characters
- Apply newline conversion to `--body` flag in both `create` and `update` commands
- Add comprehensive tests for the newline conversion function

## Test plan

- [x] All existing tests pass
- [x] New `TestUnescapeNewlines` tests pass
- [x] Build succeeds

Example usage:
```bash
# Before: literal \n was stored as-is
ty create "Test task" --body "line1\nline2"
# After: actual newlines are stored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)