### PR TITLE
tui: drop statusCheckRollup from batch PR fetch to cut GraphQL cost

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -303,18 +303,20 @@ func (p *PRInfo) StatusDescription() string {
 }
 
 // ghPRListResponse is a single PR from gh pr list.
+// statusCheckRollup is intentionally omitted from the batch path — it forces
+// GraphQL to expand every check run per PR, blowing up cost. The per-task
+// detail fetch (fetchPRInfo) still pulls it for the selected task.
 type ghPRListResponse struct {
-	Number            int       `json:"number"`
-	URL               string    `json:"url"`
-	State             string    `json:"state"`
-	IsDraft           bool      `json:"isDraft"`
-	Title             string    `json:"title"`
-	HeadRefName       string    `json:"headRefName"`
-	Mergeable         string    `json:"mergeable"`
-	StatusCheckRollup []ghCheck `json:"statusCheckRollup"`
-	UpdatedAt         string    `json:"updatedAt"`
-	Additions         int       `json:"additions"`
-	Deletions         int       `json:"deletions"`
+	Number      int    `json:"number"`
+	URL         string `json:"url"`
+	State       string `json:"state"`
+	IsDraft     bool   `json:"isDraft"`
+	Title       string `json:"title"`
+	HeadRefName string `json:"headRefName"`
+	Mergeable   string `json:"mergeable"`
+	UpdatedAt   string `json:"updatedAt"`
+	Additions   int    `json:"additions"`
+	Deletions   int    `json:"deletions"`
 }
 
 // graphQLRateLimitRemaining returns the remaining GraphQL rate limit budget.
@@ -359,7 +361,7 @@ func FetchAllPRsForRepo(repoDir string) map[string]*PRInfo {
 	// Get all open PRs in one call
 	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
 		"--state", "open",
-		"--json", "number,url,state,isDraft,title,headRefName,mergeable,statusCheckRollup,updatedAt,additions,deletions",
+		"--json", "number,url,state,isDraft,title,headRefName,mergeable,updatedAt,additions,deletions",
 		"--limit", "100")
 	cmd.Dir = repoDir
 
@@ -447,8 +449,9 @@ func parsePRListResponse(pr *ghPRListResponse) *PRInfo {
 		info.State = PRStateOpen
 	}
 
-	// Parse check state
-	info.CheckState = parseCheckState(pr.StatusCheckRollup)
+	// CheckState left as CheckStateNone — the batch query no longer fetches
+	// statusCheckRollup. The per-task detail fetch in GetPRForBranch fills it
+	// in when a task is selected.
 
 	// Parse updated time
 	if t, err := time.Parse(time.RFC3339, pr.UpdatedAt); err == nil {


### PR DESCRIPTION
## Summary
- The TUI's 4-minute `prRefreshTick` calls `FetchAllPRsForRepo` per active repo, and the batch query asked for `statusCheckRollup`. That field forces GraphQL to expand every check run on every PR — at ~30 PRs × ~10 checks, one refresh = 30–80 points and we exhausted the 5000/hr GraphQL window in under 90 minutes today.
- Drop `statusCheckRollup` from the batch `gh pr list --json` field list and from `ghPRListResponse`; stop populating `CheckState` from the batch path. Expected per-refresh delta drops to ~5–10 points.
- The per-task detail fetch in `GetPRForBranch` / `fetchPRInfo` is unchanged — it still pulls `statusCheckRollup` via `gh pr view` for the selected task. List-view check badges fall back to the neutral "Open PR" state (the default branch in `styles.go` already handles `CheckStateNone`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/github/...`
- [x] `go test ./internal/ui/...`
- [ ] Run `ty` locally for a few minutes; confirm PR badges still show number/draft/mergeable in the list view, and the check-status badge fills in for the *selected* task only.
- [ ] Sample `gh api rate_limit --jq .resources.graphql.used` before and after a refresh cycle; expect per-refresh delta to drop from ~30–80 to ~5–10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)