### PR TITLE
Fix attachments UI overlap in task form

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -1350,22 +1350,23 @@ func (m *FormModel) View() string {
 		cursor = cursorStyle.Render("▸")
 	}
 	attachmentInputView := m.attachmentsInput.View()
-	var attachmentChips []string
+	b.WriteString("\n")
+	b.WriteString(cursor + " " + labelStyle.Render("Attachments") + "\n")
 	if len(m.attachments) > 0 {
 		for i, path := range m.attachments {
 			style := AttachmentChip
 			if m.focused == FieldAttachments && m.attachmentSelectionActive() && m.attachmentCursor == i {
 				style = AttachmentChipSelected
 			}
-			attachmentChips = append(attachmentChips, style.Render(filepath.Base(path)))
+			chip := style.Render(filepath.Base(path))
+			for _, line := range strings.Split(chip, "\n") {
+				if line != "" {
+					b.WriteString("   " + line + "\n")
+				}
+			}
 		}
 	}
-	b.WriteString("\n")
-	b.WriteString(cursor + " " + labelStyle.Render("Attachments"))
-	if len(attachmentChips) > 0 {
-		b.WriteString(" " + strings.Join(attachmentChips, " "))
-	}
-	b.WriteString("  " + attachmentInputView + "\n")
+	b.WriteString("   " + attachmentInputView + "\n")
 	if len(m.attachments) > 0 {
 		help := Dim.Render(IconArrowLeft() + "/" + IconArrowRight() + " select • backspace/delete remove")
 		b.WriteString("   " + help + "\n")


### PR DESCRIPTION
## Summary
- Fixed attachment chips overlapping with the file drop zone input in the task form
- Attachment chips (rendered as multi-line bordered boxes via lipgloss) were being concatenated inline with `strings.Join`, causing garbled layout when mixed with the single-line input field
- Each element now renders on its own line: label, vertically stacked chips with proper indentation, then the input field below

## Test plan
- [x] Existing `TestAttachmentRemovalFlow` passes
- [ ] Open task form with attachments and verify chips display without overlap
- [ ] Verify chip selection highlighting still works
- [ ] Verify file drag-and-drop still adds chips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)