### PR TITLE
Auto-allow taskyou MCP tools in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__taskyou__*"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@
 .env.local
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/settings.json
 .crush/
 
 # Archives


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with permission rule `mcp__taskyou__*` to auto-allow all taskyou MCP tools
- Update `.gitignore` to track `.claude/settings.json` while keeping other `.claude/` files ignored

This eliminates the annoying permission prompts every time Claude Code uses taskyou tools like `taskyou_get_project_context`.

## Test plan
- [ ] Start a new Claude Code session
- [ ] Verify taskyou MCP tools (like `taskyou_get_project_context`) no longer prompt for permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)