### PR TITLE
Replace Status button with Edit button in task detail

### DIFF
--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -33,7 +33,6 @@ type KeybindingsConfig struct {
 	Settings           *KeybindingConfig `yaml:"settings,omitempty"`
 	Help               *KeybindingConfig `yaml:"help,omitempty"`
 	Quit               *KeybindingConfig `yaml:"quit,omitempty"`
-	ChangeStatus       *KeybindingConfig `yaml:"change_status,omitempty"`
 	CommandPalette     *KeybindingConfig `yaml:"command_palette,omitempty"`
 	ToggleDangerous    *KeybindingConfig `yaml:"toggle_dangerous,omitempty"`
 	QueueDangerous     *KeybindingConfig `yaml:"queue_dangerous,omitempty"`

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -46,7 +46,6 @@ const (
 	ViewSettings
 	ViewRetry
 	ViewAttachments
-	ViewChangeStatus
 	ViewCommandPalette
 )
 
@@ -69,7 +68,6 @@ type KeyMap struct {
 	Settings           key.Binding
 	Help               key.Binding
 	Quit               key.Binding
-	ChangeStatus       key.Binding
 	CommandPalette     key.Binding
 	ToggleDangerous    key.Binding
 	QueueDangerous     key.Binding
@@ -117,7 +115,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.Enter, k.New, k.Queue, k.QueueDangerous, k.Close},
 		{k.Retry, k.Archive, k.Delete, k.OpenWorktree, k.OpenBrowser, k.Spotlight},
 		{k.Filter, k.CommandPalette, k.Settings},
-		{k.ChangeStatus, k.TogglePin, k.Refresh, k.Help},
+		{k.TogglePin, k.Refresh, k.Help},
 		{k.Quit},
 	}
 }
@@ -192,10 +190,6 @@ func DefaultKeyMap() KeyMap {
 		Quit: key.NewBinding(
 			key.WithKeys("ctrl+c"),
 			key.WithHelp("ctrl+c", "quit"),
-		),
-		ChangeStatus: key.NewBinding(
-			key.WithKeys("S"),
-			key.WithHelp("S", "status"),
 		),
 		CommandPalette: key.NewBinding(
 			key.WithKeys("p", "ctrl+p"),
@@ -333,7 +327,6 @@ func ApplyKeybindingsConfig(km KeyMap, cfg *config.KeybindingsConfig) KeyMap {
 	km.Settings = applyBinding(km.Settings, cfg.Settings)
 	km.Help = applyBinding(km.Help, cfg.Help)
 	km.Quit = applyBinding(km.Quit, cfg.Quit)
-	km.ChangeStatus = applyBinding(km.ChangeStatus, cfg.ChangeStatus)
 	km.CommandPalette = applyBinding(km.CommandPalette, cfg.CommandPalette)
 	km.ToggleDangerous = applyBinding(km.ToggleDangerous, cfg.ToggleDangerous)
 	km.QueueDangerous = applyBinding(km.QueueDangerous, cfg.QueueDangerous)
@@ -477,11 +470,6 @@ type AppModel struct {
 
 	// Attachments view state
 	attachmentsView *AttachmentsModel
-
-	// Change status view state
-	changeStatusForm        *huh.Form
-	changeStatusValue       string
-	pendingChangeStatusTask *db.Task
 
 	// Command palette view state
 	commandPaletteView *CommandPaletteModel
@@ -745,9 +733,6 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.currentView == ViewRetry && m.retryView != nil {
 			return m.updateRetry(msg)
-		}
-		if m.currentView == ViewChangeStatus && m.changeStatusForm != nil {
-			return m.updateChangeStatus(msg)
 		}
 		if m.currentView == ViewCommandPalette && m.commandPaletteView != nil {
 			return m.updateCommandPalette(msg)
@@ -1493,8 +1478,6 @@ func (m *AppModel) View() string {
 		if m.attachmentsView != nil {
 			return m.attachmentsView.View()
 		}
-	case ViewChangeStatus:
-		return m.viewChangeStatus()
 	case ViewCommandPalette:
 		if m.commandPaletteView != nil {
 			return m.commandPaletteView.View()
@@ -2133,11 +2116,6 @@ func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.loading = true
 		return m, m.loadTasks()
 
-	case key.Matches(msg, m.keys.ChangeStatus):
-		if task := m.kanban.SelectedTask(); task != nil {
-			return m.showChangeStatus(task)
-		}
-
 	case key.Matches(msg, m.keys.Help):
 		m.help.ShowAll = !m.help.ShowAll
 		return m, nil
@@ -2678,9 +2656,6 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentView = ViewEditTask
 		return m, m.editTaskForm.Init()
 	}
-	if key.Matches(keyMsg, m.keys.ChangeStatus) && m.selectedTask != nil {
-		return m.showChangeStatus(m.selectedTask)
-	}
 	if key.Matches(keyMsg, m.keys.TogglePin) && m.selectedTask != nil {
 		return m, m.toggleTaskPinned(m.selectedTask.ID)
 	}
@@ -2887,19 +2862,31 @@ func (m *AppModel) updateEditTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Preserve the original task's ID and other fields
 			updatedTask.ID = m.editingTask.ID
-			updatedTask.Status = m.editingTask.Status
 			updatedTask.WorktreePath = m.editingTask.WorktreePath
 			updatedTask.BranchName = m.editingTask.BranchName
 			updatedTask.CreatedAt = m.editingTask.CreatedAt
 			updatedTask.StartedAt = m.editingTask.StartedAt
 			updatedTask.CompletedAt = m.editingTask.CompletedAt
 
+			// Check if status changed
+			statusChanged := updatedTask.Status != m.editingTask.Status
+
 			// Capture old title before clearing editingTask
 			oldTitle := m.editingTask.Title
+			taskID := m.editingTask.ID
 
 			m.editTaskForm = nil
 			m.editingTask = nil
 			m.currentView = m.previousView
+
+			// If status changed, also trigger the status change command
+			// to notify the executor and update the task list
+			if statusChanged {
+				return m, tea.Batch(
+					m.updateTaskWithRename(updatedTask, oldTitle),
+					m.changeTaskStatus(taskID, updatedTask.Status),
+				)
+			}
 			return m, m.updateTaskWithRename(updatedTask, oldTitle)
 		}
 		if form.cancelled {
@@ -3419,133 +3406,6 @@ func (m *AppModel) updateArchiveConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.archiveConfirm.State == huh.StateAborted {
 		m.pendingArchiveTask = nil
 		m.archiveConfirm = nil
-		m.currentView = m.previousView
-		return m, nil
-	}
-
-	return m, cmd
-}
-
-func (m *AppModel) showChangeStatus(task *db.Task) (tea.Model, tea.Cmd) {
-	m.pendingChangeStatusTask = task
-	m.changeStatusValue = task.Status
-
-	// Build status options - exclude the current status
-	// Only include statuses that map to Kanban columns (Processing is system-managed)
-	statusOptions := []huh.Option[string]{}
-	allStatuses := []struct {
-		value string
-		label string
-	}{
-		{db.StatusBacklog, IconBacklog() + " Backlog"},
-		{db.StatusQueued, IconInProgress() + " In Progress"},
-		{db.StatusBlocked, IconBlocked() + " Blocked"},
-		{db.StatusDone, IconDone() + " Done"},
-	}
-
-	for _, s := range allStatuses {
-		if s.value != task.Status {
-			statusOptions = append(statusOptions, huh.NewOption(s.label, s.value))
-		}
-	}
-
-	modalWidth := min(50, m.width-8)
-	m.changeStatusForm = huh.NewForm(
-		huh.NewGroup(
-			huh.NewSelect[string]().
-				Key("status").
-				Title(fmt.Sprintf("Change status for task #%d", task.ID)).
-				Description(task.Title).
-				Options(statusOptions...).
-				Value(&m.changeStatusValue),
-		),
-	).WithTheme(huh.ThemeDracula()).
-		WithWidth(modalWidth - 6).
-		WithShowHelp(true)
-	m.previousView = m.currentView
-	m.currentView = ViewChangeStatus
-	return m, m.changeStatusForm.Init()
-}
-
-func (m *AppModel) viewChangeStatus() string {
-	if m.changeStatusForm == nil {
-		return ""
-	}
-
-	// Modal header
-	header := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(ColorSecondary).
-		MarginBottom(1).
-		Render("⇄ Change Status")
-
-	formView := m.changeStatusForm.View()
-
-	// Modal box with border
-	modalWidth := min(50, m.width-8)
-	modalBox := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorSecondary).
-		Padding(1, 2).
-		Width(modalWidth)
-
-	modalContent := modalBox.Render(lipgloss.JoinVertical(lipgloss.Center, header, formView))
-
-	// Center the modal on screen
-	return lipgloss.NewStyle().
-		Width(m.width).
-		Height(m.height).
-		Align(lipgloss.Center, lipgloss.Center).
-		Render(modalContent)
-}
-
-func (m *AppModel) updateChangeStatus(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Handle escape to cancel
-	if keyMsg, ok := msg.(tea.KeyMsg); ok {
-		if keyMsg.String() == "esc" {
-			m.currentView = m.previousView
-			m.changeStatusForm = nil
-			m.pendingChangeStatusTask = nil
-			return m, nil
-		}
-	}
-
-	// Update the huh form
-	form, cmd := m.changeStatusForm.Update(msg)
-	if f, ok := form.(*huh.Form); ok {
-		m.changeStatusForm = f
-	}
-
-	// Check if form completed
-	if m.changeStatusForm.State == huh.StateCompleted {
-		if m.pendingChangeStatusTask != nil && m.changeStatusValue != "" {
-			taskID := m.pendingChangeStatusTask.ID
-			newStatus := m.changeStatusValue
-
-			// Update the task in the UI immediately for responsiveness
-			m.pendingChangeStatusTask.Status = newStatus
-			m.updateTaskInList(m.pendingChangeStatusTask)
-
-			// Update detail view if showing this task
-			var switchCmd tea.Cmd
-			if m.selectedTask != nil && m.selectedTask.ID == taskID {
-				m.selectedTask.Status = newStatus
-				if m.detailView != nil {
-					switchCmd = m.detailView.UpdateTask(m.selectedTask)
-				}
-			}
-
-			m.pendingChangeStatusTask = nil
-			m.changeStatusForm = nil
-			m.currentView = m.previousView
-			if switchCmd != nil {
-				return m, tea.Batch(switchCmd, m.changeTaskStatus(taskID, newStatus))
-			}
-			return m, m.changeTaskStatus(taskID, newStatus)
-		}
-		// Cancelled or no selection
-		m.pendingChangeStatusTask = nil
-		m.changeStatusForm = nil
 		m.currentView = m.previousView
 		return m, nil
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -29,10 +29,6 @@ func TestDefaultKeyMap(t *testing.T) {
 		t.Error("New key should have help text 'n'")
 	}
 
-	if keys.ChangeStatus.Help().Key != "S" {
-		t.Error("ChangeStatus key should have help text 'S'")
-	}
-
 	if keys.OpenWorktree.Help().Key != "o" {
 		t.Error("OpenWorktree key should have help text 'o'")
 	}
@@ -160,7 +156,6 @@ func TestApplyKeybindingsConfig_AllBindings(t *testing.T) {
 		Settings:           &config.KeybindingConfig{Keys: []string{"S"}, Help: "config"},
 		Help:               &config.KeybindingConfig{Keys: []string{"H"}, Help: "help"},
 		Quit:               &config.KeybindingConfig{Keys: []string{"Q"}, Help: "exit"},
-		ChangeStatus:       &config.KeybindingConfig{Keys: []string{"s"}, Help: "status"},
 		CommandPalette:     &config.KeybindingConfig{Keys: []string{"p"}, Help: "palette"},
 		ToggleDangerous:    &config.KeybindingConfig{Keys: []string{"!"}, Help: "danger"},
 		QueueDangerous:     &config.KeybindingConfig{Keys: []string{"ctrl+x"}, Help: "exec danger"},
@@ -191,90 +186,54 @@ func TestApplyKeybindingsConfig_AllBindings(t *testing.T) {
 	}
 }
 
-func TestShowChangeStatus_OnlyIncludesKanbanStatuses(t *testing.T) {
-	// Create a minimal app model
-	m := &AppModel{
-		width: 100,
-	}
-
-	// Create a task with backlog status
+func TestEditFormIncludesStatusField(t *testing.T) {
 	task := &db.Task{
 		ID:     1,
 		Title:  "Test Task",
 		Status: db.StatusBacklog,
 	}
 
-	// Call showChangeStatus
-	m.showChangeStatus(task)
+	form := NewEditFormModel(nil, task, 100, 50, []string{"claude"})
 
-	// Verify that the form was created
-	if m.changeStatusForm == nil {
-		t.Fatal("changeStatusForm was not created")
+	// Verify that the form has status set to the task's current status
+	if form.status != db.StatusBacklog {
+		t.Errorf("form.status = %q, want %q", form.status, db.StatusBacklog)
 	}
 
-	// Verify that the current view is set correctly
-	if m.currentView != ViewChangeStatus {
-		t.Errorf("currentView = %v, want %v", m.currentView, ViewChangeStatus)
+	// Verify that statuses contains the expected Kanban-mapped statuses
+	expectedStatuses := []string{db.StatusBacklog, db.StatusQueued, db.StatusBlocked, db.StatusDone}
+	if len(form.statuses) != len(expectedStatuses) {
+		t.Fatalf("form.statuses has %d items, want %d", len(form.statuses), len(expectedStatuses))
+	}
+	for i, s := range expectedStatuses {
+		if form.statuses[i] != s {
+			t.Errorf("form.statuses[%d] = %q, want %q", i, form.statuses[i], s)
+		}
 	}
 
-	// Verify that the pending task is set
-	if m.pendingChangeStatusTask != task {
-		t.Error("pendingChangeStatusTask was not set correctly")
+	// Verify GetDBTask returns the form's status
+	dbTask := form.GetDBTask()
+	if dbTask.Status != db.StatusBacklog {
+		t.Errorf("GetDBTask().Status = %q, want %q", dbTask.Status, db.StatusBacklog)
 	}
-
-	// The function should only offer statuses that map to Kanban columns
-	// We verify this by checking that the available statuses are only:
-	// - StatusQueued (In Progress)
-	// - StatusBlocked
-	// - StatusDone
-	// StatusProcessing should NOT be included as it's system-managed
-	// StatusBacklog is excluded because it's the current status
-
-	// Note: We can't directly inspect the form options without accessing
-	// internal huh.Form fields, but we've verified the code only includes
-	// the 4 Kanban-mapped statuses in the allStatuses slice
 }
 
-func TestShowChangeStatus_ExcludesCurrentStatus(t *testing.T) {
-	m := &AppModel{
-		width: 100,
+func TestEditFormStatusChange(t *testing.T) {
+	task := &db.Task{
+		ID:     1,
+		Title:  "Test Task",
+		Status: db.StatusBacklog,
 	}
 
-	tests := []struct {
-		name          string
-		currentStatus string
-	}{
-		{"backlog task", db.StatusBacklog},
-		{"queued task", db.StatusQueued},
-		{"blocked task", db.StatusBlocked},
-		{"done task", db.StatusDone},
-	}
+	form := NewEditFormModel(nil, task, 100, 50, []string{"claude"})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			task := &db.Task{
-				ID:     1,
-				Title:  "Test Task",
-				Status: tt.currentStatus,
-			}
+	// Simulate changing status to "done"
+	form.status = db.StatusDone
+	form.statusIdx = 3
 
-			m.showChangeStatus(task)
-
-			if m.changeStatusForm == nil {
-				t.Fatal("changeStatusForm was not created")
-			}
-
-			// Verify the pending task is set correctly
-			if m.pendingChangeStatusTask != task {
-				t.Error("pendingChangeStatusTask was not set correctly")
-			}
-
-			// The form.Init() updates changeStatusValue to the first available option,
-			// so we verify that it's not the current status (which was excluded)
-			if m.changeStatusValue == tt.currentStatus {
-				t.Errorf("changeStatusValue should not equal current status %q after form init", tt.currentStatus)
-			}
-		})
+	dbTask := form.GetDBTask()
+	if dbTask.Status != db.StatusDone {
+		t.Errorf("GetDBTask().Status = %q after change, want %q", dbTask.Status, db.StatusDone)
 	}
 }
 

--- a/internal/ui/debug.go
+++ b/internal/ui/debug.go
@@ -239,8 +239,6 @@ func viewName(v View) string {
 		return "retry"
 	case ViewAttachments:
 		return "attachments"
-	case ViewChangeStatus:
-		return "change_status"
 	case ViewCommandPalette:
 		return "command_palette"
 	default:

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2856,7 +2856,6 @@ func (m *DetailModel) renderHelp() string {
 	}
 
 	// Always show status change option
-	keys = append(keys, helpKey{"S", "status", false})
 
 	if m.task != nil {
 		pinDesc := "pin task"

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -29,6 +29,7 @@ const (
 	FieldAttachments // Moved after body for proximity - drag works from any field
 	FieldType
 	FieldExecutor
+	FieldStatus // Only shown in edit mode
 	FieldCount
 )
 
@@ -66,6 +67,9 @@ type FormModel struct {
 	executors          []string
 	availableExecutors []string // Original list of available executors (for rebuilding when project changes)
 	queue              bool
+	status             string // Task status (only used in edit mode)
+	statusIdx          int
+	statuses           []string // Available statuses for editing
 	attachments        []string // Parsed file paths
 	attachmentCursor   int      // Index of the currently selected attachment chip
 
@@ -208,6 +212,17 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int, availab
 		taskRefAutocomplete: NewTaskRefAutocompleteModel(database, width-24),
 		attachmentCursor:    -1,
 		showAdvanced:        true, // Always show all fields when editing
+	}
+
+	// Set up status selector for edit mode
+	// Only include statuses that map to Kanban columns (Processing is system-managed)
+	m.statuses = []string{db.StatusBacklog, db.StatusQueued, db.StatusBlocked, db.StatusDone}
+	m.status = task.Status
+	for i, s := range m.statuses {
+		if s == task.Status {
+			m.statusIdx = i
+			break
+		}
 	}
 
 	// Load task types from database
@@ -737,6 +752,11 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.executor = m.executors[m.executorIdx]
 				return m, nil
 			}
+			if m.focused == FieldStatus && len(m.statuses) > 0 {
+				m.statusIdx = (m.statusIdx - 1 + len(m.statuses)) % len(m.statuses)
+				m.status = m.statuses[m.statusIdx]
+				return m, nil
+			}
 
 		case "right":
 			if m.handleAttachmentNavigation(1) {
@@ -758,6 +778,11 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.focused == FieldExecutor && len(m.executors) > 0 {
 				m.executorIdx = (m.executorIdx + 1) % len(m.executors)
 				m.executor = m.executors[m.executorIdx]
+				return m, nil
+			}
+			if m.focused == FieldStatus && len(m.statuses) > 0 {
+				m.statusIdx = (m.statusIdx + 1) % len(m.statuses)
+				m.status = m.statuses[m.statusIdx]
 				return m, nil
 			}
 
@@ -1163,7 +1188,11 @@ func (m *FormModel) rebuildExecutorListForProject() {
 
 // isFieldVisible returns whether a field should be shown in the current view.
 // When showAdvanced is false, only Title and Body are visible.
+// FieldStatus is only visible in edit mode.
 func (m *FormModel) isFieldVisible(field FormField) bool {
+	if field == FieldStatus {
+		return m.isEdit && m.showAdvanced
+	}
 	if m.showAdvanced {
 		return true
 	}
@@ -1689,6 +1718,16 @@ func (m *FormModel) View() string {
 		}
 		b.WriteString(cursor + " " + labelStyle.Render("Executor") + m.renderSelector(m.executors, m.executorIdx, m.focused == FieldExecutor, selectedStyle, optionStyle, dimStyle))
 		b.WriteString("\n\n")
+
+		// Status selector (only in edit mode)
+		if m.isEdit && len(m.statuses) > 0 {
+			cursor = " "
+			if m.focused == FieldStatus {
+				cursor = cursorStyle.Render("▸")
+			}
+			b.WriteString(cursor + " " + labelStyle.Render("Status") + m.renderSelector(m.statuses, m.statusIdx, m.focused == FieldStatus, selectedStyle, optionStyle, dimStyle))
+			b.WriteString("\n\n")
+		}
 	} else {
 		// Show compact summary of defaults and toggle hint
 		b.WriteString("\n")
@@ -1772,7 +1811,9 @@ func (m *FormModel) hasFormData() bool {
 // GetDBTask returns a db.Task from the form values.
 func (m *FormModel) GetDBTask() *db.Task {
 	status := db.StatusBacklog
-	if m.queue {
+	if m.isEdit && m.status != "" {
+		status = m.status
+	} else if m.queue {
 		status = db.StatusQueued
 	}
 


### PR DESCRIPTION
## Summary
- Removed the standalone "S" (status change) modal — status can now be changed directly in the edit form
- Added a Status selector field to the edit form (only visible in edit mode, under advanced fields)
- When status is changed via edit, the executor is notified just like the old status modal did

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All existing tests pass (`go test ./internal/ui/ ./internal/config/`)
- [x] New tests for edit form status field added and passing
- [ ] Manual: Open task detail, press `e` to edit, verify Status field appears with current status
- [ ] Manual: Change status via edit form, verify task moves to correct column
- [ ] Manual: Verify `S` key no longer triggers any action

🤖 Generated with [Claude Code](https://claude.com/claude-code)