### PR TITLE
Allow tasks to share a worktree

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -473,6 +473,7 @@ Examples:
 			tags, _ := cmd.Flags().GetString("tags")
 			pinned, _ := cmd.Flags().GetBool("pinned")
 			branch, _ := cmd.Flags().GetString("branch")
+			shareWorktree, _ := cmd.Flags().GetInt64("share-worktree")
 			outputJSON, _ := cmd.Flags().GetBool("json")
 
 			// Validate that either title or body is provided
@@ -575,15 +576,16 @@ Examples:
 
 			// Create the task
 			task := &db.Task{
-				Title:        title,
-				Body:         body,
-				Status:       status,
-				Type:         taskType,
-				Project:      project,
-				Executor:     taskExecutor,
-				Tags:         tags,
-				Pinned:       pinned,
-				SourceBranch: branch,
+				Title:                title,
+				Body:                 body,
+				Status:               status,
+				Type:                 taskType,
+				Project:              project,
+				Executor:             taskExecutor,
+				Tags:                 tags,
+				Pinned:               pinned,
+				SourceBranch:         branch,
+				SharedWorktreeTaskID: shareWorktree,
 			}
 
 			if err := database.CreateTask(task); err != nil {
@@ -603,12 +605,18 @@ Examples:
 				if task.SourceBranch != "" {
 					output["source_branch"] = task.SourceBranch
 				}
+				if task.SharedWorktreeTaskID > 0 {
+					output["shared_worktree_task_id"] = task.SharedWorktreeTaskID
+				}
 				jsonBytes, _ := json.Marshal(output)
 				fmt.Println(string(jsonBytes))
 			} else {
 				msg := fmt.Sprintf("Created task #%d: %s", task.ID, task.Title)
 				if branch != "" {
 					msg += fmt.Sprintf(" (branch: %s)", branch)
+				}
+				if shareWorktree > 0 {
+					msg += fmt.Sprintf(" (sharing worktree with #%d)", shareWorktree)
 				}
 				if execute {
 					msg += " (queued for execution)"
@@ -625,6 +633,7 @@ Examples:
 	createCmd.Flags().String("tags", "", "Task tags (comma-separated)")
 	createCmd.Flags().Bool("pinned", false, "Pin the task to the top of its column")
 	createCmd.Flags().StringP("branch", "b", "", "Existing branch to checkout for worktree (e.g., fix/ui-overflow)")
+	createCmd.Flags().Int64("share-worktree", 0, "Share worktree with another task by ID (e.g., --share-worktree 42)")
 	createCmd.Flags().Bool("json", false, "Output in JSON format")
 	rootCmd.AddCommand(createCmd)
 

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -251,6 +251,8 @@ func (db *DB) migrate() error {
 		`ALTER TABLE tasks ADD COLUMN archive_branch_name TEXT DEFAULT ''`,   // Original branch name before archiving
 		// Source branch for checking out existing branches in worktrees (e.g., for QA deployments)
 		`ALTER TABLE tasks ADD COLUMN source_branch TEXT DEFAULT ''`, // Existing branch to checkout instead of creating new branch
+		// Shared worktree support - allows multiple tasks to share one worktree
+		`ALTER TABLE tasks ADD COLUMN shared_worktree_task_id INTEGER DEFAULT 0`, // ID of another task whose worktree to share
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2190,6 +2190,7 @@ func (m *AppModel) updateEditTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			updatedTask.Status = m.editingTask.Status
 			updatedTask.WorktreePath = m.editingTask.WorktreePath
 			updatedTask.BranchName = m.editingTask.BranchName
+			updatedTask.SharedWorktreeTaskID = m.editingTask.SharedWorktreeTaskID
 			updatedTask.CreatedAt = m.editingTask.CreatedAt
 			updatedTask.StartedAt = m.editingTask.StartedAt
 			updatedTask.CompletedAt = m.editingTask.CompletedAt
@@ -3507,6 +3508,7 @@ func (m *AppModel) moveTaskToProject(newTaskData *db.Task, oldTask *db.Task) tea
 		newTaskData.Port = 0
 		newTaskData.ClaudeSessionID = ""
 		newTaskData.DaemonSession = ""
+		newTaskData.SharedWorktreeTaskID = 0
 		newTaskData.StartedAt = nil
 		newTaskData.CompletedAt = nil
 		// Keep the status - if it was backlog, stay backlog; if queued, stay queued


### PR DESCRIPTION
## Summary
- Adds `shared_worktree_task_id` field to tasks, allowing multiple tasks to run in the same git worktree directory
- When a task has `shared_worktree_task_id` set, it reuses the referenced task's worktree instead of creating its own
- Cleanup/archive operations are worktree-aware: they skip removing a worktree when other active tasks still use it
- Accessible via MCP (`taskyou_create_task` with `shared_worktree_task_id`), CLI (`task create --share-worktree 42`), and preserved through edit/move operations

## Changes
- **internal/db/tasks.go**: New `SharedWorktreeTaskID` field, `CountTasksSharingWorktree` helper, updated all queries/scans
- **internal/db/sqlite.go**: DB migration for `shared_worktree_task_id` column
- **internal/executor/executor.go**: `setupWorktree` handles shared worktrees; `CleanupWorktree`/`ArchiveWorktree` check shared count before removal
- **internal/mcp/server.go**: `taskyou_create_task` accepts `shared_worktree_task_id` parameter
- **cmd/task/main.go**: `--share-worktree` CLI flag
- **internal/ui/app.go**: Preserve `SharedWorktreeTaskID` during edit and project move

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New tests for `SharedWorktreeTaskID` persistence (create, read, update)
- [x] New tests for `CountTasksSharingWorktree` (active vs done tasks, multiple sharers)
- [x] New test for MCP `taskyou_create_task` with `shared_worktree_task_id`
- [ ] Manual: Create two tasks sharing a worktree via CLI and verify they use the same directory
- [ ] Manual: Archive/cleanup one shared task and verify the worktree is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)