### PR TITLE
Add GitHub Issue sync for task/PR number alignment

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -244,6 +244,11 @@ func (db *DB) migrate() error {
 		`ALTER TABLE projects ADD COLUMN context TEXT DEFAULT ''`, // Auto-generated project context (codebase summary, patterns, etc.)
 		// Last accessed timestamp for tracking recently visited tasks in command palette
 		`ALTER TABLE tasks ADD COLUMN last_accessed_at DATETIME`, // When task was last accessed/opened in UI
+		// GitHub Issue tracking for synced task/issue numbers
+		`ALTER TABLE tasks ADD COLUMN issue_url TEXT DEFAULT ''`,      // GitHub Issue URL (created with task for synced numbering)
+		`ALTER TABLE tasks ADD COLUMN issue_number INTEGER DEFAULT 0`, // GitHub Issue number (used for branch naming when synced)
+		// Project setting to enable GitHub Issue sync
+		`ALTER TABLE projects ADD COLUMN sync_github_issues INTEGER DEFAULT 0`, // Whether to create GitHub Issues when tasks are created
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/github/issue.go
+++ b/internal/github/issue.go
@@ -1,0 +1,110 @@
+// Package github provides GitHub integration for issues and PRs.
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// IssueInfo contains information about a created GitHub Issue.
+type IssueInfo struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+}
+
+// ghIssueCreateResponse is the JSON response from gh issue create.
+type ghIssueCreateResponse struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+}
+
+// CreateIssue creates a GitHub Issue for a task and returns the issue information.
+// Uses the gh CLI to create the issue in the repository at repoDir.
+// Returns nil if the gh CLI is not available or the creation fails.
+func CreateIssue(repoDir, title, body string) (*IssueInfo, error) {
+	// Check if gh CLI is available
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil, fmt.Errorf("gh CLI not found: %w", err)
+	}
+
+	// Use timeout to prevent blocking on slow network or GitHub API
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Build arguments
+	args := []string{"issue", "create", "--title", title, "--json", "number,url,title"}
+
+	// Add body if provided
+	if body != "" {
+		args = append(args, "--body", body)
+	} else {
+		// Empty body is required or gh will open an editor
+		args = append(args, "--body", "")
+	}
+
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = repoDir
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh issue create failed: %s", string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("gh issue create failed: %w", err)
+	}
+
+	var resp ghIssueCreateResponse
+	if err := json.Unmarshal(output, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &IssueInfo{
+		Number: resp.Number,
+		URL:    resp.URL,
+		Title:  resp.Title,
+	}, nil
+}
+
+// CloseIssue closes a GitHub Issue by number.
+// Used when a task is completed or archived.
+func CloseIssue(repoDir string, issueNumber int) error {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return fmt.Errorf("gh CLI not found: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "issue", "close", fmt.Sprintf("%d", issueNumber))
+	cmd.Dir = repoDir
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("gh issue close failed: %s", string(exitErr.Stderr))
+		}
+		return fmt.Errorf("gh issue close failed: %w", err)
+	}
+
+	return nil
+}
+
+// IsGitHubRepo checks if the directory is a GitHub repository.
+// Returns true if 'gh repo view' succeeds.
+func IsGitHubRepo(repoDir string) bool {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "name")
+	cmd.Dir = repoDir
+
+	return cmd.Run() == nil
+}

--- a/internal/github/issue_test.go
+++ b/internal/github/issue_test.go
@@ -1,0 +1,51 @@
+package github
+
+import (
+	"testing"
+)
+
+func TestIssueInfoStructure(t *testing.T) {
+	// Verify IssueInfo struct can be created
+	info := IssueInfo{
+		Number: 123,
+		URL:    "https://github.com/test/repo/issues/123",
+		Title:  "Test Issue",
+	}
+
+	if info.Number != 123 {
+		t.Errorf("IssueInfo.Number = %d, want 123", info.Number)
+	}
+	if info.URL != "https://github.com/test/repo/issues/123" {
+		t.Errorf("IssueInfo.URL = %s, want https://github.com/test/repo/issues/123", info.URL)
+	}
+	if info.Title != "Test Issue" {
+		t.Errorf("IssueInfo.Title = %s, want Test Issue", info.Title)
+	}
+}
+
+func TestIsGitHubRepoNoGh(t *testing.T) {
+	// If gh CLI is not available or not in a github repo, should return false
+	// This test just verifies the function doesn't panic
+	result := IsGitHubRepo("/nonexistent/path")
+	// We expect false since the path doesn't exist
+	if result {
+		t.Error("IsGitHubRepo should return false for nonexistent path")
+	}
+}
+
+func TestCreateIssueNoGh(t *testing.T) {
+	// Test that CreateIssue returns an error when not in a valid repo
+	// This test uses a nonexistent path to ensure failure
+	_, err := CreateIssue("/nonexistent/path", "Test", "Body")
+	if err == nil {
+		t.Error("CreateIssue should return an error for nonexistent path")
+	}
+}
+
+func TestCloseIssueNoGh(t *testing.T) {
+	// Test that CloseIssue returns an error when not in a valid repo
+	err := CloseIssue("/nonexistent/path", 123)
+	if err == nil {
+		t.Error("CloseIssue should return an error for nonexistent path")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a new "Sync GitHub Issues" option to project settings
- When enabled, creates a GitHub Issue when a task starts, using that issue number for branch naming
- This keeps task/issue/PR numbers closer together since they share the same numbering sequence

## Problem
Currently, task IDs (auto-increment database IDs like #1017) diverge wildly from PR numbers (GitHub's numbering like #374), which can be confusing when tracking work.

## Solution
By creating a GitHub Issue when a task is started, we get a number from GitHub's shared issue/PR numbering sequence. The branch is then named using that issue number (e.g., `task/375-add-feature`) instead of the internal task ID. When a PR is created from that branch, it will be the next number in the sequence (e.g., #376).

## Changes
- `internal/db/tasks.go`: Added `IssueNumber` and `IssueURL` fields to Task struct
- `internal/db/tasks.go`: Added `SyncGitHubIssues` field to Project struct
- `internal/db/sqlite.go`: Added database migrations for new columns
- `internal/github/issue.go`: New file with GitHub Issue creation via `gh` CLI
- `internal/executor/executor.go`: Modified worktree setup to create issues and use issue numbers for branch naming
- `internal/ui/settings.go`: Added project setting toggle for GitHub Issue sync

## Test plan
- [x] All existing tests pass
- [x] New tests added for issue.go
- [ ] Manual testing: Enable "Sync GitHub Issues" on a project, create a task, verify issue is created and branch uses issue number

🤖 Generated with [Claude Code](https://claude.com/claude-code)