### PR TITLE
Add ty-feedback: embeddable feedback widget for app prototypes

### DIFF
--- a/extensions/ty-feedback/.gitignore
+++ b/extensions/ty-feedback/.gitignore
@@ -1,0 +1,1 @@
+ty-feedback

--- a/extensions/ty-feedback/README.md
+++ b/extensions/ty-feedback/README.md
@@ -1,0 +1,173 @@
+# ty-feedback
+
+Embeddable feedback widget for deployed app prototypes. Users submit feedback through an in-app widget, which creates tasks in TaskYou for iterative development.
+
+## Quick Start
+
+```bash
+cd extensions/ty-feedback
+go build -o ty-feedback ./cmd
+
+# Copy and edit config
+cp config.example.yaml ~/.config/ty-feedback/config.yaml
+
+# Start the server
+./ty-feedback serve
+```
+
+## How It Works
+
+```
+App Prototype ──widget.js──▶ ty-feedback server ──ty CLI──▶ TaskYou
+     │                            │
+     │  POST /api/feedback        │  ty create "Bug: ..."
+     │◀────── task #42 ──────────▶│
+     │                            │
+     └── user sees confirmation ──┘
+```
+
+1. Add the widget to your app with a script tag
+2. Users click the feedback button to report bugs, request features, or ask questions
+3. Each submission creates a task in TaskYou
+4. Tasks appear in your queue for review and execution
+5. Claude (or another executor) works on the task in an isolated worktree
+
+## Embedding the Widget
+
+Add this script tag to your app's HTML:
+
+```html
+<script src="http://your-server:8090/widget.js"></script>
+```
+
+With API key authentication:
+
+```html
+<script src="http://your-server:8090/widget.js" data-api-key="your-key"></script>
+```
+
+Position the button (default: bottom-right):
+
+```html
+<script src="http://your-server:8090/widget.js" data-position="bottom-left"></script>
+```
+
+Generate the snippet:
+
+```bash
+./ty-feedback snippet
+```
+
+## API Endpoints
+
+### POST /api/feedback
+
+Submit feedback (creates a task).
+
+```json
+{
+  "title": "Login button broken",
+  "body": "Clicking login does nothing on mobile Safari",
+  "category": "bug",
+  "url": "https://myapp.example.com/login"
+}
+```
+
+Response:
+
+```json
+{
+  "id": 42,
+  "title": "[Bug report] Login button broken",
+  "status": "backlog",
+  "project": "myapp"
+}
+```
+
+### GET /api/tasks
+
+List tasks for the configured project.
+
+### GET /api/tasks/:id
+
+Get a specific task.
+
+### POST /api/tasks/:id/input
+
+Send input to a blocked task.
+
+```json
+{
+  "input": "Go with option 2"
+}
+```
+
+### GET /widget.js
+
+Serves the embeddable JavaScript widget.
+
+### GET /health
+
+Health check.
+
+## Configuration
+
+Config lives at `~/.config/ty-feedback/config.yaml`:
+
+```yaml
+server:
+  port: 8090
+  project: myapp
+  allowed_origins:
+    - http://localhost:3000
+  api_key: optional-secret
+  default_tags: feedback
+  auto_execute: false
+
+taskyou:
+  cli: ty
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `server.port` | 8090 | HTTP server port |
+| `server.project` | feedback | TaskYou project for created tasks |
+| `server.allowed_origins` | (all) | CORS allowed origins |
+| `server.api_key` | (none) | Bearer token for API auth |
+| `server.default_tags` | (none) | Tags added to all tasks |
+| `server.auto_execute` | false | Queue tasks for immediate execution |
+| `taskyou.cli` | ty | Path to ty binary |
+
+## Deployment
+
+### On the same server as TaskYou
+
+Run ty-feedback alongside TaskYou on the server where your worktrees live:
+
+```bash
+# Start ty-feedback
+./ty-feedback serve &
+
+# Your app prototype runs on another port (e.g., 3000)
+# Feedback widget submits to ty-feedback on port 8090
+# ty-feedback creates tasks via ty CLI
+# TaskYou daemon picks up tasks and executes in worktrees
+```
+
+### With systemd
+
+```ini
+[Unit]
+Description=ty-feedback
+After=network.target
+
+[Service]
+ExecStart=/path/to/ty-feedback serve
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+```

--- a/extensions/ty-feedback/cmd/main.go
+++ b/extensions/ty-feedback/cmd/main.go
@@ -1,0 +1,137 @@
+// Command ty-feedback provides a feedback widget and HTTP API for TaskYou.
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/bborn/workflow/extensions/ty-feedback/internal/bridge"
+	"github.com/bborn/workflow/extensions/ty-feedback/internal/server"
+	"github.com/bborn/workflow/extensions/ty-feedback/internal/widget"
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds the full configuration.
+type Config struct {
+	Server  server.Config `yaml:"server"`
+	TaskYou struct {
+		CLI string `yaml:"cli"`
+	} `yaml:"taskyou"`
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "serve":
+		if err := serve(); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			os.Exit(1)
+		}
+	case "snippet":
+		snippet()
+	case "help", "-h", "--help":
+		printUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func serve() error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	br := bridge.New(cfg.TaskYou.CLI)
+	if !br.IsAvailable() {
+		return fmt.Errorf("ty CLI not found at: %s (is it installed and in PATH?)", cfg.TaskYou.CLI)
+	}
+
+	srv := server.New(br, &cfg.Server, logger)
+	return srv.ListenAndServe()
+}
+
+func snippet() {
+	cfg, err := loadConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Warning: could not load config:", err)
+		fmt.Println(widget.ScriptTag("http://localhost:8090", ""))
+		return
+	}
+
+	url := fmt.Sprintf("http://localhost:%d", cfg.Server.Port)
+	fmt.Println("Add this to your HTML:")
+	fmt.Println()
+	fmt.Println("  " + widget.ScriptTag(url, cfg.Server.APIKey))
+	fmt.Println()
+}
+
+func loadConfig() (*Config, error) {
+	// Check for --config flag
+	path := ""
+	for i, arg := range os.Args {
+		if arg == "--config" && i+1 < len(os.Args) {
+			path = os.Args[i+1]
+			break
+		}
+	}
+
+	if path == "" {
+		home, _ := os.UserHomeDir()
+		path = filepath.Join(home, ".config", "ty-feedback", "config.yaml")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("config not found at %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	// Defaults
+	if cfg.TaskYou.CLI == "" {
+		cfg.TaskYou.CLI = "ty"
+	}
+	if cfg.Server.Port == 0 {
+		cfg.Server.Port = 8090
+	}
+	if cfg.Server.Project == "" {
+		cfg.Server.Project = "feedback"
+	}
+
+	return &cfg, nil
+}
+
+func printUsage() {
+	fmt.Println(`ty-feedback - Feedback widget and API for TaskYou
+
+Usage:
+  ty-feedback serve [--config path]    Start the feedback API server
+  ty-feedback snippet                  Print the HTML snippet to embed the widget
+  ty-feedback help                     Show this help
+
+The server provides:
+  POST /api/feedback     Submit feedback (creates a task)
+  GET  /api/tasks        List tasks for the project
+  GET  /api/tasks/:id    Get task details
+  POST /api/tasks/:id/input  Send input to a blocked task
+  GET  /widget.js        Embeddable JavaScript widget
+  GET  /health           Health check
+
+Config: ~/.config/ty-feedback/config.yaml (or --config path)`)
+}

--- a/extensions/ty-feedback/config.example.yaml
+++ b/extensions/ty-feedback/config.example.yaml
@@ -1,0 +1,20 @@
+server:
+  port: 8090
+  project: myapp
+
+  # Restrict which origins can submit feedback (empty = allow all)
+  allowed_origins:
+    - http://localhost:3000
+    - http://localhost:5173
+
+  # Optional API key for authentication
+  # api_key: your-secret-key
+
+  # Tags added to all feedback tasks
+  default_tags: feedback
+
+  # Automatically queue tasks for execution when submitted
+  auto_execute: false
+
+taskyou:
+  cli: ty

--- a/extensions/ty-feedback/go.mod
+++ b/extensions/ty-feedback/go.mod
@@ -1,0 +1,5 @@
+module github.com/bborn/workflow/extensions/ty-feedback
+
+go 1.22
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/extensions/ty-feedback/go.sum
+++ b/extensions/ty-feedback/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/extensions/ty-feedback/internal/bridge/bridge.go
+++ b/extensions/ty-feedback/internal/bridge/bridge.go
@@ -1,0 +1,158 @@
+// Package bridge provides the interface to TaskYou via the ty CLI.
+package bridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Bridge executes TaskYou commands via the ty CLI.
+type Bridge struct {
+	tyPath string
+}
+
+// New creates a new bridge to TaskYou.
+func New(tyPath string) *Bridge {
+	if tyPath == "" {
+		tyPath = "ty"
+	}
+	return &Bridge{tyPath: tyPath}
+}
+
+// Task represents a task from TaskYou.
+type Task struct {
+	ID      int64  `json:"id"`
+	Title   string `json:"title"`
+	Body    string `json:"body"`
+	Status  string `json:"status"`
+	Project string `json:"project"`
+	Type    string `json:"type"`
+}
+
+// CreateResult is returned when creating a task.
+type CreateResult struct {
+	ID      int64  `json:"id"`
+	Title   string `json:"title"`
+	Status  string `json:"status"`
+	Project string `json:"project"`
+}
+
+// FeedbackInput holds the data needed to create a task from feedback.
+type FeedbackInput struct {
+	Title   string
+	Body    string
+	Project string
+	Type    string
+	Tags    string
+	Execute bool
+}
+
+// CreateTask creates a new task from feedback.
+func (b *Bridge) CreateTask(input *FeedbackInput) (*CreateResult, error) {
+	args := []string{"create", input.Title, "--json"}
+
+	if input.Body != "" {
+		args = append(args, "--body", input.Body)
+	}
+	if input.Project != "" {
+		args = append(args, "--project", input.Project)
+	}
+	if input.Type != "" {
+		args = append(args, "--type", input.Type)
+	}
+	if input.Tags != "" {
+		args = append(args, "--tags", input.Tags)
+	}
+	if input.Execute {
+		args = append(args, "--execute")
+	}
+
+	out, err := b.run(args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var result CreateResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse create result: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListTasks returns current tasks, optionally filtered by project and status.
+func (b *Bridge) ListTasks(project, status string) ([]Task, error) {
+	args := []string{"list", "--json", "--all"}
+	if status != "" {
+		args = append(args, "--status", status)
+	}
+
+	out, err := b.run(args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var tasks []Task
+	if err := json.Unmarshal(out, &tasks); err != nil {
+		if strings.TrimSpace(string(out)) == "" || strings.TrimSpace(string(out)) == "[]" {
+			return []Task{}, nil
+		}
+		return nil, fmt.Errorf("failed to parse tasks: %w", err)
+	}
+
+	// Filter by project if specified
+	if project != "" {
+		var filtered []Task
+		for _, t := range tasks {
+			if t.Project == project {
+				filtered = append(filtered, t)
+			}
+		}
+		return filtered, nil
+	}
+
+	return tasks, nil
+}
+
+// GetTask returns a specific task by ID.
+func (b *Bridge) GetTask(id int64) (*Task, error) {
+	out, err := b.run("show", strconv.FormatInt(id, 10), "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	var task Task
+	if err := json.Unmarshal(out, &task); err != nil {
+		return nil, fmt.Errorf("failed to parse task: %w", err)
+	}
+
+	return &task, nil
+}
+
+// SendInput sends input to a blocked task.
+func (b *Bridge) SendInput(taskID int64, input string) error {
+	_, err := b.run("input", strconv.FormatInt(taskID, 10), input)
+	return err
+}
+
+// IsAvailable checks if the ty CLI is available.
+func (b *Bridge) IsAvailable() bool {
+	_, err := exec.LookPath(b.tyPath)
+	return err == nil
+}
+
+// run executes a ty command and returns the output.
+func (b *Bridge) run(args ...string) ([]byte, error) {
+	cmd := exec.Command(b.tyPath, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("ty %s failed: %s", strings.Join(args, " "), string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("ty %s failed: %w", strings.Join(args, " "), err)
+	}
+	return out, nil
+}

--- a/extensions/ty-feedback/internal/bridge/bridge_test.go
+++ b/extensions/ty-feedback/internal/bridge/bridge_test.go
@@ -1,0 +1,24 @@
+package bridge
+
+import (
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	b := New("")
+	if b.tyPath != "ty" {
+		t.Errorf("New(\"\").tyPath = %q, want \"ty\"", b.tyPath)
+	}
+
+	b = New("/usr/local/bin/ty")
+	if b.tyPath != "/usr/local/bin/ty" {
+		t.Errorf("New(\"/usr/local/bin/ty\").tyPath = %q", b.tyPath)
+	}
+}
+
+func TestIsAvailable(t *testing.T) {
+	b := New("nonexistent-binary-that-does-not-exist")
+	if b.IsAvailable() {
+		t.Error("nonexistent binary should not be available")
+	}
+}

--- a/extensions/ty-feedback/internal/server/server.go
+++ b/extensions/ty-feedback/internal/server/server.go
@@ -1,0 +1,342 @@
+// Package server provides the HTTP API for the feedback widget.
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/bborn/workflow/extensions/ty-feedback/internal/bridge"
+	"github.com/bborn/workflow/extensions/ty-feedback/internal/widget"
+)
+
+// Config holds server configuration.
+type Config struct {
+	Port           int      `yaml:"port"`
+	Project        string   `yaml:"project"`
+	AllowedOrigins []string `yaml:"allowed_origins"`
+	APIKey         string   `yaml:"api_key"`
+	DefaultTags    string   `yaml:"default_tags"`
+	AutoExecute    bool     `yaml:"auto_execute"`
+}
+
+// Server is the HTTP server for the feedback widget.
+type Server struct {
+	bridge *bridge.Bridge
+	config *Config
+	logger *slog.Logger
+	mux    *http.ServeMux
+}
+
+// New creates a new feedback server.
+func New(br *bridge.Bridge, cfg *Config, logger *slog.Logger) *Server {
+	s := &Server{
+		bridge: br,
+		config: cfg,
+		logger: logger,
+		mux:    http.NewServeMux(),
+	}
+
+	s.mux.HandleFunc("POST /api/feedback", s.handleFeedback)
+	s.mux.HandleFunc("GET /api/tasks", s.handleListTasks)
+	s.mux.HandleFunc("GET /api/tasks/", s.handleGetTask)
+	s.mux.HandleFunc("POST /api/tasks/", s.handleTaskInput)
+	s.mux.HandleFunc("GET /widget.js", s.handleWidget)
+	s.mux.HandleFunc("GET /health", s.handleHealth)
+
+	return s
+}
+
+// Handler returns the HTTP handler with middleware applied.
+func (s *Server) Handler() http.Handler {
+	return s.corsMiddleware(s.authMiddleware(s.mux))
+}
+
+// ListenAndServe starts the server.
+func (s *Server) ListenAndServe() error {
+	addr := fmt.Sprintf(":%d", s.config.Port)
+	s.logger.Info("feedback server starting", "addr", addr, "project", s.config.Project)
+	return http.ListenAndServe(addr, s.Handler())
+}
+
+// FeedbackRequest is the JSON body for POST /api/feedback.
+type FeedbackRequest struct {
+	Title    string `json:"title"`
+	Body     string `json:"body"`
+	Category string `json:"category"` // bug, feature, question, other
+	URL      string `json:"url"`      // Page URL where feedback was submitted
+	UserInfo string `json:"user"`     // Optional user identifier
+}
+
+// FeedbackResponse is returned after creating feedback.
+type FeedbackResponse struct {
+	ID      int64  `json:"id"`
+	Title   string `json:"title"`
+	Status  string `json:"status"`
+	Project string `json:"project"`
+}
+
+// ErrorResponse is returned on errors.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func (s *Server) handleFeedback(w http.ResponseWriter, r *http.Request) {
+	var req FeedbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Body == "" {
+		s.jsonError(w, "body is required", http.StatusBadRequest)
+		return
+	}
+
+	// Build task title
+	title := req.Title
+	if title == "" {
+		title = buildTitle(req.Category, req.Body)
+	}
+
+	// Build task body with metadata
+	body := req.Body
+	if req.URL != "" || req.UserInfo != "" || req.Category != "" {
+		var meta []string
+		if req.Category != "" {
+			meta = append(meta, fmt.Sprintf("Category: %s", req.Category))
+		}
+		if req.URL != "" {
+			meta = append(meta, fmt.Sprintf("Page: %s", req.URL))
+		}
+		if req.UserInfo != "" {
+			meta = append(meta, fmt.Sprintf("User: %s", req.UserInfo))
+		}
+		body = strings.Join(meta, "\n") + "\n\n" + body
+	}
+
+	// Build tags
+	tags := s.config.DefaultTags
+	if req.Category != "" {
+		if tags != "" {
+			tags += ","
+		}
+		tags += req.Category
+	}
+
+	input := &bridge.FeedbackInput{
+		Title:   title,
+		Body:    body,
+		Project: s.config.Project,
+		Type:    "code",
+		Tags:    tags,
+		Execute: s.config.AutoExecute,
+	}
+
+	result, err := s.bridge.CreateTask(input)
+	if err != nil {
+		s.logger.Error("failed to create task", "error", err)
+		s.jsonError(w, "failed to create task", http.StatusInternalServerError)
+		return
+	}
+
+	s.logger.Info("feedback submitted", "task_id", result.ID, "title", result.Title)
+
+	resp := FeedbackResponse{
+		ID:      result.ID,
+		Title:   result.Title,
+		Status:  result.Status,
+		Project: result.Project,
+	}
+	s.jsonResponse(w, resp, http.StatusCreated)
+}
+
+func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
+	status := r.URL.Query().Get("status")
+	tasks, err := s.bridge.ListTasks(s.config.Project, status)
+	if err != nil {
+		s.logger.Error("failed to list tasks", "error", err)
+		s.jsonError(w, "failed to list tasks", http.StatusInternalServerError)
+		return
+	}
+
+	s.jsonResponse(w, tasks, http.StatusOK)
+}
+
+func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
+	idStr := strings.TrimPrefix(r.URL.Path, "/api/tasks/")
+	// Check if this is a sub-path like /api/tasks/123/input
+	parts := strings.SplitN(idStr, "/", 2)
+	idStr = parts[0]
+
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		s.jsonError(w, "invalid task ID", http.StatusBadRequest)
+		return
+	}
+
+	task, err := s.bridge.GetTask(id)
+	if err != nil {
+		s.jsonError(w, "task not found", http.StatusNotFound)
+		return
+	}
+
+	s.jsonResponse(w, task, http.StatusOK)
+}
+
+func (s *Server) handleTaskInput(w http.ResponseWriter, r *http.Request) {
+	// POST /api/tasks/123/input
+	path := strings.TrimPrefix(r.URL.Path, "/api/tasks/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) != 2 || parts[1] != "input" {
+		s.jsonError(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	id, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		s.jsonError(w, "invalid task ID", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Input string `json:"input"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.bridge.SendInput(id, req.Input); err != nil {
+		s.logger.Error("failed to send input", "task_id", id, "error", err)
+		s.jsonError(w, "failed to send input", http.StatusInternalServerError)
+		return
+	}
+
+	s.jsonResponse(w, map[string]string{"status": "sent"}, http.StatusOK)
+}
+
+func (s *Server) handleWidget(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+
+	apiURL := r.URL.Query().Get("api")
+	if apiURL == "" {
+		// Default to the same origin
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		apiURL = fmt.Sprintf("%s://%s", scheme, r.Host)
+	}
+
+	js := widget.Generate(apiURL, s.config.Project)
+	w.Write([]byte(js))
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	available := s.bridge.IsAvailable()
+	status := http.StatusOK
+	if !available {
+		status = http.StatusServiceUnavailable
+	}
+	s.jsonResponse(w, map[string]interface{}{
+		"status":       "ok",
+		"ty_available": available,
+		"project":      s.config.Project,
+	}, status)
+}
+
+// corsMiddleware adds CORS headers.
+func (s *Server) corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		allowed := false
+
+		if len(s.config.AllowedOrigins) == 0 {
+			// Allow all origins if none specified
+			allowed = true
+		} else {
+			for _, o := range s.config.AllowedOrigins {
+				if o == "*" || o == origin {
+					allowed = true
+					break
+				}
+			}
+		}
+
+		if allowed && origin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.Header().Set("Access-Control-Max-Age", "86400")
+		}
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// authMiddleware checks the API key if configured.
+func (s *Server) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip auth for widget.js and health endpoints
+		if r.URL.Path == "/widget.js" || r.URL.Path == "/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Skip auth for OPTIONS
+		if r.Method == "OPTIONS" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if s.config.APIKey != "" {
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer "+s.config.APIKey {
+				s.jsonError(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) jsonResponse(w http.ResponseWriter, data interface{}, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}
+
+func (s *Server) jsonError(w http.ResponseWriter, msg string, status int) {
+	s.jsonResponse(w, ErrorResponse{Error: msg}, status)
+}
+
+func buildTitle(category, body string) string {
+	prefix := "Feedback"
+	switch category {
+	case "bug":
+		prefix = "Bug report"
+	case "feature":
+		prefix = "Feature request"
+	case "question":
+		prefix = "Question"
+	}
+
+	// Use first line of body as title, truncated
+	firstLine := strings.SplitN(body, "\n", 2)[0]
+	if len(firstLine) > 60 {
+		firstLine = firstLine[:57] + "..."
+	}
+
+	return fmt.Sprintf("[%s] %s", prefix, firstLine)
+}

--- a/extensions/ty-feedback/internal/server/server_test.go
+++ b/extensions/ty-feedback/internal/server/server_test.go
@@ -1,0 +1,212 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/bborn/workflow/extensions/ty-feedback/internal/bridge"
+)
+
+// mockBridge records calls to CreateTask for testing.
+type mockBridge struct {
+	tasks      []bridge.Task
+	createErr  error
+	lastInput  *bridge.FeedbackInput
+	available  bool
+}
+
+func (m *mockBridge) createTask(input *bridge.FeedbackInput) (*bridge.CreateResult, error) {
+	m.lastInput = input
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	return &bridge.CreateResult{
+		ID:      42,
+		Title:   input.Title,
+		Status:  "backlog",
+		Project: input.Project,
+	}, nil
+}
+
+func TestBuildTitle(t *testing.T) {
+	tests := []struct {
+		category string
+		body     string
+		want     string
+	}{
+		{"bug", "Login button broken", "[Bug report] Login button broken"},
+		{"feature", "Dark mode support", "[Feature request] Dark mode support"},
+		{"question", "How does auth work?", "[Question] How does auth work?"},
+		{"other", "Just a thought", "[Feedback] Just a thought"},
+		{"", "No category", "[Feedback] No category"},
+		{"bug", "This is a very long description that should be truncated because it exceeds sixty characters in length", "[Bug report] This is a very long description that should be truncated ..."},
+	}
+
+	for _, tt := range tests {
+		got := buildTitle(tt.category, tt.body)
+		if got != tt.want {
+			t.Errorf("buildTitle(%q, %q) = %q, want %q", tt.category, tt.body, got, tt.want)
+		}
+	}
+}
+
+func TestHandleHealth(t *testing.T) {
+	br := bridge.New("nonexistent-binary-ty")
+	cfg := &Config{Port: 8090, Project: "test"}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	srv := New(br, cfg, logger)
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable && w.Code != http.StatusOK {
+		t.Errorf("health check returned %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if resp["project"] != "test" {
+		t.Errorf("health check project = %v, want test", resp["project"])
+	}
+}
+
+func TestHandleWidget(t *testing.T) {
+	br := bridge.New("ty")
+	cfg := &Config{Port: 8090, Project: "myapp"}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	srv := New(br, cfg, logger)
+
+	req := httptest.NewRequest("GET", "/widget.js", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("widget returned %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if ct := w.Header().Get("Content-Type"); ct != "application/javascript" {
+		t.Errorf("Content-Type = %q, want application/javascript", ct)
+	}
+
+	if !bytes.Contains([]byte(body), []byte("myapp")) {
+		t.Error("widget does not contain project name")
+	}
+}
+
+func TestHandleFeedbackValidation(t *testing.T) {
+	br := bridge.New("ty")
+	cfg := &Config{Port: 8090, Project: "test"}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	srv := New(br, cfg, logger)
+
+	// Missing body
+	body := `{"title":"test"}`
+	req := httptest.NewRequest("POST", "/api/feedback", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("empty body returned %d, want %d", w.Code, http.StatusBadRequest)
+	}
+
+	// Invalid JSON
+	req = httptest.NewRequest("POST", "/api/feedback", bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("invalid json returned %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestCORSMiddleware(t *testing.T) {
+	br := bridge.New("ty")
+	cfg := &Config{
+		Port:           8090,
+		Project:        "test",
+		AllowedOrigins: []string{"http://localhost:3000"},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	srv := New(br, cfg, logger)
+
+	// Allowed origin
+	req := httptest.NewRequest("OPTIONS", "/api/feedback", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("OPTIONS returned %d, want %d", w.Code, http.StatusNoContent)
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "http://localhost:3000" {
+		t.Errorf("CORS origin = %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+
+	// Disallowed origin
+	req = httptest.NewRequest("OPTIONS", "/api/feedback", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Error("CORS should not allow evil.com")
+	}
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	br := bridge.New("ty")
+	cfg := &Config{
+		Port:    8090,
+		Project: "test",
+		APIKey:  "secret-key",
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	srv := New(br, cfg, logger)
+
+	// No auth header
+	req := httptest.NewRequest("GET", "/api/tasks", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no auth returned %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	// Wrong auth
+	req = httptest.NewRequest("GET", "/api/tasks", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("wrong auth returned %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	// Widget should skip auth
+	req = httptest.NewRequest("GET", "/widget.js", nil)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("widget with no auth returned %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Health should skip auth
+	req = httptest.NewRequest("GET", "/health", nil)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Error("health check should not require auth")
+	}
+}

--- a/extensions/ty-feedback/internal/widget/widget.go
+++ b/extensions/ty-feedback/internal/widget/widget.go
@@ -1,0 +1,317 @@
+// Package widget provides the embeddable JavaScript feedback widget.
+package widget
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Generate returns the JavaScript widget code configured for the given API URL.
+func Generate(apiURL, project string) string {
+	js := widgetJS
+	js = strings.ReplaceAll(js, "{{API_URL}}", apiURL)
+	js = strings.ReplaceAll(js, "{{PROJECT}}", project)
+	return js
+}
+
+// ScriptTag returns an HTML script tag to embed the widget.
+func ScriptTag(serverURL, apiKey string) string {
+	tag := fmt.Sprintf(`<script src="%s/widget.js"`, serverURL)
+	if apiKey != "" {
+		tag += fmt.Sprintf(` data-api-key="%s"`, apiKey)
+	}
+	tag += "></script>"
+	return tag
+}
+
+const widgetJS = `(function() {
+  'use strict';
+
+  var TY_API = '{{API_URL}}';
+  var TY_PROJECT = '{{PROJECT}}';
+
+  // Read config from script tag
+  var scriptTag = document.currentScript;
+  var apiKey = scriptTag ? scriptTag.getAttribute('data-api-key') : '';
+  var position = scriptTag ? (scriptTag.getAttribute('data-position') || 'bottom-right') : 'bottom-right';
+
+  // State
+  var isOpen = false;
+  var submitting = false;
+  var tasks = [];
+
+  // Styles
+  var css = '' +
+    '#ty-feedback-btn {' +
+    '  position: fixed; z-index: 99999;' +
+    '  width: 48px; height: 48px; border-radius: 50%;' +
+    '  background: #6366f1; color: white; border: none; cursor: pointer;' +
+    '  font-size: 20px; display: flex; align-items: center; justify-content: center;' +
+    '  box-shadow: 0 4px 12px rgba(99,102,241,0.4);' +
+    '  transition: transform 0.2s, box-shadow 0.2s;' +
+    '}' +
+    '#ty-feedback-btn:hover { transform: scale(1.1); box-shadow: 0 6px 16px rgba(99,102,241,0.5); }' +
+    '#ty-feedback-panel {' +
+    '  position: fixed; z-index: 99998;' +
+    '  width: 360px; max-height: 500px;' +
+    '  background: #1a1a2e; color: #e0e0e0; border-radius: 12px;' +
+    '  box-shadow: 0 8px 32px rgba(0,0,0,0.3); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;' +
+    '  font-size: 14px; overflow: hidden; display: none; flex-direction: column;' +
+    '}' +
+    '#ty-feedback-panel.open { display: flex; }' +
+    '#ty-feedback-header {' +
+    '  padding: 14px 16px; background: #16213e; border-bottom: 1px solid #2a2a4a;' +
+    '  display: flex; justify-content: space-between; align-items: center; flex-shrink: 0;' +
+    '}' +
+    '#ty-feedback-header h3 { margin: 0; font-size: 14px; font-weight: 600; color: #fff; }' +
+    '#ty-feedback-tabs {' +
+    '  display: flex; gap: 0; border-bottom: 1px solid #2a2a4a; flex-shrink: 0;' +
+    '}' +
+    '.ty-tab {' +
+    '  flex: 1; padding: 8px; text-align: center; cursor: pointer;' +
+    '  background: none; border: none; color: #888; font-size: 12px;' +
+    '  border-bottom: 2px solid transparent; transition: all 0.2s;' +
+    '}' +
+    '.ty-tab:hover { color: #bbb; }' +
+    '.ty-tab.active { color: #6366f1; border-bottom-color: #6366f1; }' +
+    '#ty-feedback-body { padding: 16px; overflow-y: auto; flex: 1; }' +
+    '#ty-feedback-body label { display: block; margin-bottom: 4px; font-size: 12px; color: #999; }' +
+    '#ty-feedback-body select,' +
+    '#ty-feedback-body input,' +
+    '#ty-feedback-body textarea {' +
+    '  width: 100%; padding: 8px 10px; margin-bottom: 12px;' +
+    '  background: #0f0f23; color: #e0e0e0; border: 1px solid #2a2a4a; border-radius: 6px;' +
+    '  font-size: 13px; font-family: inherit; box-sizing: border-box; resize: vertical;' +
+    '}' +
+    '#ty-feedback-body select:focus,' +
+    '#ty-feedback-body input:focus,' +
+    '#ty-feedback-body textarea:focus { outline: none; border-color: #6366f1; }' +
+    '#ty-submit-btn {' +
+    '  width: 100%; padding: 10px; background: #6366f1; color: white;' +
+    '  border: none; border-radius: 6px; cursor: pointer; font-size: 13px; font-weight: 500;' +
+    '  transition: background 0.2s;' +
+    '}' +
+    '#ty-submit-btn:hover { background: #4f46e5; }' +
+    '#ty-submit-btn:disabled { background: #4a4a6a; cursor: not-allowed; }' +
+    '#ty-success { display: none; text-align: center; padding: 20px; }' +
+    '#ty-success .check { font-size: 32px; margin-bottom: 8px; }' +
+    '#ty-tasks-list { list-style: none; padding: 0; margin: 0; }' +
+    '#ty-tasks-list li {' +
+    '  padding: 10px; border-bottom: 1px solid #2a2a4a; cursor: pointer;' +
+    '}' +
+    '#ty-tasks-list li:hover { background: #16213e; }' +
+    '.ty-task-status {' +
+    '  display: inline-block; padding: 2px 6px; border-radius: 4px;' +
+    '  font-size: 10px; font-weight: 600; text-transform: uppercase;' +
+    '}' +
+    '.ty-status-backlog { background: #2a2a4a; color: #888; }' +
+    '.ty-status-queued { background: #1e3a5f; color: #60a5fa; }' +
+    '.ty-status-processing { background: #1e3a1e; color: #4ade80; }' +
+    '.ty-status-blocked { background: #5f3a1e; color: #fb923c; }' +
+    '.ty-status-done { background: #1a2e1a; color: #22c55e; }' +
+    '.ty-close-btn {' +
+    '  background: none; border: none; color: #888; cursor: pointer; font-size: 18px; padding: 0 4px;' +
+    '}' +
+    '.ty-close-btn:hover { color: #fff; }' +
+    '.ty-empty { text-align: center; color: #666; padding: 20px; font-size: 13px; }';
+
+  // Inject styles
+  var style = document.createElement('style');
+  style.textContent = css;
+  document.head.appendChild(style);
+
+  // Position helper
+  function getPositionCSS(pos) {
+    switch(pos) {
+      case 'bottom-left': return 'bottom: 20px; left: 20px;';
+      case 'top-right': return 'top: 20px; right: 20px;';
+      case 'top-left': return 'top: 20px; left: 20px;';
+      default: return 'bottom: 20px; right: 20px;';
+    }
+  }
+
+  function getPanelPositionCSS(pos) {
+    switch(pos) {
+      case 'bottom-left': return 'bottom: 76px; left: 20px;';
+      case 'top-right': return 'top: 76px; right: 20px;';
+      case 'top-left': return 'top: 76px; left: 20px;';
+      default: return 'bottom: 76px; right: 20px;';
+    }
+  }
+
+  // Create button
+  var btn = document.createElement('button');
+  btn.id = 'ty-feedback-btn';
+  btn.setAttribute('style', getPositionCSS(position));
+  btn.innerHTML = '\u2709';
+  btn.title = 'Send Feedback';
+  document.body.appendChild(btn);
+
+  // Create panel
+  var panel = document.createElement('div');
+  panel.id = 'ty-feedback-panel';
+  panel.setAttribute('style', getPanelPositionCSS(position));
+  panel.innerHTML = '' +
+    '<div id="ty-feedback-header">' +
+    '  <h3>Feedback \u2014 ' + escapeHtml(TY_PROJECT) + '</h3>' +
+    '  <button class="ty-close-btn" id="ty-close">\u00d7</button>' +
+    '</div>' +
+    '<div id="ty-feedback-tabs">' +
+    '  <button class="ty-tab active" data-tab="submit">Submit</button>' +
+    '  <button class="ty-tab" data-tab="tasks">Tasks</button>' +
+    '</div>' +
+    '<div id="ty-feedback-body">' +
+    '  <div id="ty-tab-submit">' +
+    '    <div id="ty-form">' +
+    '      <label>Category</label>' +
+    '      <select id="ty-category">' +
+    '        <option value="bug">Bug Report</option>' +
+    '        <option value="feature">Feature Request</option>' +
+    '        <option value="question">Question</option>' +
+    '        <option value="other">Other</option>' +
+    '      </select>' +
+    '      <label>Title (optional)</label>' +
+    '      <input type="text" id="ty-title" placeholder="Brief summary...">' +
+    '      <label>Description</label>' +
+    '      <textarea id="ty-body" rows="4" placeholder="What happened? What did you expect?"></textarea>' +
+    '      <button id="ty-submit-btn">Submit Feedback</button>' +
+    '    </div>' +
+    '    <div id="ty-success">' +
+    '      <div class="check">\u2705</div>' +
+    '      <div>Feedback submitted!</div>' +
+    '      <div style="color:#888;font-size:12px;margin-top:4px">Task <span id="ty-task-id"></span> created</div>' +
+    '      <button id="ty-another-btn" style="margin-top:12px;padding:6px 16px;background:#2a2a4a;color:#e0e0e0;border:none;border-radius:6px;cursor:pointer;">Submit Another</button>' +
+    '    </div>' +
+    '  </div>' +
+    '  <div id="ty-tab-tasks" style="display:none">' +
+    '    <ul id="ty-tasks-list"></ul>' +
+    '  </div>' +
+    '</div>';
+  document.body.appendChild(panel);
+
+  // Event handlers
+  btn.addEventListener('click', function() {
+    isOpen = !isOpen;
+    panel.classList.toggle('open', isOpen);
+    if (isOpen) {
+      btn.innerHTML = '\u2715';
+    } else {
+      btn.innerHTML = '\u2709';
+    }
+  });
+
+  document.getElementById('ty-close').addEventListener('click', function() {
+    isOpen = false;
+    panel.classList.remove('open');
+    btn.innerHTML = '\u2709';
+  });
+
+  // Tabs
+  var tabs = panel.querySelectorAll('.ty-tab');
+  tabs.forEach(function(tab) {
+    tab.addEventListener('click', function() {
+      var target = this.getAttribute('data-tab');
+      tabs.forEach(function(t) { t.classList.remove('active'); });
+      this.classList.add('active');
+      document.getElementById('ty-tab-submit').style.display = target === 'submit' ? 'block' : 'none';
+      document.getElementById('ty-tab-tasks').style.display = target === 'tasks' ? 'block' : 'none';
+      if (target === 'tasks') loadTasks();
+    });
+  });
+
+  // Submit
+  document.getElementById('ty-submit-btn').addEventListener('click', function() {
+    if (submitting) return;
+    var body = document.getElementById('ty-body').value.trim();
+    if (!body) {
+      document.getElementById('ty-body').style.borderColor = '#ef4444';
+      return;
+    }
+    document.getElementById('ty-body').style.borderColor = '#2a2a4a';
+
+    submitting = true;
+    this.disabled = true;
+    this.textContent = 'Submitting...';
+
+    apiRequest('POST', '/api/feedback', {
+      title: document.getElementById('ty-title').value.trim(),
+      body: body,
+      category: document.getElementById('ty-category').value,
+      url: window.location.href,
+      user: ''
+    }, function(data) {
+      submitting = false;
+      document.getElementById('ty-submit-btn').disabled = false;
+      document.getElementById('ty-submit-btn').textContent = 'Submit Feedback';
+      document.getElementById('ty-form').style.display = 'none';
+      document.getElementById('ty-success').style.display = 'block';
+      document.getElementById('ty-task-id').textContent = '#' + data.id;
+    }, function(err) {
+      submitting = false;
+      document.getElementById('ty-submit-btn').disabled = false;
+      document.getElementById('ty-submit-btn').textContent = 'Submit Feedback';
+      alert('Failed to submit: ' + err);
+    });
+  });
+
+  // Reset form
+  document.getElementById('ty-another-btn').addEventListener('click', function() {
+    document.getElementById('ty-form').style.display = 'block';
+    document.getElementById('ty-success').style.display = 'none';
+    document.getElementById('ty-title').value = '';
+    document.getElementById('ty-body').value = '';
+  });
+
+  // Load tasks
+  function loadTasks() {
+    var list = document.getElementById('ty-tasks-list');
+    list.innerHTML = '<li class="ty-empty">Loading...</li>';
+
+    apiRequest('GET', '/api/tasks', null, function(data) {
+      if (!data || data.length === 0) {
+        list.innerHTML = '<li class="ty-empty">No tasks yet</li>';
+        return;
+      }
+      tasks = data;
+      list.innerHTML = '';
+      data.forEach(function(task) {
+        var li = document.createElement('li');
+        li.innerHTML = '<div style="display:flex;justify-content:space-between;align-items:center">' +
+          '<span style="font-weight:500">#' + task.id + '</span>' +
+          '<span class="ty-task-status ty-status-' + task.status + '">' + task.status + '</span>' +
+          '</div>' +
+          '<div style="margin-top:4px;font-size:13px">' + escapeHtml(task.title) + '</div>';
+        list.appendChild(li);
+      });
+    }, function() {
+      list.innerHTML = '<li class="ty-empty">Failed to load tasks</li>';
+    });
+  }
+
+  // API helper
+  function apiRequest(method, path, body, onSuccess, onError) {
+    var xhr = new XMLHttpRequest();
+    xhr.open(method, TY_API + path);
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    if (apiKey) {
+      xhr.setRequestHeader('Authorization', 'Bearer ' + apiKey);
+    }
+    xhr.onload = function() {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try { onSuccess(JSON.parse(xhr.responseText)); }
+        catch(e) { onSuccess(null); }
+      } else {
+        try { onError(JSON.parse(xhr.responseText).error); }
+        catch(e) { onError('Request failed (' + xhr.status + ')'); }
+      }
+    };
+    xhr.onerror = function() { onError('Network error'); };
+    xhr.send(body ? JSON.stringify(body) : null);
+  }
+
+  function escapeHtml(s) {
+    var div = document.createElement('div');
+    div.textContent = s;
+    return div.innerHTML;
+  }
+})();`

--- a/extensions/ty-feedback/internal/widget/widget_test.go
+++ b/extensions/ty-feedback/internal/widget/widget_test.go
@@ -1,0 +1,38 @@
+package widget
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	js := Generate("http://localhost:8090", "myapp")
+
+	if !strings.Contains(js, "http://localhost:8090") {
+		t.Error("widget does not contain API URL")
+	}
+	if !strings.Contains(js, "myapp") {
+		t.Error("widget does not contain project name")
+	}
+	if !strings.Contains(js, "ty-feedback-btn") {
+		t.Error("widget does not contain button ID")
+	}
+	if !strings.Contains(js, "/api/feedback") {
+		t.Error("widget does not contain feedback endpoint")
+	}
+}
+
+func TestScriptTag(t *testing.T) {
+	tag := ScriptTag("http://localhost:8090", "")
+	if !strings.Contains(tag, "http://localhost:8090/widget.js") {
+		t.Errorf("ScriptTag = %q, want to contain widget.js URL", tag)
+	}
+	if strings.Contains(tag, "data-api-key") {
+		t.Error("empty api key should not produce data-api-key attribute")
+	}
+
+	tag = ScriptTag("http://localhost:8090", "secret")
+	if !strings.Contains(tag, `data-api-key="secret"`) {
+		t.Errorf("ScriptTag with key = %q, want data-api-key", tag)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ty-feedback` extension under `extensions/ty-feedback/` — a standalone Go module that provides an embeddable feedback widget for deployed app prototypes
- Users submit bugs, feature requests, and questions through an in-app widget, which creates tasks in TaskYou via the `ty` CLI
- Enables iterative, user-driven development where feedback flows directly into the task queue for execution in isolated worktrees

## Architecture

```
App Prototype ──widget.js──▶ ty-feedback server ──ty CLI──▶ TaskYou
     │                            │
     │  POST /api/feedback        │  ty create "[Bug report] ..."
     │◀────── task #42 ──────────▶│
```

## Components

- **HTTP API server** — `POST /api/feedback`, `GET /api/tasks`, `POST /api/tasks/:id/input`, `GET /health`
- **JavaScript widget** — self-contained, served at `/widget.js`, configurable position and API key auth via data attributes
- **Bridge** — wraps `ty` CLI for task creation and management (follows ty-email pattern)
- **CORS + API key auth** — configurable allowed origins and optional bearer token

## How to use

1. Build: `cd extensions/ty-feedback && go build -o ty-feedback ./cmd`
2. Configure: `cp config.example.yaml ~/.config/ty-feedback/config.yaml`
3. Run: `./ty-feedback serve`
4. Embed: `<script src="http://server:8090/widget.js"></script>`

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] Binary builds and runs
- [ ] Manual test: embed widget in a sample app, submit feedback, verify task creation
- [ ] Manual test: verify CORS works cross-origin
- [ ] Manual test: verify API key auth blocks unauthorized requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)