### PR TITLE
Add dangerous mode and send command to ty-email

### DIFF
--- a/extensions/ty-email/README.md
+++ b/extensions/ty-email/README.md
@@ -169,6 +169,12 @@ echo -e "Subject: Fix the bug\n\nThe login is broken" | ty-email test
 
 # Check status
 ty-email status
+
+# Send an email (for tasks to report results)
+ty-email send --to user@example.com --subject "Results" --body "Task completed!"
+
+# Send with body from stdin
+echo "Task results" | ty-email send --to user@example.com --subject "Results"
 ```
 
 ## Usage Examples
@@ -221,6 +227,38 @@ Subject: What's happening with the checkout fix?
 
 You'll get a status update on matching tasks.
 
+### Send Results from Tasks
+
+Tasks can send results back via email using the `send` command:
+
+```bash
+# Send a simple email
+ty-email send --to user@example.com --subject "Task complete" --body "Results here"
+
+# Pipe content from a command
+cat output.log | ty-email send --to user@example.com --subject "Build results"
+
+# Include task ID for email threading
+ty-email send --to user@example.com --subject "Task #123 done" --task 123 --body "Done!"
+```
+
+This is useful for:
+- Notifying users when long-running tasks complete
+- Sending task output/results back to the original requester
+- Maintaining email thread context with `--task` flag
+
+### Dangerous Mode
+
+Enable dangerous mode to allow tasks to perform destructive operations (like `git push --force`):
+
+```yaml
+taskyou:
+  cli: ty
+  dangerous: true
+```
+
+When enabled, tasks created via email will have the `--dangerous` flag set. Use with caution.
+
 ## Configuration
 
 Config lives at `~/.config/ty-email/config.yaml`:
@@ -248,6 +286,7 @@ classifier:
 
 taskyou:
   cli: ty
+  dangerous: false  # Enable dangerous mode for tasks
 
 security:
   allowed_senders:

--- a/extensions/ty-email/config.example.yaml
+++ b/extensions/ty-email/config.example.yaml
@@ -56,6 +56,7 @@ classifier:
 # TaskYou integration
 taskyou:
   cli: ty  # Path to ty binary
+  dangerous: false  # Enable dangerous mode (allows destructive operations like force pushes)
 
 # Routing rules (optional)
 routing:

--- a/extensions/ty-email/internal/bridge/bridge.go
+++ b/extensions/ty-email/internal/bridge/bridge.go
@@ -99,6 +99,9 @@ func (b *Bridge) CreateTask(action *classifier.Action) (*CreateResult, error) {
 	if action.Execute {
 		args = append(args, "--execute")
 	}
+	if action.Dangerous {
+		args = append(args, "--dangerous")
+	}
 
 	out, err := b.run(args...)
 	if err != nil {

--- a/extensions/ty-email/internal/classifier/classifier.go
+++ b/extensions/ty-email/internal/classifier/classifier.go
@@ -13,11 +13,12 @@ type Action struct {
 	Type ActionType `json:"type"`
 
 	// For "create" action
-	Title   string `json:"title,omitempty"`
-	Body    string `json:"body,omitempty"`
-	Project string `json:"project,omitempty"`
-	TaskType string `json:"task_type,omitempty"` // code, writing, thinking
-	Execute bool   `json:"execute,omitempty"`    // Queue immediately
+	Title     string `json:"title,omitempty"`
+	Body      string `json:"body,omitempty"`
+	Project   string `json:"project,omitempty"`
+	TaskType  string `json:"task_type,omitempty"`  // code, writing, thinking
+	Execute   bool   `json:"execute,omitempty"`    // Queue immediately
+	Dangerous bool   `json:"dangerous,omitempty"`  // Enable dangerous mode (allows destructive operations)
 
 	// For "input" action
 	TaskID    int64  `json:"task_id,omitempty"`


### PR DESCRIPTION
## Summary
- Add `--dangerous` flag support when creating tasks from email
- Update processor to pass `dangerous=true` based on config setting
- Add `taskyou.dangerous` config option for enabling dangerous mode
- Add `ty-email send` CLI command for tasks to email results back
- Document send command and dangerous mode in README

## Test plan
- [ ] Verify `ty-email send --to test@example.com --subject "Test" --body "Hello"` sends email
- [ ] Verify piping works: `echo "Hello" | ty-email send --to test@example.com --subject "Test"`
- [ ] Verify `--task` flag finds thread ID for proper email threading
- [ ] Verify `taskyou.dangerous: true` in config causes created tasks to have `--dangerous` flag
- [ ] Verify config without `dangerous` field defaults to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)