### PR TITLE
Prevent agents from marking tasks as done

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -329,20 +329,17 @@ func (s *Server) handleToolCall(id interface{}, params *toolCallParams) {
 			}
 		}
 
-		// Log the completion
+		// Log the completion summary (but don't move to done - only humans close tasks)
 		s.db.AppendTaskLog(s.taskID, "system", fmt.Sprintf("Task completed: %s", summary))
 
-		// Update task status
-		s.db.UpdateTaskStatus(s.taskID, db.StatusDone)
-
-		// Trigger callback
+		// Trigger callback (signals the agent is done, but doesn't change status to done)
 		if s.onComplete != nil {
 			s.onComplete()
 		}
 
 		s.sendResult(id, toolCallResult{
 			Content: []contentBlock{
-				{Type: "text", Text: "Task marked as complete." + contextReminder},
+				{Type: "text", Text: "Task summary recorded. A human will review and close this task." + contextReminder},
 			},
 		})
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -156,13 +156,16 @@ func TestWorkflowComplete(t *testing.T) {
 		t.Fatalf("unexpected error: %s", resp.Error.Message)
 	}
 
-	// Verify task status was updated
+	// Verify task status was NOT changed to done (only humans close tasks)
 	updatedTask, err := database.GetTask(task.ID)
 	if err != nil {
 		t.Fatalf("failed to get task: %v", err)
 	}
-	if updatedTask.Status != db.StatusDone {
-		t.Errorf("expected status 'done', got '%s'", updatedTask.Status)
+	if updatedTask.Status == db.StatusDone {
+		t.Errorf("expected status to NOT be 'done' (only humans should close tasks), got '%s'", updatedTask.Status)
+	}
+	if updatedTask.Status != db.StatusProcessing {
+		t.Errorf("expected status to remain 'processing', got '%s'", updatedTask.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Removed `UpdateTaskStatus(StatusDone)` from the MCP `taskyou_complete` tool — agents can no longer move tasks to "done"
- Changed executor to move successful agent runs to "backlog" (instead of "done") so a human can review and close
- Updated test to verify `taskyou_complete` does NOT change status to done

Only humans should close tasks. The agent's `taskyou_complete` call now just logs the summary and signals the agent is finished.

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `TestWorkflowComplete` updated to verify status remains `processing` after `taskyou_complete`
- [ ] Manual: run a task, confirm agent finishes but task stays in backlog (not done)
- [ ] Manual: confirm human can still close tasks via UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)