### PR TITLE
Fix SQLite database busy error

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -77,7 +77,16 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("create db directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", path)
+	// Pass PRAGMAs via DSN so they are applied to EVERY new connection.
+	// This is critical because SetConnMaxLifetime causes periodic connection
+	// recycling, and PRAGMAs set via Exec() only apply to the initial
+	// connection — new connections from the pool would lack busy_timeout
+	// and fail immediately with SQLITE_BUSY under contention.
+	// Note: the bare _busy_timeout DSN param does NOT work with
+	// modernc.org/sqlite, but _pragma=busy_timeout(N) does.
+	dsn := path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
+
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -93,25 +102,8 @@ func Open(path string) (*DB, error) {
 	// modernc.org/sqlite (pure-Go) uses file I/O instead of mmap for the
 	// WAL shared-memory, so a long-lived connection may cache a stale WAL
 	// index and miss writes from other processes (e.g., CLI commands).
+	// PRAGMAs are re-applied automatically via the DSN _pragma parameters.
 	db.SetConnMaxLifetime(2 * time.Second)
-
-	// Set busy timeout to retry on SQLITE_BUSY instead of failing immediately.
-	// This is critical for the daemon where multiple goroutines update task
-	// status concurrently. Note: _busy_timeout DSN param does NOT work with
-	// modernc.org/sqlite — must use PRAGMA.
-	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
-		return nil, fmt.Errorf("set busy timeout: %w", err)
-	}
-
-	// Enable WAL mode for better concurrent access
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		return nil, fmt.Errorf("enable WAL: %w", err)
-	}
-
-	// Enable foreign keys
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
-	}
 
 	wrapped := &DB{DB: db, path: path}
 

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -75,6 +75,38 @@ func TestBusyTimeoutIsSet(t *testing.T) {
 	}
 }
 
+func TestBusyTimeoutSurvivesConnectionRecycling(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	database, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer database.Close()
+
+	// Force connection recycling by waiting longer than ConnMaxLifetime (2s)
+	time.Sleep(3 * time.Second)
+
+	// After recycling, the new connection should still have busy_timeout
+	var timeout int
+	if err := database.QueryRow("PRAGMA busy_timeout").Scan(&timeout); err != nil {
+		t.Fatalf("failed to query busy_timeout after recycling: %v", err)
+	}
+	if timeout != 5000 {
+		t.Errorf("expected busy_timeout=5000 after connection recycling, got %d", timeout)
+	}
+
+	// Also verify WAL mode persists
+	var journalMode string
+	if err := database.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("failed to query journal_mode after recycling: %v", err)
+	}
+	if journalMode != "wal" {
+		t.Errorf("expected journal_mode=wal after connection recycling, got %s", journalMode)
+	}
+}
+
 func TestPersonalProjectCreation(t *testing.T) {
 	// Create temporary database
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary
- Moved SQLite PRAGMAs (`busy_timeout`, `journal_mode`, `foreign_keys`) from one-time `Exec()` calls to DSN `_pragma` parameters
- This ensures PRAGMAs are applied to **every** new connection, not just the initial one — `SetConnMaxLifetime(2s)` causes periodic connection recycling, and recycled connections were missing `busy_timeout`, causing immediate `SQLITE_BUSY` failures under contention
- Added test verifying `busy_timeout` survives connection recycling

## Test plan
- [x] Existing `TestBusyTimeoutIsSet` passes
- [x] New `TestBusyTimeoutSurvivesConnectionRecycling` passes (waits 3s for recycling, verifies PRAGMA persists)
- [x] Full `go test ./internal/db/` passes
- [x] Full `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)