### PR TITLE
Update detail view status on execute

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -777,7 +777,16 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		cmds = append(cmds, m.loadTasks())
 
-	case taskQueuedMsg, taskClosedMsg, taskArchivedMsg, taskDeletedMsg, taskRetriedMsg, taskStatusChangedMsg:
+	case taskQueuedMsg:
+		if msg.err == nil && m.selectedTask != nil && m.detailView != nil {
+			if task, err := m.db.GetTask(m.selectedTask.ID); err == nil && task != nil {
+				m.selectedTask = task
+				m.detailView.UpdateTask(task)
+			}
+		}
+		cmds = append(cmds, m.loadTasks())
+
+	case taskClosedMsg, taskArchivedMsg, taskDeletedMsg, taskRetriedMsg, taskStatusChangedMsg:
 		cmds = append(cmds, m.loadTasks())
 
 	case taskDangerousModeToggledMsg:

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -202,10 +202,23 @@ func (m *DetailModel) Refresh() {
 		return
 	}
 
+	prevTask := m.task
+
 	// Reload task
 	task, err := m.database.GetTask(m.task.ID)
 	if err == nil && task != nil {
 		m.task = task
+	}
+
+	if m.ready && prevTask != nil && m.task != nil {
+		if prevTask.Status != m.task.Status ||
+			prevTask.DangerousMode != m.task.DangerousMode ||
+			prevTask.Pinned != m.task.Pinned ||
+			prevTask.Project != m.task.Project ||
+			prevTask.Type != m.task.Type ||
+			prevTask.Title != m.task.Title {
+			m.viewport.SetContent(m.renderContent())
+		}
 	}
 
 	// Check log count first to avoid loading all logs if unchanged


### PR DESCRIPTION
## Summary
- refresh detail view content when task metadata changes
- reload selected task after queueing so status updates immediately

## Testing
- make test (fails: Go toolchain version mismatch: go1.24.4 vs go1.25.5)