### PR TITLE
Improve GitHub PR state reliability and speed

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -251,6 +251,8 @@ func (db *DB) migrate() error {
 		`ALTER TABLE tasks ADD COLUMN archive_branch_name TEXT DEFAULT ''`,   // Original branch name before archiving
 		// Source branch for checking out existing branches in worktrees (e.g., for QA deployments)
 		`ALTER TABLE tasks ADD COLUMN source_branch TEXT DEFAULT ''`, // Existing branch to checkout instead of creating new branch
+		// Cached PR state as JSON for instant display on startup (avoids waiting for GitHub API)
+		`ALTER TABLE tasks ADD COLUMN pr_info_json TEXT DEFAULT ''`, // JSON blob of github.PRInfo
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4053,6 +4053,7 @@ func (e *Executor) updateTaskPRInfo(task *db.Task, projectDir string) {
 	if prInfo != nil {
 		task.PRURL = prInfo.URL
 		task.PRNumber = prInfo.Number
+		task.PRInfoJSON = github.MarshalPRInfo(prInfo)
 	}
 }
 

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -258,6 +258,74 @@ func TestParseCheckState(t *testing.T) {
 	}
 }
 
+func TestMarshalUnmarshalPRInfo(t *testing.T) {
+	// Test nil
+	if got := MarshalPRInfo(nil); got != "" {
+		t.Errorf("MarshalPRInfo(nil) = %q, want empty", got)
+	}
+	if got := UnmarshalPRInfo(""); got != nil {
+		t.Errorf("UnmarshalPRInfo(\"\") = %v, want nil", got)
+	}
+
+	// Test round-trip
+	original := &PRInfo{
+		Number:     42,
+		URL:        "https://github.com/test/repo/pull/42",
+		State:      PRStateOpen,
+		IsDraft:    false,
+		Title:      "Fix things",
+		CheckState: CheckStatePassing,
+		Mergeable:  "MERGEABLE",
+		Additions:  10,
+		Deletions:  5,
+	}
+
+	jsonStr := MarshalPRInfo(original)
+	if jsonStr == "" {
+		t.Fatal("MarshalPRInfo returned empty string")
+	}
+
+	restored := UnmarshalPRInfo(jsonStr)
+	if restored == nil {
+		t.Fatal("UnmarshalPRInfo returned nil")
+	}
+
+	if restored.Number != original.Number {
+		t.Errorf("Number = %d, want %d", restored.Number, original.Number)
+	}
+	if restored.URL != original.URL {
+		t.Errorf("URL = %q, want %q", restored.URL, original.URL)
+	}
+	if restored.State != original.State {
+		t.Errorf("State = %q, want %q", restored.State, original.State)
+	}
+	if restored.CheckState != original.CheckState {
+		t.Errorf("CheckState = %q, want %q", restored.CheckState, original.CheckState)
+	}
+	if restored.Mergeable != original.Mergeable {
+		t.Errorf("Mergeable = %q, want %q", restored.Mergeable, original.Mergeable)
+	}
+	if restored.Title != original.Title {
+		t.Errorf("Title = %q, want %q", restored.Title, original.Title)
+	}
+
+	// Test invalid JSON
+	if got := UnmarshalPRInfo("not json"); got != nil {
+		t.Errorf("UnmarshalPRInfo(invalid) = %v, want nil", got)
+	}
+
+	// Test merged state round-trip
+	merged := &PRInfo{
+		Number: 42,
+		State:  PRStateMerged,
+	}
+	mergedJSON := MarshalPRInfo(merged)
+	restoredMerged := UnmarshalPRInfo(mergedJSON)
+	if restoredMerged.State != PRStateMerged {
+		t.Errorf("State = %q, want MERGED", restoredMerged.State)
+	}
+}
+
 func TestPRCacheInvalidate(t *testing.T) {
 	cache := NewPRCache()
 


### PR DESCRIPTION
## Summary
- **Persist PR state in database**: Store full PR info as JSON in a new `pr_info_json` column so PR badges display instantly on app startup without waiting for GitHub API calls
- **Faster refresh cycle**: Reduce PR polling interval from 30s to 15s (both cache TTL and UI refresh tick)
- **Always-on refresh**: PR state refreshes continuously regardless of the current view (not just when on the dashboard), and triggers immediately when transitioning back to the dashboard
- **Closed PR tracking**: Batch fetch now includes closed PRs (in addition to open and merged) so closed PR state is reflected accurately

## Test plan
- [x] All existing tests pass
- [x] New test: `TestUpdateTaskPRInfo` validates DB persistence of PR info JSON
- [x] New test: `TestMarshalUnmarshalPRInfo` validates JSON round-trip serialization
- [ ] Manual: Verify PR badges appear instantly on app startup (from DB cache)
- [ ] Manual: Verify PR state updates within ~15s of a GitHub change
- [ ] Manual: Verify merged/closed PR states are reflected in the kanban board

🤖 Generated with [Claude Code](https://claude.com/claude-code)