### PR TITLE
Add task.worktree_ready event hook

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -875,6 +875,7 @@ func (e *Executor) executeTask(ctx context.Context, task *db.Task) {
 		e.hooks.OnStatusChange(task, db.StatusBlocked, "Worktree setup failed - cannot execute task safely")
 		return
 	}
+	e.events.EmitTaskWorktreeReady(task)
 
 	// Prepare attachments (write to .claude/attachments for seamless access)
 	attachmentPaths, cleanupAttachments := e.prepareAttachments(task.ID, workDir)


### PR DESCRIPTION
## Summary
- Adds a new `task.worktree_ready` event emitted after worktree setup completes, before the AI executor launches
- Hook scripts receive `WORKTREE_PATH`, `WORKTREE_BRANCH`, and `WORKTREE_PORT` env vars (also available on all events when a worktree is set)
- Enables use cases like starting a dev server or installing deps before execution begins

## Test plan
- [x] New test `TestEmitterWorktreeReadyPassesEnv` verifies hook runs with correct env vars
- [x] All existing events tests pass
- [ ] Manual: create `~/.config/task/hooks/task.worktree_ready` script, run a task, verify hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)