### PR TITLE
Fix kanban header showing task title instead of 'Tasks'

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1692,7 +1692,7 @@ func (m *DetailModel) breakTmuxPanes(saveHeight bool, resizeTUI bool) {
 	osExec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "M-S-Down").Run()
 
 	// Reset pane title back to main view label
-	osExec.CommandContext(ctx, "tmux", "select-pane", "-t", "task-ui:.0", "-T", "Tasks").Run()
+	osExec.CommandContext(ctx, "tmux", "select-pane", "-t", m.uiSessionName+":.0", "-T", "Tasks").Run()
 
 	// Break the Claude pane back to task-daemon
 	if m.claudePaneID == "" {


### PR DESCRIPTION
## Summary
- Fixed `breakTmuxPanes` using hardcoded `"task-ui:.0"` tmux target instead of `m.uiSessionName + ":.0"`
- The actual session name includes a PID suffix (e.g., `"task-ui-12345"`), so the hardcoded target silently failed to reset the pane title
- After returning from detail view to kanban, the pane border now correctly shows "Tasks" instead of the previous task's title

## Root Cause
In `internal/ui/detail.go:1695`, the tmux `select-pane` command used `"task-ui:.0"` to reset the pane title back to "Tasks". But since the UI session is named `"task-ui-<PID>"` (via `getUISessionName()`), this tmux command couldn't find the target and failed silently, leaving the task detail title (e.g., "Task 1059: ActiveRecord::InvalidForeignKey...") in the pane border.

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/ui/` passes
- [ ] Manual: open a task detail, then press Escape to return to kanban — pane border should show "Tasks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)