### PR TITLE
Improve first-time user experience

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -3204,7 +3204,7 @@ func (m tailModel) View() string {
 
 	statusLabels := map[string]string{
 		db.StatusProcessing: "In Progress",
-		db.StatusBlocked:    "Blocked",
+		db.StatusBlocked:    "Needs Input",
 		db.StatusQueued:     "Queued",
 		db.StatusBacklog:    "Backlog",
 		db.StatusDone:       "Done",
@@ -3352,7 +3352,12 @@ func execInTmux() error {
 	cmdStr := strings.Join(args, " ")
 
 	// Set WORKTREE_SESSION_ID env var so child processes use the same session ID
-	envCmd := fmt.Sprintf("WORKTREE_SESSION_ID=%s %s", sessionID, cmdStr)
+	// Also forward WORKTREE_DB_PATH if set, so isolated instances use the correct database
+	envParts := fmt.Sprintf("WORKTREE_SESSION_ID=%s", sessionID)
+	if dbPath := os.Getenv("WORKTREE_DB_PATH"); dbPath != "" {
+		envParts += fmt.Sprintf(" WORKTREE_DB_PATH=%s", dbPath)
+	}
+	envCmd := fmt.Sprintf("%s %s", envParts, cmdStr)
 
 	// Check if session already exists
 	if osexec.Command("tmux", "has-session", "-t", sessionName).Run() == nil {

--- a/cmd/taskd/main.go
+++ b/cmd/taskd/main.go
@@ -40,7 +40,12 @@ func main() {
 	home, _ := os.UserHomeDir()
 
 	if *dbPath == "" {
-		*dbPath = filepath.Join(home, ".local", "share", "task", "tasks.db")
+		// Check for explicit path from environment
+		if p := os.Getenv("WORKTREE_DB_PATH"); p != "" {
+			*dbPath = p
+		} else {
+			*dbPath = filepath.Join(home, ".local", "share", "task", "tasks.db")
+		}
 	}
 	if *hostKey == "" {
 		*hostKey = filepath.Join(home, ".ssh", "task_ed25519")

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -239,7 +239,7 @@ func DefaultKeyMap() KeyMap {
 		),
 		FocusBlocked: key.NewBinding(
 			key.WithKeys("L"),
-			key.WithHelp("L", "blocked"),
+			key.WithHelp("L", "needs input"),
 		),
 		FocusDone: key.NewBinding(
 			key.WithKeys("D"),
@@ -829,11 +829,17 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// If this is the very first run (no tasks, onboarding not completed), auto-open new task form
 			if len(msg.tasks) == 0 && m.db.IsFirstRun() && !m.onboardingShown {
 				m.onboardingShown = true
-				// Auto-open the new task form to guide users to create their first task
-				m.newTaskForm = NewFormModel(m.db, m.width, m.height, m.workingDir, m.availableExecutors)
-				m.previousView = m.currentView
-				m.currentView = ViewNewTask
-				return m, m.newTaskForm.Init()
+				// Create a sample task to demonstrate the workflow
+				sampleTask := &db.Task{
+					Title:   "Hello world — try executing me with x",
+					Body:    "This is a sample task to show how TaskYou works.\n\nPress x to execute it and watch the AI work.\nPress c to close it when done, or d to delete it.",
+					Project: "personal",
+					Status:  db.StatusBacklog,
+				}
+				if err := m.db.CreateTask(sampleTask); err == nil {
+					m.showWelcome = false
+					return m, m.loadTasks()
+				}
 			}
 		}
 
@@ -1696,12 +1702,32 @@ func (m *AppModel) renderWelcomeMessage(height int) string {
 	))
 	lines = append(lines, "")
 
-	// Quick start action
-	lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top,
-		descStyle.Render("Press "),
-		actionStyle.Render("n"),
-		descStyle.Render(" to create your first task"),
-	))
+	// Project setup suggestion
+	if suggestion := m.suggestedProjectFromCwd(); suggestion != "" {
+		hintStyle := lipgloss.NewStyle().
+			Foreground(ColorSecondary)
+		lines = append(lines, subtitleStyle.Render("Get started:"))
+		lines = append(lines, "")
+		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top,
+			descStyle.Render("Press "),
+			actionStyle.Render("a"),
+			descStyle.Render(" to add "),
+			hintStyle.Render(suggestion),
+			descStyle.Render(" as a project"),
+		))
+		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top,
+			descStyle.Render("Press "),
+			actionStyle.Render("n"),
+			descStyle.Render(" to create a task in "),
+			hintStyle.Render("personal"),
+		))
+	} else {
+		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top,
+			descStyle.Render("Press "),
+			actionStyle.Render("n"),
+			descStyle.Render(" to create your first task"),
+		))
+	}
 	lines = append(lines, "")
 
 	// Executor status
@@ -1730,6 +1756,39 @@ func (m *AppModel) renderWelcomeMessage(height int) string {
 
 	// Center in available space
 	return lipgloss.Place(m.width, height, lipgloss.Center, lipgloss.Center, boxed)
+}
+
+// suggestedProjectFromCwd returns the directory name if the working directory
+// is a git repo that isn't already registered as a project. Returns "" otherwise.
+func (m *AppModel) suggestedProjectFromCwd() string {
+	if m.workingDir == "" {
+		return ""
+	}
+	// Check if cwd is a git repo
+	gitDir := filepath.Join(m.workingDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return ""
+	}
+	// Check if already registered as a project
+	if projects, err := m.db.ListProjects(); err == nil {
+		for _, p := range projects {
+			if p.Path == m.workingDir {
+				return ""
+			}
+		}
+	}
+	return filepath.Base(m.workingDir)
+}
+
+// addCwdAsProject creates a new project from the current working directory.
+func (m *AppModel) addCwdAsProject() error {
+	name := filepath.Base(m.workingDir)
+	project := &db.Project{
+		Name:         name,
+		Path:         m.workingDir,
+		UseWorktrees: true,
+	}
+	return m.db.CreateProject(project)
 }
 
 // renderFilterBar renders the filter input bar.
@@ -2022,8 +2081,29 @@ func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.loadTask(task.ID)
 		}
 
+	// Add cwd as project (welcome screen only)
+	case m.showWelcome && msg.String() == "a":
+		if suggestion := m.suggestedProjectFromCwd(); suggestion != "" {
+			if err := m.addCwdAsProject(); err == nil {
+				m.notification = fmt.Sprintf("%s Added project: %s", IconDone(), suggestion)
+				m.notifyUntil = time.Now().Add(5 * time.Second)
+				m.showWelcome = false
+				// Open simplified new task form in the new project
+				m.newTaskForm = NewFormModel(m.db, m.width, m.height, m.workingDir, m.availableExecutors)
+				m.newTaskForm.SetSimpleMode()
+				m.previousView = m.currentView
+				m.currentView = ViewNewTask
+				return m, m.newTaskForm.Init()
+			}
+		}
+		return m, nil
+
 	case key.Matches(msg, m.keys.New):
 		m.newTaskForm = NewFormModel(m.db, m.width, m.height, m.workingDir, m.availableExecutors)
+		// Use simple mode on first run
+		if m.db.IsFirstRun() {
+			m.newTaskForm.SetSimpleMode()
+		}
 		m.previousView = m.currentView
 		m.currentView = ViewNewTask
 		return m, m.newTaskForm.Init()
@@ -3439,7 +3519,7 @@ func (m *AppModel) showChangeStatus(task *db.Task) (tea.Model, tea.Cmd) {
 	}{
 		{db.StatusBacklog, IconBacklog() + " Backlog"},
 		{db.StatusQueued, IconInProgress() + " In Progress"},
-		{db.StatusBlocked, IconBlocked() + " Blocked"},
+		{db.StatusBlocked, IconBlocked() + " Needs Input"},
 		{db.StatusDone, IconDone() + " Done"},
 	}
 

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -1161,6 +1161,14 @@ func (m *FormModel) rebuildExecutorListForProject() {
 	}
 }
 
+// SetSimpleMode hides advanced fields and focuses the title input.
+// Used for first-time users to reduce overwhelm.
+func (m *FormModel) SetSimpleMode() {
+	m.showAdvanced = false
+	m.focused = FieldTitle
+	m.titleInput.Focus()
+}
+
 // isFieldVisible returns whether a field should be shown in the current view.
 // When showAdvanced is false, only Title and Body are visible.
 func (m *FormModel) isFieldVisible(field FormField) bool {

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -82,7 +82,7 @@ func makeKanbanColumns() []KanbanColumn {
 	return []KanbanColumn{
 		{Title: "Backlog", Status: db.StatusBacklog, Color: ColorMuted, Icon: IconBacklog()},
 		{Title: "In Progress", Status: db.StatusQueued, Color: ColorInProgress, Icon: IconInProgress()}, // Also shows processing
-		{Title: "Blocked", Status: db.StatusBlocked, Color: ColorBlocked, Icon: IconBlocked()},
+		{Title: "Needs Input", Status: db.StatusBlocked, Color: ColorBlocked, Icon: IconBlocked()},
 		{Title: "Done", Status: db.StatusDone, Color: ColorDone, Icon: IconDone()},
 	}
 }
@@ -1045,8 +1045,8 @@ func (k *KanbanBoard) renderColumnTabs() string {
 			name += " Back"
 		case "In Progress":
 			name += " Prog"
-		case "Blocked":
-			name += " Block"
+		case "Needs Input":
+			name += " Input"
 		case "Done":
 			name += " Done"
 		default:

--- a/internal/ui/kanban_test.go
+++ b/internal/ui/kanban_test.go
@@ -1246,7 +1246,7 @@ func TestKanbanBoard_ColumnColors(t *testing.T) {
 	}{
 		{"Backlog", "ColorMuted"},
 		{"In Progress", "ColorInProgress"},
-		{"Blocked", "ColorBlocked"},
+		{"Needs Input", "ColorBlocked"},
 		{"Done", "ColorDone"},
 	}
 

--- a/internal/web/board.go
+++ b/internal/web/board.go
@@ -41,7 +41,7 @@ func BuildBoardSnapshot(tasks []*db.Task, limit int) BoardSnapshot {
 	}{
 		{db.StatusBacklog, "Backlog"},
 		{db.StatusProcessing, "In Progress"},
-		{db.StatusBlocked, "Blocked"},
+		{db.StatusBlocked, "Needs Input"},
 		{db.StatusDone, "Done"},
 	}
 


### PR DESCRIPTION
## Summary
- Rename "Blocked" column to "Needs Input" across TUI, CLI, and web API to better convey that tasks are waiting for human input
- Show a sample task on first launch so the board isn't empty and users have something to interact with
- Detect cwd as a potential project on the welcome screen and offer one-key setup (press `a`)
- Default to simplified task form (just Title + Body) for first-time users
- Forward `WORKTREE_DB_PATH` through tmux so isolated ty instances use the correct database

## Test plan
- [ ] Launch ty with a fresh database — verify sample task appears in Backlog
- [ ] Verify "Needs Input" column title renders correctly in TUI, `ty tail`, and web API
- [ ] Launch ty from a git repo directory that isn't a registered project — verify welcome screen suggests adding it
- [ ] Press `a` on welcome screen — verify project is created and simplified task form opens
- [ ] Press `n` on first run — verify simplified form (Title + Body only) appears
- [ ] Set `WORKTREE_DB_PATH` and launch ty — verify it uses the custom database path through tmux
- [ ] Run `go test ./internal/ui/ ./internal/web/ ./internal/db/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)