### PR TITLE
Improve task archiving to preserve uncommitted changes

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -244,6 +244,11 @@ func (db *DB) migrate() error {
 		`ALTER TABLE projects ADD COLUMN context TEXT DEFAULT ''`, // Auto-generated project context (codebase summary, patterns, etc.)
 		// Last accessed timestamp for tracking recently visited tasks in command palette
 		`ALTER TABLE tasks ADD COLUMN last_accessed_at DATETIME`, // When task was last accessed/opened in UI
+		// Archive state columns for preserving worktree state when archiving
+		`ALTER TABLE tasks ADD COLUMN archive_ref TEXT DEFAULT ''`,           // Git ref storing stashed changes (e.g., "refs/task-archive/123")
+		`ALTER TABLE tasks ADD COLUMN archive_commit TEXT DEFAULT ''`,        // Commit hash at time of archiving
+		`ALTER TABLE tasks ADD COLUMN archive_worktree_path TEXT DEFAULT ''`, // Original worktree path before archiving
+		`ALTER TABLE tasks ADD COLUMN archive_branch_name TEXT DEFAULT ''`,   // Original branch name before archiving
 	}
 
 	for _, m := range alterMigrations {


### PR DESCRIPTION
## Summary

- Task archiving now saves complete git state (including uncommitted changes) to a git ref before removing the worktree
- Tasks can be unarchived to restore their exact code state
- Press 'a' on archived tasks to unarchive them

## Details

### Archive Process
1. Saves all changes (committed, uncommitted, tracked, untracked except ignored) to a git ref (`refs/task-archive/<task-id>`)
2. Stores the archive metadata (ref, commit, original worktree path, branch name) in the database
3. Runs teardown script
4. Removes the worktree with `--force`

### Unarchive Process
1. Recreates the worktree using the same branch (or creates new branch if deleted, or detaches if branch in use)
2. Restores uncommitted changes from the saved ref
3. Runs init script
4. Clears archive state from database

### Edge Cases Handled
- Branch deleted since archiving: Creates new branch from archive commit
- Branch taken by another worktree: Creates detached worktree
- Directory name taken: Generates new unique path
- Branch has new commits: Attempts to apply archived changes as patch

## Test plan
- [x] Tests pass
- [ ] Archive a task with uncommitted changes and verify they're preserved
- [ ] Unarchive a task and verify changes are restored
- [ ] Test edge cases: branch deleted, directory taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)