### PR TITLE
Fix MCP server name: rename 'workflow' to 'taskyou'

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "workflow": {
+    "taskyou": {
       "args": [
         "mcp-server",
         "--task-id",

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3894,7 +3894,8 @@ func writeWorkflowMCPConfig(worktreePath string, taskID int64) error {
 		mcpServers = make(map[string]interface{})
 	}
 
-	// Add/update the taskyou server
+	// Add/update the taskyou server (and remove old "workflow" name if present)
+	delete(mcpServers, "workflow")
 	mcpServers["taskyou"] = taskyouServer
 	projectConfig["mcpServers"] = mcpServers
 	projects[worktreePath] = projectConfig


### PR DESCRIPTION
## Summary
- Renamed MCP server from `workflow` to `taskyou` in `.mcp.json` project config
- Added migration logic in `writeWorkflowMCPConfig` to clean up old `workflow` entries from `~/.claude.json`
- Added test for the migration of old `workflow` entries

The MCP server was renamed to `taskyou` in the Go code but the `.mcp.json` project config file still referenced the old `workflow` name, causing Claude Code to fail connecting to the MCP server.

## Test plan
- [x] Existing `TestWriteWorkflowMCPConfig` tests pass
- [x] New test `removes old workflow entry and replaces with taskyou` passes
- [x] `TestSymlinkMCPConfig` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)