### PR TITLE
Make highlighted task background span full column width

### DIFF
--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -551,7 +551,7 @@ func (k *KanbanBoard) viewDesktop() string {
 		for i := 0; i < pinnedSlots; i++ {
 			task := pinnedTasks[i]
 			isSelected := isSelectedCol && i == k.selectedRow
-			taskView := k.renderTaskCard(task, colWidth-2, isSelected)
+			taskView := k.renderTaskCard(task, colWidth, isSelected)
 			taskViews = append(taskViews, taskView)
 		}
 
@@ -570,7 +570,7 @@ func (k *KanbanBoard) viewDesktop() string {
 			task := unpinnedTasks[i]
 			globalIndex := pinnedCount + i
 			isSelected := isSelectedCol && globalIndex == k.selectedRow
-			taskView := k.renderTaskCard(task, colWidth-2, isSelected)
+			taskView := k.renderTaskCard(task, colWidth, isSelected)
 			taskViews = append(taskViews, taskView)
 		}
 
@@ -730,7 +730,7 @@ func (k *KanbanBoard) viewMobile() string {
 	for i := 0; i < toRenderPinned; i++ {
 		task := pinnedTasks[i]
 		isSelected := i == k.selectedRow
-		taskView := k.renderTaskCard(task, colWidth-2, isSelected)
+		taskView := k.renderTaskCard(task, colWidth, isSelected)
 		taskViews = append(taskViews, taskView)
 	}
 
@@ -749,7 +749,7 @@ func (k *KanbanBoard) viewMobile() string {
 		task := unpinnedTasks[i]
 		globalIndex := len(pinnedTasks) + i
 		isSelected := globalIndex == k.selectedRow
-		taskView := k.renderTaskCard(task, colWidth-2, isSelected)
+		taskView := k.renderTaskCard(task, colWidth, isSelected)
 		taskViews = append(taskViews, taskView)
 	}
 


### PR DESCRIPTION
## Summary
- Task card backgrounds now fill the entire column width when selected
- Changed `renderTaskCard` width parameter from `colWidth-2` to `colWidth` in both desktop and mobile views
- Ensures a cleaner visual appearance for the selected task highlight

## Test plan
- [ ] Run `task` command and navigate the kanban board
- [ ] Verify the selected task background extends to the full column width
- [ ] Test in both desktop (wide) and mobile (narrow) terminal widths
- [ ] Confirm all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)