### PR TITLE
Add Google Antigravity CLI as a new executor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Guide for AI agents working in this repository.
 This is **Task You** - a personal task management system with:
 - **SQLite storage** for tasks and projects
 - **SSH-accessible TUI** via Wish
-- **Background executor** with support for multiple AI coding agents (Claude, Codex, Gemini, Pi, OpenClaw, OpenCode)
+- **Background executor** with support for multiple AI coding agents (Claude, Codex, Gemini, Antigravity, Pi, OpenClaw, OpenCode)
 - **Beautiful terminal UI** built with Charm libraries (Kanban board)
 - **Git worktree isolation** for parallel task execution
 - **Task lifecycle hooks** for real-time task state tracking
@@ -270,7 +270,8 @@ TaskYou supports multiple AI coding agent backends:
 
 - **claude** (default) - Claude Code CLI with hooks and session resume
 - **codex** - OpenAI Codex CLI with dangerous mode support
-- **gemini** - Google Gemini CLI with configurable dangerous mode flags
+- **gemini** - Google Gemini CLI with configurable dangerous mode flags (deprecated by Google on 2026-06-18)
+- **antigravity** - Google Antigravity CLI (`agy`), successor to the Gemini CLI
 - **pi** - Pi coding agent with session continuity
 - **openclaw** - OpenClaw AI assistant
 - **opencode** - OpenCode AI assistant

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A personal task management system with a beautiful terminal UI, SQLite storage, 
 
 - **Kanban Board** - Visual task management with 4 columns (Backlog, In Progress, Blocked, Done)
 - **Git Worktrees** - Each task runs in an isolated worktree, no conflicts between parallel tasks
-- **Pluggable Executors** - Choose between Claude Code, OpenAI Codex, Gemini, Pi, OpenClaw, or OpenCode per task
+- **Pluggable Executors** - Choose between Claude Code, OpenAI Codex, Gemini, Antigravity, Pi, OpenClaw, or OpenCode per task
 - **Event Hooks** - Run scripts when tasks change state (see [Event Hooks](#event-hooks))
 - **Ghost Text Autocomplete** - LLM-powered suggestions for task titles and descriptions as you type
 - **VS Code-style Fuzzy Search** - Quick task navigation with smart matching (e.g., "dsno" matches "diseno website")
@@ -292,7 +292,8 @@ Task You supports multiple AI executors for processing tasks. You can choose the
 |----------|-----|-------------|
 | Claude (default) | `claude` | [Claude Code](https://claude.ai/claude-code) - Anthropic's coding agent with session resumption |
 | Codex | `codex` | [OpenAI Codex CLI](https://github.com/openai/codex) - OpenAI's coding assistant |
-| Gemini | `gemini` | [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli) - Google's Gemini-based coding assistant |
+| Gemini | `gemini` | [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli) - Google's Gemini-based coding assistant (deprecated by Google on 2026-06-18) |
+| Antigravity | `agy` | [Antigravity CLI](https://antigravity.google) - Google's terminal-first coding agent, successor to the Gemini CLI |
 | Pi | `pi` | [Pi Coding Agent](https://github.com/mariozechner/pi-coding-agent) - Multi-provider AI coding agent with session continuity |
 | OpenCode | `opencode` | [OpenCode](https://opencode.ai) - Open-source AI coding assistant with multi-LLM support |
 | OpenClaw | `openclaw` | [OpenClaw](https://openclaw.ai) - Open-source personal AI assistant with session resumption |
@@ -300,8 +301,10 @@ Task You supports multiple AI executors for processing tasks. You can choose the
 All executors run in tmux windows with the same worktree isolation and environment variables. The main differences:
 
 - **Claude Code**, **Pi**, and **OpenClaw** support session resumption - when you retry a task, they continue with full conversation history
-- **Codex** and **Gemini** start fresh on each execution but receive the full prompt with any feedback
+- **Codex**, **Gemini**, and **Antigravity** start fresh on each execution but receive the full prompt with any feedback
 - **OpenCode** does not support session resumption
+
+> **Gemini → Antigravity:** Google is replacing the Gemini CLI with the Antigravity CLI; the Gemini CLI stops serving requests on 2026-06-18. The `gemini` executor remains available until then, after which `antigravity` is the recommended Google executor.
 
 ### Installing Executors
 
@@ -316,6 +319,9 @@ npm install -g @openai/codex
 
 # Google Gemini CLI
 # See https://ai.google.dev/gemini-api/docs/cli for installation instructions
+
+# Google Antigravity CLI (agy) - successor to the Gemini CLI
+curl -fsSL https://antigravity.google/cli/install.sh | bash
 
 # Pi Coding Agent
 npm install -g @mariozechner/pi-coding-agent

--- a/cmd/task/completion.go
+++ b/cmd/task/completion.go
@@ -139,6 +139,7 @@ func completeFlagExecutors(cmd *cobra.Command, args []string, toComplete string)
 		"claude\tAnthropic Claude (default)",
 		"codex\tOpenAI Codex",
 		"gemini\tGoogle Gemini",
+		"antigravity\tGoogle Antigravity CLI (agy)",
 		"pi\tInflection Pi",
 		"opencode\tOpenCode",
 		"openclaw\tOpenClaw",

--- a/cmd/task/completion_test.go
+++ b/cmd/task/completion_test.go
@@ -100,8 +100,8 @@ func TestCompleteFlagExecutors(t *testing.T) {
 	if directive != cobra.ShellCompDirectiveNoFileComp {
 		t.Errorf("expected NoFileComp directive")
 	}
-	if len(completions) != 6 {
-		t.Errorf("expected 6 executors, got %d", len(completions))
+	if len(completions) != 7 {
+		t.Errorf("expected 7 executors, got %d", len(completions))
 	}
 }
 

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -615,7 +615,7 @@ Examples:
 			}
 
 			// Validate executor if provided
-			validExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw}
+			validExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorAntigravity, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw}
 			if taskExecutor != "" {
 				validExecutor := false
 				for _, e := range validExecutors {
@@ -722,7 +722,7 @@ Examples:
 	createCmd.Flags().String("body", "", "Task body/description (if no title, AI generates from body)")
 	createCmd.Flags().StringP("type", "t", "", "Task type: code, writing, thinking (default: code)")
 	createCmd.Flags().StringP("project", "p", "", "Project name (auto-detected from cwd if not specified)")
-	createCmd.Flags().StringP("executor", "e", "", "Task executor: claude, codex, gemini, pi, opencode, openclaw (default: claude)")
+	createCmd.Flags().StringP("executor", "e", "", "Task executor: claude, codex, gemini, antigravity, pi, opencode, openclaw (default: claude)")
 	createCmd.Flags().BoolP("execute", "x", false, "Queue task for immediate execution")
 	createCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (requires --execute)")
 	createCmd.Flags().String("tags", "", "Task tags (comma-separated)")
@@ -1315,7 +1315,7 @@ Examples:
 
 			// Validate executor if provided
 			if taskExecutor != "" {
-				validExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw}
+				validExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorAntigravity, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw}
 				validExecutor := false
 				for _, e := range validExecutors {
 					if e == taskExecutor {
@@ -1374,7 +1374,7 @@ Examples:
 	updateCmd.Flags().String("body", "", "Update task body/description")
 	updateCmd.Flags().StringP("type", "t", "", "Update task type: code, writing, thinking")
 	updateCmd.Flags().StringP("project", "p", "", "Update project name")
-	updateCmd.Flags().StringP("executor", "e", "", "Update task executor: claude, codex, gemini, pi, opencode, openclaw")
+	updateCmd.Flags().StringP("executor", "e", "", "Update task executor: claude, codex, gemini, antigravity, pi, opencode, openclaw")
 	updateCmd.Flags().String("tags", "", "Update task tags (comma-separated)")
 	updateCmd.Flags().Bool("pinned", false, "Pin or unpin the task")
 	updateCmd.RegisterFlagCompletionFunc("project", completeFlagProjects)

--- a/docs/executor_interface.md
+++ b/docs/executor_interface.md
@@ -29,3 +29,17 @@ Task executors live in `internal/executor` and implement the `TaskExecutor` inte
 The Gemini executor follows the same pattern as Codex: it starts a fresh CLI process for every run and replays the full prompt with appended feedback during retries. Gemini's dangerous-mode flag defaults to `--dangerously-allow-run` but can be overridden via the `GEMINI_DANGEROUS_ARGS` environment variable if Google updates the CLI syntax.
 
 Review `internal/executor/gemini_executor.go` for a reference implementation that satisfies all of the above requirements.
+
+## Antigravity CLI Notes
+
+The Antigravity executor (`agy`) is the successor to the Gemini CLI — Google deprecates the Gemini CLI on 2026-06-18. It is installed via `curl -fsSL https://antigravity.google/cli/install.sh | bash`, which drops the binary at `~/.local/bin/agy`.
+
+The Antigravity CLI is a TUI and does not currently expose documented flags for headless prompting, session resume, or auto-approve ("YOLO") mode — auto-approve is configured in-app via the `/permissions` command. The executor therefore:
+
+- Treats every run as **stateless** (`SupportsSessionResume()` returns `false`); retries replay the full prompt with appended feedback, like Codex and Gemini.
+- Reports **no dangerous mode** (`SupportsDangerousMode()` returns `false`); `ResumeDangerous`/`ResumeSafe` are no-ops.
+- Appends task guidance to the end of the prompt (the OpenClaw pattern), since the CLI has no separate system-prompt mechanism.
+
+To stay resilient while Google stabilizes the CLI surface, the invocation is overridable via environment variables: `ANTIGRAVITY_BIN` (binary name/path, default `agy`) and `ANTIGRAVITY_PROMPT_FLAG` (flag used to pass the initial prompt, default `-i `, matching the Gemini CLI it replaces). When Google documents resume/auto-approve flags, update `internal/executor/antigravity_executor.go` accordingly.
+
+Review `internal/executor/antigravity_executor.go` for the reference implementation.

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -17,7 +17,7 @@ type Task struct {
 	Status          string
 	Type            string
 	Project         string
-	Executor        string // Task executor: "claude" (default), "codex", "gemini"
+	Executor        string // Task executor: "claude" (default), "codex", "gemini", "antigravity", etc.
 	WorktreePath    string
 	BranchName      string
 	Port            int    // Unique port for running the application in this task's worktree
@@ -73,12 +73,13 @@ const (
 
 // Task executors
 const (
-	ExecutorClaude   = "claude"   // Claude Code CLI (default)
-	ExecutorCodex    = "codex"    // OpenAI Codex CLI
-	ExecutorGemini   = "gemini"   // Google Gemini CLI
-	ExecutorOpenClaw = "openclaw" // OpenClaw AI assistant (https://openclaw.ai)
-	ExecutorOpenCode = "opencode" // OpenCode AI assistant (https://opencode.ai)
-	ExecutorPi       = "pi"       // Pi coding agent (https://github.com/mariozechner/pi-coding-agent)
+	ExecutorClaude      = "claude"      // Claude Code CLI (default)
+	ExecutorCodex       = "codex"       // OpenAI Codex CLI
+	ExecutorGemini      = "gemini"      // Google Gemini CLI (deprecated by Google on 2026-06-18, superseded by antigravity)
+	ExecutorAntigravity = "antigravity" // Google Antigravity CLI - "agy" (https://antigravity.google), successor to Gemini CLI
+	ExecutorOpenClaw    = "openclaw"    // OpenClaw AI assistant (https://openclaw.ai)
+	ExecutorOpenCode    = "opencode"    // OpenCode AI assistant (https://opencode.ai)
+	ExecutorPi          = "pi"          // Pi coding agent (https://github.com/mariozechner/pi-coding-agent)
 )
 
 // DefaultExecutor returns the default executor if none is specified.

--- a/internal/executor/antigravity_executor.go
+++ b/internal/executor/antigravity_executor.go
@@ -1,0 +1,399 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/charmbracelet/log"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// AntigravityExecutor implements TaskExecutor for Google's Antigravity CLI.
+//
+// Antigravity CLI ("agy") is Google's terminal-first coding agent and the
+// official successor to the Gemini CLI, which Google deprecates on 2026-06-18.
+// It shares the Antigravity 2.0 agent engine and is installed via:
+//
+//	curl -fsSL https://antigravity.google/cli/install.sh | bash
+//
+// The installer drops the binary at ~/.local/bin/agy.
+//
+// The Antigravity CLI is a TUI. It does not currently expose documented
+// command-line flags for headless prompting, session resume, or auto-approve
+// ("YOLO") mode — auto-approve is configured in-app via the /permissions
+// command. To stay resilient to CLI changes while Google stabilizes the
+// surface, the invocation flags are overridable via environment variables:
+//
+//	ANTIGRAVITY_BIN          - binary name/path (default: agy)
+//	ANTIGRAVITY_PROMPT_FLAG  - flag used to pass the initial prompt (default: "-i ")
+type AntigravityExecutor struct {
+	executor       *Executor
+	logger         *log.Logger
+	suspendedTasks map[int64]time.Time
+}
+
+// NewAntigravityExecutor creates a new Antigravity executor.
+func NewAntigravityExecutor(e *Executor) *AntigravityExecutor {
+	return &AntigravityExecutor{
+		executor:       e,
+		logger:         e.logger,
+		suspendedTasks: make(map[int64]time.Time),
+	}
+}
+
+// Name returns the executor name.
+func (a *AntigravityExecutor) Name() string {
+	return db.ExecutorAntigravity
+}
+
+// antigravityBinary returns the configured Antigravity CLI binary name.
+// Defaults to "agy" but can be overridden via ANTIGRAVITY_BIN.
+func antigravityBinary() string {
+	if bin := strings.TrimSpace(os.Getenv("ANTIGRAVITY_BIN")); bin != "" {
+		return bin
+	}
+	return "agy"
+}
+
+// antigravityBinaryPath resolves the Antigravity CLI to an invokable path.
+// It honors ANTIGRAVITY_BIN, then PATH, then falls back to the installer's
+// default location (~/.local/bin/agy). If nothing is found it returns the
+// bare binary name so callers still get a meaningful "not installed" error.
+func antigravityBinaryPath() string {
+	bin := antigravityBinary()
+	if path, err := exec.LookPath(bin); err == nil {
+		return path
+	}
+	// The install script (antigravity.google/cli/install.sh) installs to
+	// ~/.local/bin/agy, which is not always on PATH for non-login shells.
+	if home, err := os.UserHomeDir(); err == nil {
+		fallback := filepath.Join(home, ".local", "bin", bin)
+		if info, err := os.Stat(fallback); err == nil && !info.IsDir() {
+			return fallback
+		}
+	}
+	return bin
+}
+
+// buildAntigravityPromptFlag returns the flag prefix used to pass an initial
+// prompt to the Antigravity CLI. Defaults to "-i " (interactive-with-prompt,
+// matching the Gemini CLI it replaces) and is overridable via
+// ANTIGRAVITY_PROMPT_FLAG so operators can adapt without a code change.
+func buildAntigravityPromptFlag() string {
+	flag := os.Getenv("ANTIGRAVITY_PROMPT_FLAG")
+	if flag == "" {
+		return "-i "
+	}
+	if !strings.HasSuffix(flag, " ") {
+		flag += " "
+	}
+	return flag
+}
+
+// IsAvailable checks if the Antigravity CLI is installed.
+func (a *AntigravityExecutor) IsAvailable() bool {
+	bin := antigravityBinary()
+	if _, err := exec.LookPath(bin); err == nil {
+		return true
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		fallback := filepath.Join(home, ".local", "bin", bin)
+		if info, err := os.Stat(fallback); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+// Execute runs a task using the Antigravity CLI.
+func (a *AntigravityExecutor) Execute(ctx context.Context, task *db.Task, workDir, prompt string) ExecResult {
+	return a.runAntigravity(ctx, task, workDir, prompt, "", false)
+}
+
+// Resume reruns Antigravity with the full prompt plus feedback.
+//
+// The Antigravity CLI does not expose a documented session-resume flag, so
+// retries replay the full prompt with appended feedback — the same stateless
+// strategy the Codex and Gemini executors use when no session is available.
+func (a *AntigravityExecutor) Resume(ctx context.Context, task *db.Task, workDir, prompt, feedback string) ExecResult {
+	return a.runAntigravity(ctx, task, workDir, prompt, feedback, true)
+}
+
+func (a *AntigravityExecutor) runAntigravity(ctx context.Context, task *db.Task, workDir, prompt, feedback string, isResume bool) ExecResult {
+	paths := a.executor.claudePathsForProject(task.Project)
+
+	if !a.IsAvailable() {
+		a.executor.logLine(task.ID, "error", "Antigravity CLI (agy) is not installed - run: curl -fsSL https://antigravity.google/cli/install.sh | bash")
+		return ExecResult{Message: "Antigravity CLI is not installed"}
+	}
+
+	if _, err := exec.LookPath("tmux"); err != nil {
+		a.executor.logLine(task.ID, "error", "tmux is not installed - required for task execution")
+		return ExecResult{Message: "tmux is not installed"}
+	}
+
+	daemonSession, err := ensureTmuxDaemon()
+	if err != nil {
+		a.logger.Error("could not create task-daemon session", "error", err)
+		a.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux daemon: %s", err.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create tmux daemon: %s", err.Error())}
+	}
+
+	windowName := TmuxWindowName(task.ID)
+	windowTarget := fmt.Sprintf("%s:%s", daemonSession, windowName)
+
+	// Kill ALL existing windows with this name (handles duplicates)
+	KillAllWindowsByNameAllSessions(windowName)
+
+	promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
+	if err != nil {
+		a.logger.Error("could not create temp file", "error", err)
+		a.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create temp file: %s", err.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create temp file: %s", err.Error())}
+	}
+	promptFile.WriteString(a.buildFullPrompt(prompt, feedback, isResume))
+	promptFile.Close()
+	defer os.Remove(promptFile.Name())
+
+	sessionID := os.Getenv("WORKTREE_SESSION_ID")
+	if sessionID == "" {
+		sessionID = fmt.Sprintf("%d", os.Getpid())
+	}
+
+	envPrefix := claudeEnvPrefix(paths.configDir)
+	promptFlag := buildAntigravityPromptFlag()
+	bin := antigravityBinaryPath()
+	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %s%s %s"$(cat %q)"`,
+		task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, bin, promptFlag, promptFile.Name())
+
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, a.executor.getProjectDir(task.Project))
+	if tmuxErr != nil {
+		a.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
+		a.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create tmux window: %s", tmuxErr.Error())}
+	}
+
+	if actualSession != daemonSession {
+		windowTarget = fmt.Sprintf("%s:%s", actualSession, windowName)
+		daemonSession = actualSession
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := a.executor.db.UpdateTaskDaemonSession(task.ID, daemonSession); err != nil {
+		a.logger.Warn("failed to save daemon session", "task", task.ID, "error", err)
+	}
+	if windowID := getWindowID(daemonSession, windowName); windowID != "" {
+		if err := a.executor.db.UpdateTaskWindowID(task.ID, windowID); err != nil {
+			a.logger.Warn("failed to save window ID", "task", task.ID, "error", err)
+		}
+	}
+
+	a.executor.ensureShellPane(windowTarget, workDir, task.ID, task.Port, task.WorktreePath, paths.configDir)
+	a.executor.configureTmuxWindow(windowTarget)
+
+	result := a.executor.pollTmuxSession(ctx, task.ID, windowTarget)
+
+	return ExecResult(result)
+}
+
+// buildFullPrompt assembles the prompt sent to Antigravity. Because the CLI
+// has no separate system-prompt mechanism (unlike Claude's
+// --append-system-prompt or Gemini's GEMINI.md), task guidance is appended to
+// the end of the prompt — the same approach the OpenClaw executor uses.
+func (a *AntigravityExecutor) buildFullPrompt(prompt, feedback string, isResume bool) string {
+	var b strings.Builder
+	b.WriteString(prompt)
+	if isResume && feedback != "" {
+		b.WriteString("\n\n## User Feedback\n\n")
+		b.WriteString(feedback)
+	}
+	b.WriteString("\n\n")
+	b.WriteString(a.executor.buildSystemInstructions())
+	return b.String()
+}
+
+// GetProcessID returns the PID of the Antigravity process for a task.
+func (a *AntigravityExecutor) GetProcessID(taskID int64) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	windowName := TmuxWindowName(taskID)
+
+	out, err := exec.CommandContext(ctx, "tmux", "list-panes", "-a", "-F", "#{session_name}:#{window_name}:#{pane_index} #{pane_pid}").Output()
+	if err != nil {
+		return 0
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		target := parts[0]
+		pidStr := parts[1]
+		if !strings.Contains(target, windowName) {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		cmdOut, _ := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+		if strings.Contains(string(cmdOut), "agy") {
+			return pid
+		}
+		childOut, err := exec.CommandContext(ctx, "pgrep", "-P", strconv.Itoa(pid), "agy").Output()
+		if err == nil && len(childOut) > 0 {
+			childPid, err := strconv.Atoi(strings.TrimSpace(string(childOut)))
+			if err == nil {
+				return childPid
+			}
+		}
+	}
+	return 0
+}
+
+// Kill terminates the Antigravity process for a task.
+func (a *AntigravityExecutor) Kill(taskID int64) bool {
+	pid := a.GetProcessID(taskID)
+	if pid == 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		a.logger.Debug("Failed to find Antigravity process", "pid", pid, "error", err)
+		return false
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		a.logger.Debug("Failed to terminate Antigravity process", "pid", pid, "error", err)
+		return false
+	}
+	a.logger.Info("Terminated Antigravity process", "task", taskID, "pid", pid)
+	delete(a.suspendedTasks, taskID)
+	return true
+}
+
+// Suspend pauses the Antigravity process for a task.
+func (a *AntigravityExecutor) Suspend(taskID int64) bool {
+	pid := a.GetProcessID(taskID)
+	if pid == 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		a.logger.Debug("Failed to find process", "pid", pid, "error", err)
+		return false
+	}
+	if err := sendSIGTSTP(proc); err != nil {
+		a.logger.Debug("Failed to suspend process", "pid", pid, "error", err)
+		return false
+	}
+	a.suspendedTasks[taskID] = time.Now()
+	a.logger.Info("Suspended Antigravity process", "task", taskID, "pid", pid)
+	a.executor.logLine(taskID, "system", "Antigravity suspended (idle timeout)")
+	return true
+}
+
+// IsSuspended reports whether the Antigravity process is suspended for a task.
+func (a *AntigravityExecutor) IsSuspended(taskID int64) bool {
+	_, suspended := a.suspendedTasks[taskID]
+	return suspended
+}
+
+// ResumeProcess resumes a previously suspended Antigravity process.
+func (a *AntigravityExecutor) ResumeProcess(taskID int64) bool {
+	if !a.IsSuspended(taskID) {
+		return false
+	}
+	pid := a.GetProcessID(taskID)
+	if pid == 0 {
+		delete(a.suspendedTasks, taskID)
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		delete(a.suspendedTasks, taskID)
+		return false
+	}
+	if err := sendSIGCONT(proc); err != nil {
+		a.logger.Debug("Failed to resume process", "pid", pid, "error", err)
+		return false
+	}
+	delete(a.suspendedTasks, taskID)
+	a.logger.Info("Resumed Antigravity process", "task", taskID, "pid", pid)
+	a.executor.logLine(taskID, "system", "Antigravity resumed")
+	return true
+}
+
+// BuildCommand returns the shell command to start an interactive Antigravity session.
+func (a *AntigravityExecutor) BuildCommand(task *db.Task, sessionID, prompt string) string {
+	worktreeSessionID := os.Getenv("WORKTREE_SESSION_ID")
+	if worktreeSessionID == "" {
+		worktreeSessionID = fmt.Sprintf("%d", os.Getpid())
+	}
+
+	envVars := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath)
+	bin := antigravityBinaryPath()
+
+	if prompt != "" {
+		promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
+		if err != nil {
+			a.logger.Error("BuildCommand: failed to create temp file", "error", err)
+			return fmt.Sprintf(`%s %s`, envVars, bin)
+		}
+		// Antigravity has no separate system-prompt mechanism, so task
+		// guidance is appended to the prompt (see buildFullPrompt).
+		promptFile.WriteString(a.buildFullPrompt(prompt, "", false))
+		promptFile.Close()
+		return fmt.Sprintf(`%s %s %s"$(cat %q)"; rm -f %q`,
+			envVars, bin, buildAntigravityPromptFlag(), promptFile.Name(), promptFile.Name())
+	}
+
+	return fmt.Sprintf(`%s %s`, envVars, bin)
+}
+
+// ---- Session and Dangerous Mode Support ----
+
+// SupportsSessionResume returns false - the Antigravity CLI does not expose a
+// documented session-resume flag. Retries replay the full prompt instead.
+func (a *AntigravityExecutor) SupportsSessionResume() bool {
+	return false
+}
+
+// SupportsDangerousMode returns false - the Antigravity CLI has no command-line
+// flag for auto-approve ("YOLO") mode. It is enabled in-app via /permissions.
+func (a *AntigravityExecutor) SupportsDangerousMode() bool {
+	return false
+}
+
+// FindSessionID returns an empty string - Antigravity sessions are not
+// discoverable from disk in a documented, stable way.
+func (a *AntigravityExecutor) FindSessionID(workDir string) string {
+	return ""
+}
+
+// ResumeDangerous is not supported for Antigravity (no dangerous-mode flag).
+func (a *AntigravityExecutor) ResumeDangerous(task *db.Task, workDir string) bool {
+	a.executor.logLine(task.ID, "system", "Antigravity executor does not support dangerous mode - enable auto-approve in-app via /permissions")
+	return false
+}
+
+// ResumeSafe is not supported for Antigravity (no dangerous-mode flag).
+func (a *AntigravityExecutor) ResumeSafe(task *db.Task, workDir string) bool {
+	a.executor.logLine(task.ID, "system", "Antigravity executor does not support dangerous mode toggle")
+	return false
+}

--- a/internal/executor/antigravity_executor_test.go
+++ b/internal/executor/antigravity_executor_test.go
@@ -1,0 +1,152 @@
+package executor
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+// newTestExecutor spins up an Executor backed by a throwaway SQLite database.
+func newTestExecutor(t *testing.T) *Executor {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp("", "test-antigravity-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	return New(database, &config.Config{})
+}
+
+func TestAntigravityExecutorName(t *testing.T) {
+	exec := newTestExecutor(t)
+	a := exec.executorFactory.Get(db.ExecutorAntigravity)
+	if a == nil {
+		t.Fatal("antigravity executor not registered in factory")
+	}
+	if got := a.Name(); got != db.ExecutorAntigravity {
+		t.Errorf("Name() = %q, want %q", got, db.ExecutorAntigravity)
+	}
+}
+
+func TestAntigravityExecutorRegistered(t *testing.T) {
+	exec := newTestExecutor(t)
+	for _, name := range exec.executorFactory.All() {
+		if name == db.ExecutorAntigravity {
+			return
+		}
+	}
+	t.Errorf("antigravity not found among registered executors: %v", exec.executorFactory.All())
+}
+
+func TestAntigravityBinary(t *testing.T) {
+	t.Run("defaults to agy", func(t *testing.T) {
+		os.Unsetenv("ANTIGRAVITY_BIN")
+		if got := antigravityBinary(); got != "agy" {
+			t.Errorf("antigravityBinary() = %q, want %q", got, "agy")
+		}
+	})
+
+	t.Run("honors ANTIGRAVITY_BIN override", func(t *testing.T) {
+		t.Setenv("ANTIGRAVITY_BIN", "/custom/path/agy")
+		if got := antigravityBinary(); got != "/custom/path/agy" {
+			t.Errorf("antigravityBinary() = %q, want %q", got, "/custom/path/agy")
+		}
+	})
+}
+
+func TestBuildAntigravityPromptFlag(t *testing.T) {
+	t.Run("defaults to -i", func(t *testing.T) {
+		os.Unsetenv("ANTIGRAVITY_PROMPT_FLAG")
+		if got := buildAntigravityPromptFlag(); got != "-i " {
+			t.Errorf("buildAntigravityPromptFlag() = %q, want %q", got, "-i ")
+		}
+	})
+
+	t.Run("honors ANTIGRAVITY_PROMPT_FLAG override", func(t *testing.T) {
+		t.Setenv("ANTIGRAVITY_PROMPT_FLAG", "--prompt")
+		got := buildAntigravityPromptFlag()
+		if got != "--prompt " {
+			t.Errorf("buildAntigravityPromptFlag() = %q, want %q (with trailing space)", got, "--prompt ")
+		}
+	})
+}
+
+func TestAntigravityCapabilities(t *testing.T) {
+	exec := newTestExecutor(t)
+	a := exec.executorFactory.Get(db.ExecutorAntigravity)
+
+	if a.SupportsSessionResume() {
+		t.Error("SupportsSessionResume() = true, want false (no documented resume flag)")
+	}
+	if a.SupportsDangerousMode() {
+		t.Error("SupportsDangerousMode() = true, want false (auto-approve is in-app)")
+	}
+	if got := a.FindSessionID("/tmp/whatever"); got != "" {
+		t.Errorf("FindSessionID() = %q, want empty", got)
+	}
+	if a.ResumeDangerous(&db.Task{ID: 1}, "/tmp/whatever") {
+		t.Error("ResumeDangerous() = true, want false")
+	}
+	if a.ResumeSafe(&db.Task{ID: 1}, "/tmp/whatever") {
+		t.Error("ResumeSafe() = true, want false")
+	}
+}
+
+func TestAntigravityBuildCommand(t *testing.T) {
+	os.Unsetenv("ANTIGRAVITY_BIN")
+	os.Unsetenv("ANTIGRAVITY_PROMPT_FLAG")
+
+	exec := newTestExecutor(t)
+	a := exec.executorFactory.Get(db.ExecutorAntigravity)
+
+	task := &db.Task{
+		ID:           7,
+		Port:         3199,
+		WorktreePath: "/tmp/test-worktree/7-task",
+	}
+
+	t.Run("without prompt", func(t *testing.T) {
+		cmd := a.BuildCommand(task, "", "")
+		if !strings.Contains(cmd, "WORKTREE_TASK_ID=7") {
+			t.Errorf("BuildCommand() should contain WORKTREE_TASK_ID=7, got %q", cmd)
+		}
+		if !strings.Contains(cmd, "WORKTREE_PORT=3199") {
+			t.Errorf("BuildCommand() should contain WORKTREE_PORT=3199, got %q", cmd)
+		}
+		if !strings.Contains(cmd, "agy") {
+			t.Errorf("BuildCommand() should invoke the agy binary, got %q", cmd)
+		}
+	})
+
+	t.Run("with prompt", func(t *testing.T) {
+		cmd := a.BuildCommand(task, "", "do the thing")
+		if !strings.Contains(cmd, "-i ") {
+			t.Errorf("BuildCommand() should contain the -i prompt flag, got %q", cmd)
+		}
+		if !strings.Contains(cmd, "cat ") {
+			t.Errorf("BuildCommand() should read the prompt from a temp file, got %q", cmd)
+		}
+	})
+
+	t.Run("never includes a dangerous-mode flag", func(t *testing.T) {
+		dangerousTask := &db.Task{ID: 8, Port: 3200, WorktreePath: "/tmp/wt", DangerousMode: true}
+		cmd := a.BuildCommand(dangerousTask, "", "")
+		for _, flag := range []string{"--dangerously-allow-run", "--yolo", "--dangerously-skip-permissions"} {
+			if strings.Contains(cmd, flag) {
+				t.Errorf("BuildCommand() = %q, should not contain %q", cmd, flag)
+			}
+		}
+	})
+}

--- a/internal/executor/dangerous_mode_test.go
+++ b/internal/executor/dangerous_mode_test.go
@@ -60,6 +60,13 @@ func TestExecutorInterfaceImplementation(t *testing.T) {
 			dangerousFlag:         "--dangerously-allow-run",
 		},
 		{
+			name:                  "Antigravity executor",
+			executorName:          db.ExecutorAntigravity,
+			supportsSessionResume: false, // Antigravity CLI has no documented session-resume flag
+			supportsDangerousMode: false, // Auto-approve is configured in-app via /permissions
+			dangerousFlag:         "",
+		},
+		{
 			name:                  "OpenClaw executor",
 			executorName:          db.ExecutorOpenClaw,
 			supportsSessionResume: true,
@@ -1021,7 +1028,7 @@ func TestBuildCommandIncludesEnvironmentVariables(t *testing.T) {
 		WorktreePath: "/home/user/projects/myapp/.task-worktrees/42-fix-bug",
 	}
 
-	executors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorOpenClaw, db.ExecutorOpenCode}
+	executors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorAntigravity, db.ExecutorOpenClaw, db.ExecutorOpenCode}
 
 	for _, name := range executors {
 		t.Run(name, func(t *testing.T) {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -113,6 +113,8 @@ func formatExecutorDisplayName(slug, raw string) string {
 		return defaultExecutorName
 	case "gemini":
 		return "Gemini"
+	case "antigravity":
+		return "Antigravity"
 	case "pi":
 		return "Pi"
 	}
@@ -168,6 +170,7 @@ func New(database *db.DB, cfg *config.Config) *Executor {
 	e.executorFactory.Register(NewClaudeExecutor(e))
 	e.executorFactory.Register(NewCodexExecutor(e))
 	e.executorFactory.Register(NewGeminiExecutor(e))
+	e.executorFactory.Register(NewAntigravityExecutor(e))
 	e.executorFactory.Register(NewOpenClawExecutor(e))
 	e.executorFactory.Register(NewOpenCodeExecutor(e))
 	e.executorFactory.Register(NewPiExecutor(e))
@@ -206,6 +209,7 @@ func NewWithLogging(database *db.DB, cfg *config.Config, w io.Writer) *Executor 
 	e.executorFactory.Register(NewClaudeExecutor(e))
 	e.executorFactory.Register(NewCodexExecutor(e))
 	e.executorFactory.Register(NewGeminiExecutor(e))
+	e.executorFactory.Register(NewAntigravityExecutor(e))
 	e.executorFactory.Register(NewOpenClawExecutor(e))
 	e.executorFactory.Register(NewOpenCodeExecutor(e))
 	e.executorFactory.Register(NewPiExecutor(e))

--- a/internal/executor/executor_identity_test.go
+++ b/internal/executor/executor_identity_test.go
@@ -39,6 +39,17 @@ func TestDetectExecutorIdentityGemini(t *testing.T) {
 	}
 }
 
+func TestDetectExecutorIdentityAntigravity(t *testing.T) {
+	t.Setenv("TASK_EXECUTOR", "antigravity")
+	slug, display := detectExecutorIdentity()
+	if slug != "antigravity" {
+		t.Fatalf("expected slug antigravity, got %q", slug)
+	}
+	if display != "Antigravity" {
+		t.Fatalf("expected display Antigravity, got %q", display)
+	}
+}
+
 func TestDetectExecutorIdentityUnknown(t *testing.T) {
 	t.Setenv("TASK_EXECUTOR", "beta")
 	slug, display := detectExecutorIdentity()

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -536,6 +536,8 @@ func taskExecutorDisplayName(task *db.Task) string {
 		return "Claude"
 	case db.ExecutorGemini:
 		return "Gemini"
+	case db.ExecutorAntigravity:
+		return "Antigravity"
 	case db.ExecutorOpenClaw:
 		return "OpenClaw"
 	default:

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -179,6 +179,8 @@ func (m *DetailModel) executorDisplayName() string {
 			return "Claude"
 		case db.ExecutorGemini:
 			return "Gemini"
+		case db.ExecutorAntigravity:
+			return "Antigravity"
 		case db.ExecutorOpenClaw:
 			return "OpenClaw"
 		default:


### PR DESCRIPTION
## Summary

- Adds **antigravity** as a new executor option alongside claude, codex, gemini, pi, opencode, openclaw — Google's terminal-first coding agent ([`agy`](https://antigravity.google)) and the official successor to the Gemini CLI, which Google retires on 2026-06-18.
- Implements `internal/executor/antigravity_executor.go` modeled on the Gemini executor for tmux + process management, but adapted for what's actually documented today.
- Wires the executor into validation lists, completion, factory registration, and UI display name switches in `cmd/task/`, `internal/ui/`, and `internal/db/`.
- Documents the new executor in `README.md`, `AGENTS.md`, and `docs/executor_interface.md`.

## Design notes

The Antigravity CLI is a TUI and does not currently expose documented command-line flags for headless prompting, session resume, or auto-approve (\"YOLO\") mode — auto-approve is configured in-app via `/permissions`. The executor reflects that reality:

- `SupportsSessionResume()` → `false` (retries replay the full prompt with appended feedback, same as Codex/Gemini fallbacks)
- `SupportsDangerousMode()` → `false` (no CLI flag exists; `ResumeDangerous`/`ResumeSafe` are no-ops with a log line)
- Task guidance is appended to the prompt (OpenClaw pattern) since `agy` has no separate system-prompt mechanism — and avoids clobbering an existing `AGENTS.md` in the worktree.

To stay resilient while Google stabilizes the CLI surface (this is `agy` 1.0.0), the invocation is overridable via env vars:

- `ANTIGRAVITY_BIN` — binary name/path (default `agy`)
- `ANTIGRAVITY_PROMPT_FLAG` — flag used to pass the initial prompt (default `-i `, matching the Gemini CLI it replaces)

`IsAvailable()` falls back to `~/.local/bin/agy` since the official installer drops the binary there and that directory is not always on PATH for non-login shells.

## Deprecating Gemini

Per the task, the `gemini` executor stays as-is until Google's Gemini CLI shutdown on 2026-06-18. The constant comment and README now note the planned deprecation.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/executor/...\`
- [x] \`go test ./internal/db/...\`
- [x] \`go test ./internal/ui/...\`
- [x] \`go test ./cmd/task/...\`
- [x] \`gofmt -l\` (clean) and \`go vet ./...\` (clean)
- [ ] Manual smoke: install \`agy\`, create a task with \`--executor antigravity\`, verify the tmux pane launches \`agy\` with the prompt
- [ ] Confirm \`ty create --executor antigravity\` completion works (\`completeFlagExecutors\` now lists 7 entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)