### PR TITLE
Show recently visited tasks first in Ctrl+P picker

### DIFF
--- a/internal/db/dependencies.go
+++ b/internal/db/dependencies.go
@@ -111,7 +111,7 @@ func (db *DB) GetBlockers(taskID int64) ([]*Task, error) {
 		       COALESCE(t.pr_url, ''), COALESCE(t.pr_number, 0),
 		       COALESCE(t.dangerous_mode, 0), COALESCE(t.pinned, 0), COALESCE(t.tags, ''), COALESCE(t.summary, ''),
 		       t.created_at, t.updated_at, t.started_at, t.completed_at,
-		       t.last_distilled_at
+		       t.last_distilled_at, t.last_accessed_at
 		FROM tasks t
 		JOIN task_dependencies d ON t.id = d.blocker_id
 		WHERE d.blocked_id = ?
@@ -135,7 +135,7 @@ func (db *DB) GetBlockedBy(taskID int64) ([]*Task, error) {
 		       COALESCE(t.pr_url, ''), COALESCE(t.pr_number, 0),
 		       COALESCE(t.dangerous_mode, 0), COALESCE(t.pinned, 0), COALESCE(t.tags, ''), COALESCE(t.summary, ''),
 		       t.created_at, t.updated_at, t.started_at, t.completed_at,
-		       t.last_distilled_at
+		       t.last_distilled_at, t.last_accessed_at
 		FROM tasks t
 		JOIN task_dependencies d ON t.id = d.blocked_id
 		WHERE d.blocker_id = ?
@@ -309,7 +309,7 @@ func scanTaskRows(rows *sql.Rows) ([]*Task, error) {
 			&t.PRURL, &t.PRNumber,
 			&t.DangerousMode, &t.Pinned, &t.Tags, &t.Summary,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
-			&t.LastDistilledAt,
+			&t.LastDistilledAt, &t.LastAccessedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan task: %w", err)

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -242,6 +242,8 @@ func (db *DB) migrate() error {
 		`ALTER TABLE tasks ADD COLUMN shell_pane_id TEXT DEFAULT ''`,  // tmux pane ID for shell pane (e.g., "%1235")
 		// Auto-generated project context for caching exploration results
 		`ALTER TABLE projects ADD COLUMN context TEXT DEFAULT ''`, // Auto-generated project context (codebase summary, patterns, etc.)
+		// Last accessed timestamp for tracking recently visited tasks in command palette
+		`ALTER TABLE tasks ADD COLUMN last_accessed_at DATETIME`, // When task was last accessed/opened in UI
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2748,6 +2748,12 @@ func (m *AppModel) loadTaskWithOptions(id int64, focusExecutor bool) tea.Cmd {
 		go m.executor.CheckPRStateAndUpdateTask(id)
 	}
 
+	// Update last accessed timestamp (async, don't block UI)
+	if m.db != nil {
+		database := m.db
+		go database.UpdateTaskLastAccessedAt(id)
+	}
+
 	return func() tea.Msg {
 		task, err := m.db.GetTask(id)
 		return taskLoadedMsg{task: task, err: err, focusExecutor: focusExecutor}


### PR DESCRIPTION
## Summary
- When opening the task picker dialog with Ctrl+P, tasks are now sorted by when they were last accessed
- Recently accessed tasks appear first, making it easier to quickly switch between tasks you're actively working on
- Tasks that have never been accessed fall back to sorting by creation date (newest first)

## Changes
- Added `LastAccessedAt` field to Task struct to track when tasks are opened in the UI
- Updated `loadTaskWithOptions` to record access time asynchronously when a task is loaded
- Modified command palette's `filterTasks` to sort by `last_accessed_at` when no search query is entered
- Added database migration for the new `last_accessed_at` column
- Added comprehensive tests for the new sorting behavior

## Test plan
- [x] Unit tests pass for new sorting logic
- [x] All existing tests continue to pass
- [ ] Manual testing: Open Ctrl+P picker, verify tasks are sorted by recency
- [ ] Manual testing: Select a task, close detail view, reopen picker, verify selected task is now first

🤖 Generated with [Claude Code](https://claude.com/claude-code)