### PR TITLE
Make task archiving update UI instantly

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -557,6 +557,19 @@ func (db *DB) UpdateTaskPinned(taskID int64, pinned bool) error {
 	return nil
 }
 
+// ClearTaskWorktreePath clears just the worktree_path for a task.
+// Used during async archive cleanup to avoid overwriting other fields.
+func (db *DB) ClearTaskWorktreePath(taskID int64) error {
+	_, err := db.Exec(`
+		UPDATE tasks SET worktree_path = '', updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?
+	`, taskID)
+	if err != nil {
+		return fmt.Errorf("clear task worktree path: %w", err)
+	}
+	return nil
+}
+
 // UpdateTaskDaemonSession updates the tmux daemon session name for a task.
 // This is used to track which daemon session owns the task's tmux window,
 // so we can properly kill the Claude process when the task completes.

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4421,9 +4421,10 @@ func (e *Executor) ArchiveWorktree(task *db.Task) error {
 		}
 	}(task.WorktreePath, paths.configFile)
 
-	// Clear worktree info from task (but keep branch name for unarchiving reference)
-	task.WorktreePath = ""
-	e.db.UpdateTask(task)
+	// Clear worktree path (but keep branch name for unarchiving reference).
+	// Use targeted update to avoid overwriting other fields that may have
+	// changed concurrently (e.g., status set to archived before this runs).
+	e.db.ClearTaskWorktreePath(task.ID)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Move expensive worktree cleanup (git operations, teardown script, worktree removal, process kill) to a background goroutine so the UI updates immediately when archiving a task
- Add `ClearTaskWorktreePath` DB method to avoid a race condition where `ArchiveWorktree`'s `UpdateTask` could overwrite the archived status set moments earlier
- DB status update + notification happen synchronously; everything else runs async

## Test plan
- [ ] Archive a task and verify the UI updates instantly (task disappears from active list)
- [ ] Verify the worktree is cleaned up after a few seconds (check filesystem)
- [ ] Unarchive the same task and verify worktree restoration works correctly
- [ ] Archive a task that has uncommitted changes and verify they're preserved for unarchiving

🤖 Generated with [Claude Code](https://claude.com/claude-code)