### PR TITLE
Add support for Claude agent teams

### DIFF
--- a/internal/db/dependencies.go
+++ b/internal/db/dependencies.go
@@ -111,7 +111,8 @@ func (db *DB) GetBlockers(taskID int64) ([]*Task, error) {
 		       COALESCE(t.pr_url, ''), COALESCE(t.pr_number, 0),
 		       COALESCE(t.dangerous_mode, 0), COALESCE(t.pinned, 0), COALESCE(t.tags, ''), COALESCE(t.summary, ''),
 		       t.created_at, t.updated_at, t.started_at, t.completed_at,
-		       t.last_distilled_at, t.last_accessed_at
+		       t.last_distilled_at, t.last_accessed_at,
+		       COALESCE(t.parent_id, 0)
 		FROM tasks t
 		JOIN task_dependencies d ON t.id = d.blocker_id
 		WHERE d.blocked_id = ?
@@ -135,7 +136,8 @@ func (db *DB) GetBlockedBy(taskID int64) ([]*Task, error) {
 		       COALESCE(t.pr_url, ''), COALESCE(t.pr_number, 0),
 		       COALESCE(t.dangerous_mode, 0), COALESCE(t.pinned, 0), COALESCE(t.tags, ''), COALESCE(t.summary, ''),
 		       t.created_at, t.updated_at, t.started_at, t.completed_at,
-		       t.last_distilled_at, t.last_accessed_at
+		       t.last_distilled_at, t.last_accessed_at,
+		       COALESCE(t.parent_id, 0)
 		FROM tasks t
 		JOIN task_dependencies d ON t.id = d.blocked_id
 		WHERE d.blocker_id = ?
@@ -310,6 +312,7 @@ func scanTaskRows(rows *sql.Rows) ([]*Task, error) {
 			&t.DangerousMode, &t.Pinned, &t.Tags, &t.Summary,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
+			&t.ParentID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan task: %w", err)

--- a/internal/db/teams.go
+++ b/internal/db/teams.go
@@ -1,0 +1,167 @@
+package db
+
+import (
+	"fmt"
+)
+
+// TeamStatus summarizes the progress of a task's child team.
+type TeamStatus struct {
+	Total      int `json:"total"`
+	Queued     int `json:"queued"`
+	Processing int `json:"processing"`
+	Blocked    int `json:"blocked"`
+	Done       int `json:"done"`
+	Backlog    int `json:"backlog"`
+}
+
+// IsComplete returns true if all child tasks are done.
+func (ts *TeamStatus) IsComplete() bool {
+	return ts.Total > 0 && ts.Done == ts.Total
+}
+
+// ActiveCount returns the number of non-done tasks.
+func (ts *TeamStatus) ActiveCount() int {
+	return ts.Total - ts.Done
+}
+
+// GetChildTasks returns all tasks whose parent_id matches the given task ID.
+func (db *DB) GetChildTasks(parentID int64) ([]*Task, error) {
+	rows, err := db.Query(`
+		SELECT id, title, body, status, type, project, COALESCE(executor, 'claude'),
+		       worktree_path, branch_name, port, claude_session_id,
+		       COALESCE(daemon_session, ''), COALESCE(tmux_window_id, ''),
+		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
+		       COALESCE(pr_url, ''), COALESCE(pr_number, 0),
+		       COALESCE(dangerous_mode, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''),
+		       created_at, updated_at, started_at, completed_at,
+		       last_distilled_at, last_accessed_at,
+		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
+		       COALESCE(archive_worktree_path, ''), COALESCE(archive_branch_name, ''),
+		       COALESCE(parent_id, 0)
+		FROM tasks
+		WHERE parent_id = ?
+		ORDER BY created_at ASC
+	`, parentID)
+	if err != nil {
+		return nil, fmt.Errorf("get child tasks: %w", err)
+	}
+	defer rows.Close()
+
+	var tasks []*Task
+	for rows.Next() {
+		t := &Task{}
+		err := rows.Scan(
+			&t.ID, &t.Title, &t.Body, &t.Status, &t.Type, &t.Project, &t.Executor,
+			&t.WorktreePath, &t.BranchName, &t.Port, &t.ClaudeSessionID,
+			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
+			&t.PRURL, &t.PRNumber,
+			&t.DangerousMode, &t.Pinned, &t.Tags,
+			&t.SourceBranch, &t.Summary,
+			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
+			&t.LastDistilledAt, &t.LastAccessedAt,
+			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
+			&t.ParentID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan child task: %w", err)
+		}
+		tasks = append(tasks, t)
+	}
+
+	return tasks, nil
+}
+
+// GetTeamStatus returns an aggregate status of all child tasks for a parent.
+func (db *DB) GetTeamStatus(parentID int64) (*TeamStatus, error) {
+	rows, err := db.Query(`
+		SELECT status, COUNT(*) as cnt
+		FROM tasks
+		WHERE parent_id = ?
+		GROUP BY status
+	`, parentID)
+	if err != nil {
+		return nil, fmt.Errorf("get team status: %w", err)
+	}
+	defer rows.Close()
+
+	ts := &TeamStatus{}
+	for rows.Next() {
+		var status string
+		var count int
+		if err := rows.Scan(&status, &count); err != nil {
+			return nil, fmt.Errorf("scan team status: %w", err)
+		}
+		ts.Total += count
+		switch status {
+		case StatusQueued:
+			ts.Queued = count
+		case StatusProcessing:
+			ts.Processing = count
+		case StatusBlocked:
+			ts.Blocked = count
+		case StatusDone, StatusArchived:
+			ts.Done += count
+		case StatusBacklog:
+			ts.Backlog = count
+		}
+	}
+
+	return ts, nil
+}
+
+// HasChildTasks returns true if the task has any child tasks.
+func (db *DB) HasChildTasks(taskID int64) (bool, error) {
+	var count int
+	err := db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE parent_id = ?`, taskID).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("count child tasks: %w", err)
+	}
+	return count > 0, nil
+}
+
+// GetTeamStatusMap returns a map of parent task IDs to their team statuses.
+// This is used by the UI to efficiently display team indicators on all parent tasks.
+func (db *DB) GetTeamStatusMap() (map[int64]*TeamStatus, error) {
+	rows, err := db.Query(`
+		SELECT parent_id, status, COUNT(*) as cnt
+		FROM tasks
+		WHERE parent_id > 0
+		GROUP BY parent_id, status
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("get team status map: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[int64]*TeamStatus)
+	for rows.Next() {
+		var parentID int64
+		var status string
+		var count int
+		if err := rows.Scan(&parentID, &status, &count); err != nil {
+			return nil, fmt.Errorf("scan team status map: %w", err)
+		}
+
+		ts, ok := result[parentID]
+		if !ok {
+			ts = &TeamStatus{}
+			result[parentID] = ts
+		}
+		ts.Total += count
+		switch status {
+		case StatusQueued:
+			ts.Queued = count
+		case StatusProcessing:
+			ts.Processing = count
+		case StatusBlocked:
+			ts.Blocked = count
+		case StatusDone, StatusArchived:
+			ts.Done += count
+		case StatusBacklog:
+			ts.Backlog = count
+		}
+	}
+
+	return result, nil
+}

--- a/internal/db/teams_test.go
+++ b/internal/db/teams_test.go
@@ -1,0 +1,307 @@
+package db
+
+import (
+	"os"
+	"testing"
+)
+
+func setupTeamsTestDB(t *testing.T) (*DB, func()) {
+	tmpFile, err := os.CreateTemp("", "test-teams-*.db")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	db, err := Open(tmpFile.Name())
+	if err != nil {
+		os.Remove(tmpFile.Name())
+		t.Fatalf("Failed to open database: %v", err)
+	}
+
+	cleanup := func() {
+		db.Close()
+		os.Remove(tmpFile.Name())
+	}
+
+	return db, cleanup
+}
+
+func TestGetChildTasks(t *testing.T) {
+	db, cleanup := setupTeamsTestDB(t)
+	defer cleanup()
+
+	// Create parent task
+	parent := &Task{Title: "Parent Task", Status: StatusProcessing}
+	if err := db.CreateTask(parent); err != nil {
+		t.Fatalf("Failed to create parent: %v", err)
+	}
+
+	// Create child tasks
+	child1 := &Task{Title: "Child 1", Status: StatusQueued, ParentID: parent.ID}
+	child2 := &Task{Title: "Child 2", Status: StatusQueued, ParentID: parent.ID}
+	child3 := &Task{Title: "Child 3", Status: StatusQueued, ParentID: parent.ID}
+	if err := db.CreateTask(child1); err != nil {
+		t.Fatalf("Failed to create child1: %v", err)
+	}
+	if err := db.CreateTask(child2); err != nil {
+		t.Fatalf("Failed to create child2: %v", err)
+	}
+	if err := db.CreateTask(child3); err != nil {
+		t.Fatalf("Failed to create child3: %v", err)
+	}
+
+	// Create unrelated task (should not appear)
+	unrelated := &Task{Title: "Unrelated", Status: StatusBacklog}
+	if err := db.CreateTask(unrelated); err != nil {
+		t.Fatalf("Failed to create unrelated: %v", err)
+	}
+
+	// Get children
+	children, err := db.GetChildTasks(parent.ID)
+	if err != nil {
+		t.Fatalf("Failed to get child tasks: %v", err)
+	}
+
+	if len(children) != 3 {
+		t.Errorf("Expected 3 children, got %d", len(children))
+	}
+
+	// Verify they're in creation order
+	if children[0].Title != "Child 1" {
+		t.Errorf("Expected first child to be 'Child 1', got %q", children[0].Title)
+	}
+	if children[2].Title != "Child 3" {
+		t.Errorf("Expected last child to be 'Child 3', got %q", children[2].Title)
+	}
+
+	// Verify parent has no children fetched via wrong ID
+	noChildren, err := db.GetChildTasks(unrelated.ID)
+	if err != nil {
+		t.Fatalf("Failed to get child tasks for unrelated: %v", err)
+	}
+	if len(noChildren) != 0 {
+		t.Errorf("Expected 0 children for unrelated task, got %d", len(noChildren))
+	}
+}
+
+func TestGetTeamStatus(t *testing.T) {
+	db, cleanup := setupTeamsTestDB(t)
+	defer cleanup()
+
+	// Create parent task
+	parent := &Task{Title: "Parent Task", Status: StatusProcessing}
+	if err := db.CreateTask(parent); err != nil {
+		t.Fatalf("Failed to create parent: %v", err)
+	}
+
+	// Create children with different statuses
+	tasks := []*Task{
+		{Title: "Queued 1", Status: StatusQueued, ParentID: parent.ID},
+		{Title: "Queued 2", Status: StatusQueued, ParentID: parent.ID},
+		{Title: "Processing", Status: StatusProcessing, ParentID: parent.ID},
+		{Title: "Done 1", Status: StatusDone, ParentID: parent.ID},
+		{Title: "Done 2", Status: StatusDone, ParentID: parent.ID},
+	}
+	for _, task := range tasks {
+		if err := db.CreateTask(task); err != nil {
+			t.Fatalf("Failed to create task %q: %v", task.Title, err)
+		}
+	}
+
+	status, err := db.GetTeamStatus(parent.ID)
+	if err != nil {
+		t.Fatalf("Failed to get team status: %v", err)
+	}
+
+	if status.Total != 5 {
+		t.Errorf("Expected total=5, got %d", status.Total)
+	}
+	if status.Queued != 2 {
+		t.Errorf("Expected queued=2, got %d", status.Queued)
+	}
+	if status.Processing != 1 {
+		t.Errorf("Expected processing=1, got %d", status.Processing)
+	}
+	if status.Done != 2 {
+		t.Errorf("Expected done=2, got %d", status.Done)
+	}
+	if status.IsComplete() {
+		t.Error("Expected IsComplete to be false")
+	}
+}
+
+func TestTeamStatusComplete(t *testing.T) {
+	db, cleanup := setupTeamsTestDB(t)
+	defer cleanup()
+
+	parent := &Task{Title: "Parent", Status: StatusProcessing}
+	if err := db.CreateTask(parent); err != nil {
+		t.Fatalf("Failed to create parent: %v", err)
+	}
+
+	// All children done
+	for i := 0; i < 3; i++ {
+		child := &Task{Title: "Done child", Status: StatusDone, ParentID: parent.ID}
+		if err := db.CreateTask(child); err != nil {
+			t.Fatalf("Failed to create child: %v", err)
+		}
+	}
+
+	status, err := db.GetTeamStatus(parent.ID)
+	if err != nil {
+		t.Fatalf("Failed to get team status: %v", err)
+	}
+
+	if !status.IsComplete() {
+		t.Error("Expected IsComplete to be true when all children are done")
+	}
+	if status.ActiveCount() != 0 {
+		t.Errorf("Expected ActiveCount=0, got %d", status.ActiveCount())
+	}
+}
+
+func TestTeamStatusEmpty(t *testing.T) {
+	db, cleanup := setupTeamsTestDB(t)
+	defer cleanup()
+
+	parent := &Task{Title: "No Team", Status: StatusBacklog}
+	if err := db.CreateTask(parent); err != nil {
+		t.Fatalf("Failed to create parent: %v", err)
+	}
+
+	status, err := db.GetTeamStatus(parent.ID)
+	if err != nil {
+		t.Fatalf("Failed to get team status: %v", err)
+	}
+
+	if status.Total != 0 {
+		t.Errorf("Expected total=0, got %d", status.Total)
+	}
+	if status.IsComplete() {
+		t.Error("Expected IsComplete to be false for empty team")
+	}
+}
+
+func TestHasChildTasks(t *testing.T) {
+	db, cleanup := setupTeamsTestDB(t)
+	defer cleanup()
+
+	parent := &Task{Title: "Parent", Status: StatusBacklog}
+	if err := db.CreateTask(parent); err != nil {
+		t.Fatalf("Failed to create parent: %v", err)
+	}
+
+	// No children yet
+	has, err := db.HasChildTasks(parent.ID)
+	if err != nil {
+		t.Fatalf("Failed to check child tasks: %v", err)
+	}
+	if has {
+		t.Error("Expected no children initially")
+	}
+
+	// Add a child
+	child := &Task{Title: "Child", Status: StatusQueued, ParentID: parent.ID}
+	if err := db.CreateTask(child); err != nil {
+		t.Fatalf("Failed to create child: %v", err)
+	}
+
+	has, err = db.HasChildTasks(parent.ID)
+	if err != nil {
+		t.Fatalf("Failed to check child tasks: %v", err)
+	}
+	if !has {
+		t.Error("Expected child tasks to exist")
+	}
+}
+
+func TestGetTeamStatusMap(t *testing.T) {
+	db, cleanup := setupTeamsTestDB(t)
+	defer cleanup()
+
+	// Create two parent tasks
+	parent1 := &Task{Title: "Parent 1", Status: StatusProcessing}
+	parent2 := &Task{Title: "Parent 2", Status: StatusProcessing}
+	if err := db.CreateTask(parent1); err != nil {
+		t.Fatalf("Failed to create parent1: %v", err)
+	}
+	if err := db.CreateTask(parent2); err != nil {
+		t.Fatalf("Failed to create parent2: %v", err)
+	}
+
+	// Children for parent1
+	db.CreateTask(&Task{Title: "P1 Child 1", Status: StatusDone, ParentID: parent1.ID})
+	db.CreateTask(&Task{Title: "P1 Child 2", Status: StatusQueued, ParentID: parent1.ID})
+
+	// Children for parent2
+	db.CreateTask(&Task{Title: "P2 Child 1", Status: StatusDone, ParentID: parent2.ID})
+	db.CreateTask(&Task{Title: "P2 Child 2", Status: StatusDone, ParentID: parent2.ID})
+	db.CreateTask(&Task{Title: "P2 Child 3", Status: StatusDone, ParentID: parent2.ID})
+
+	statusMap, err := db.GetTeamStatusMap()
+	if err != nil {
+		t.Fatalf("Failed to get team status map: %v", err)
+	}
+
+	// Check parent1
+	s1, ok := statusMap[parent1.ID]
+	if !ok {
+		t.Fatal("Expected parent1 in status map")
+	}
+	if s1.Total != 2 {
+		t.Errorf("Parent1: expected total=2, got %d", s1.Total)
+	}
+	if s1.Done != 1 {
+		t.Errorf("Parent1: expected done=1, got %d", s1.Done)
+	}
+	if s1.IsComplete() {
+		t.Error("Parent1: expected IsComplete=false")
+	}
+
+	// Check parent2
+	s2, ok := statusMap[parent2.ID]
+	if !ok {
+		t.Fatal("Expected parent2 in status map")
+	}
+	if s2.Total != 3 {
+		t.Errorf("Parent2: expected total=3, got %d", s2.Total)
+	}
+	if !s2.IsComplete() {
+		t.Error("Parent2: expected IsComplete=true")
+	}
+}
+
+func TestParentIDInTaskCRUD(t *testing.T) {
+	db, cleanup := setupTeamsTestDB(t)
+	defer cleanup()
+
+	// Create parent
+	parent := &Task{Title: "Parent", Status: StatusBacklog}
+	if err := db.CreateTask(parent); err != nil {
+		t.Fatalf("Failed to create parent: %v", err)
+	}
+
+	// Create child with parent_id
+	child := &Task{Title: "Child", Status: StatusQueued, ParentID: parent.ID}
+	if err := db.CreateTask(child); err != nil {
+		t.Fatalf("Failed to create child: %v", err)
+	}
+
+	// Fetch child and verify parent_id
+	fetched, err := db.GetTask(child.ID)
+	if err != nil {
+		t.Fatalf("Failed to get child: %v", err)
+	}
+	if fetched.ParentID != parent.ID {
+		t.Errorf("Expected ParentID=%d, got %d", parent.ID, fetched.ParentID)
+	}
+
+	// Fetch parent and verify no parent_id
+	fetchedParent, err := db.GetTask(parent.ID)
+	if err != nil {
+		t.Fatalf("Failed to get parent: %v", err)
+	}
+	if fetchedParent.ParentID != 0 {
+		t.Errorf("Expected parent ParentID=0, got %d", fetchedParent.ParentID)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `parent_id` column to tasks table enabling parent-child task relationships for agent team orchestration
- Add three new MCP tools: `taskyou_delegate_task` (create subtasks), `taskyou_get_team_status` (monitor progress), and `taskyou_wait_for_task` (poll until subtask completes)
- Add team progress indicators (👥 3/5) and child task links (↑#123) to the kanban UI
- Add comprehensive tests for all new team DB methods

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] 7 new tests in `teams_test.go` covering: GetChildTasks, GetTeamStatus, TeamStatusComplete, TeamStatusEmpty, HasChildTasks, GetTeamStatusMap, ParentIDInTaskCRUD
- [ ] Manual: verify kanban UI shows team indicators for parent tasks
- [ ] Manual: verify MCP delegate_task creates child tasks with correct parent_id
- [ ] Manual: verify MCP get_team_status returns progress for a team

🤖 Generated with [Claude Code](https://claude.com/claude-code)