### PR TITLE
Change jump-to-notification shortcut from ctrl+g to ctrl+j

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -71,7 +71,7 @@ type KeyMap struct {
 	OpenWorktree key.Binding
 	ToggleShellPane          key.Binding
 	JumpToNotification       key.Binding
-	JumpToNotificationDetail key.Binding // For detail view (uses Ctrl+g to avoid conflicting with text input)
+	JumpToNotificationDetail key.Binding // For detail view (uses Ctrl+j to avoid conflicting with text input and Claude Code's Ctrl+g)
 	// Column focus shortcuts
 	FocusBacklog    key.Binding
 	FocusInProgress key.Binding
@@ -205,8 +205,8 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("g", "go to notification"),
 		),
 		JumpToNotificationDetail: key.NewBinding(
-			key.WithKeys("ctrl+g"),
-			key.WithHelp("ctrl+g", "go to notification"),
+			key.WithKeys("ctrl+j"),
+			key.WithHelp("ctrl+j", "go to notification"),
 		),
 		FocusBacklog: key.NewBinding(
 			key.WithKeys("B"),
@@ -1606,7 +1606,7 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Handle jump to notification from detail view (Ctrl+g)
+	// Handle jump to notification from detail view (Ctrl+j)
 	if key.Matches(keyMsg, m.keys.JumpToNotificationDetail) {
 		if m.notifyTaskID > 0 && m.notification != "" {
 			taskID := m.notifyTaskID

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -730,9 +730,9 @@ func TestJumpToNotificationKey_DetailView(t *testing.T) {
 		t.Error("expected detail view to have notification before key press")
 	}
 
-	// Press Ctrl+g to jump to notification
-	ctrlGMsg := tea.KeyMsg{Type: tea.KeyCtrlG}
-	model, _ := m.updateDetail(ctrlGMsg)
+	// Press Ctrl+j to jump to notification
+	ctrlJMsg := tea.KeyMsg{Type: tea.KeyCtrlJ}
+	model, _ := m.updateDetail(ctrlJMsg)
 	am := model.(*AppModel)
 
 	// Notification should be cleared
@@ -779,9 +779,9 @@ func TestJumpToNotificationKey_DetailView_NoNotification(t *testing.T) {
 		height: 50,
 	}
 
-	// Press Ctrl+g when no notification is active
-	ctrlGMsg := tea.KeyMsg{Type: tea.KeyCtrlG}
-	_, cmd := m.updateDetail(ctrlGMsg)
+	// Press Ctrl+j when no notification is active
+	ctrlJMsg := tea.KeyMsg{Type: tea.KeyCtrlJ}
+	_, cmd := m.updateDetail(ctrlJMsg)
 
 	// Should return nil command since there's no notification
 	if cmd != nil {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2293,7 +2293,7 @@ func (m *DetailModel) renderHeader() string {
 			Background(lipgloss.Color("#4B5563")). // Muted gray background
 			Foreground(lipgloss.Color("#FFCC00")). // Yellow text
 			Padding(0, 1)
-		notifyIndicator := notifyStyle.Render(fmt.Sprintf("%s Task #%d (ctrl+g)", IconBlocked(), m.notifyTaskID))
+		notifyIndicator := notifyStyle.Render(fmt.Sprintf("%s Task #%d (ctrl+j)", IconBlocked(), m.notifyTaskID))
 
 		// Add notification with spacing
 		firstLine = metaStr + "  " + notifyIndicator
@@ -2543,7 +2543,7 @@ func (m *DetailModel) renderHelp() string {
 
 	// Show jump to notification shortcut when there's an active notification
 	if m.HasNotification() {
-		keys = append(keys, helpKey{"ctrl+g", "jump to notification", false})
+		keys = append(keys, helpKey{"ctrl+j", "jump to notification", false})
 	}
 
 	keys = append(keys, []helpKey{


### PR DESCRIPTION
## Summary
- Changed the detail view's jump-to-notification shortcut from `ctrl+g` to `ctrl+j`
- This resolves a conflict with Claude Code's `ctrl+g` shortcut for opening an editor to compose multi-line prompts

## Changes
- `internal/ui/app.go`: Updated key binding definition and comments
- `internal/ui/detail.go`: Updated notification indicator and help text
- `internal/ui/app_test.go`: Updated tests to use `ctrl+j`

## Test plan
- [x] All existing tests pass
- [x] Build compiles successfully
- [ ] Manual test: press `ctrl+j` in detail view when notification is active to verify jump works

🤖 Generated with [Claude Code](https://claude.com/claude-code)