### PR TITLE
Allow editing a project's directory after creation

### DIFF
--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -37,6 +37,7 @@ type SettingsModel struct {
 	editProject                *db.Project
 	projectForm                *huh.Form
 	projectFormName            string
+	projectFormPath            string
 	projectFormAliases         string
 	projectFormInstructions    string
 	projectFormClaudeConfigDir string
@@ -269,6 +270,7 @@ func (m *SettingsModel) showProjectForm(project *db.Project) (*SettingsModel, te
 
 	// Initialize form values
 	m.projectFormName = project.Name
+	m.projectFormPath = project.Path
 	m.projectFormAliases = project.Aliases
 	m.projectFormInstructions = project.Instructions
 	m.projectFormClaudeConfigDir = project.ClaudeConfigDir
@@ -278,45 +280,61 @@ func (m *SettingsModel) showProjectForm(project *db.Project) (*SettingsModel, te
 	description := "You'll choose a directory next"
 	if project.ID != 0 {
 		title = "Edit Project"
-		description = fmt.Sprintf("Path: %s", project.Path)
+		description = "Update project settings"
 	} else if project.Path != "" {
 		// New project but path already selected
 		description = fmt.Sprintf("Path: %s", project.Path)
 	}
 
+	fields := []huh.Field{
+		huh.NewInput().
+			Key("name").
+			Title("Name").
+			Placeholder("Project name").
+			Value(&m.projectFormName),
+	}
+
+	// For existing projects, allow editing the directory inline. New projects
+	// choose their directory via the file browser after the form is submitted.
+	if project.ID != 0 {
+		fields = append(fields, huh.NewInput().
+			Key("path").
+			Title("Directory").
+			Description("Project directory path (~ expands to home)").
+			Placeholder("~/Projects/myapp").
+			Value(&m.projectFormPath))
+	}
+
+	fields = append(fields,
+		huh.NewInput().
+			Key("aliases").
+			Title("Aliases").
+			Description("Comma-separated shortcuts").
+			Placeholder("alias1, alias2").
+			Value(&m.projectFormAliases),
+		huh.NewText().
+			Key("instructions").
+			Title("Instructions").
+			Description("Project-specific instructions for AI").
+			Placeholder("Instructions...").
+			CharLimit(5000).
+			Value(&m.projectFormInstructions),
+		huh.NewInput().
+			Key("claude_config_dir").
+			Title("Claude Config Directory").
+			Description("Overrides CLAUDE_CONFIG_DIR for this project").
+			Placeholder("~/.claude-other-account").
+			Value(&m.projectFormClaudeConfigDir),
+		huh.NewConfirm().
+			Key("use_worktrees").
+			Title("Use Git Worktrees").
+			Description("Isolate tasks in git worktrees. Disable for non-git projects.").
+			Value(&m.projectFormUseWorktrees),
+	)
+
 	modalWidth := min(70, m.width-8)
 	m.projectForm = huh.NewForm(
-		huh.NewGroup(
-			huh.NewInput().
-				Key("name").
-				Title("Name").
-				Placeholder("Project name").
-				Value(&m.projectFormName),
-			huh.NewInput().
-				Key("aliases").
-				Title("Aliases").
-				Description("Comma-separated shortcuts").
-				Placeholder("alias1, alias2").
-				Value(&m.projectFormAliases),
-			huh.NewText().
-				Key("instructions").
-				Title("Instructions").
-				Description("Project-specific instructions for AI").
-				Placeholder("Instructions...").
-				CharLimit(5000).
-				Value(&m.projectFormInstructions),
-			huh.NewInput().
-				Key("claude_config_dir").
-				Title("Claude Config Directory").
-				Description("Overrides CLAUDE_CONFIG_DIR for this project").
-				Placeholder("~/.claude-other-account").
-				Value(&m.projectFormClaudeConfigDir),
-			huh.NewConfirm().
-				Key("use_worktrees").
-				Title("Use Git Worktrees").
-				Description("Isolate tasks in git worktrees. Disable for non-git projects.").
-				Value(&m.projectFormUseWorktrees),
-		).Title(title).Description(description),
+		huh.NewGroup(fields...).Title(title).Description(description),
 	).WithTheme(huh.ThemeDracula()).
 		WithWidth(modalWidth - 6).
 		WithShowHelp(true)
@@ -425,6 +443,26 @@ func (m *SettingsModel) updateTaskTypeFormModal(msg tea.Msg) (*SettingsModel, te
 	return m, cmd
 }
 
+// resolveProjectPath expands a leading "~" to the user's home directory and
+// returns the absolute, cleaned path.
+func resolveProjectPath(path string) (string, error) {
+	expanded := path
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		expanded = home
+	} else if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		expanded = filepath.Join(home, path[2:])
+	}
+	return filepath.Abs(expanded)
+}
+
 // isGitRepo checks if a directory contains a .git folder
 func isGitRepo(path string) bool {
 	gitDir := filepath.Join(path, ".git")
@@ -526,6 +564,30 @@ func (m *SettingsModel) saveProject() (*SettingsModel, tea.Cmd) {
 	}
 
 	useWorktrees := m.projectFormUseWorktrees
+
+	// For existing projects, the directory can be edited directly in the form.
+	if m.editProject.ID != 0 {
+		formPath := strings.TrimSpace(m.projectFormPath)
+		if formPath == "" {
+			m.err = fmt.Errorf("directory is required")
+			return m, nil
+		}
+		absPath, err := resolveProjectPath(formPath)
+		if err != nil {
+			m.err = fmt.Errorf("invalid path: %w", err)
+			return m, nil
+		}
+		// When pointing an existing project at a new directory, require that
+		// directory to already exist. This avoids silently creating (and
+		// git-initializing) a directory at a mistyped path.
+		if absPath != m.editProject.Path {
+			if _, statErr := os.Stat(absPath); os.IsNotExist(statErr) {
+				m.err = fmt.Errorf("path does not exist: %s", absPath)
+				return m, nil
+			}
+		}
+		m.editProject.Path = absPath
+	}
 
 	// For new projects without a path, open file browser
 	if m.editProject.ID == 0 && m.editProject.Path == "" {

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -1,0 +1,145 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func TestResolveProjectPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"tilde only", "~", home},
+		{"tilde slash", "~/Projects/app", filepath.Join(home, "Projects/app")},
+		{"absolute", "/tmp/foo", "/tmp/foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveProjectPath(tt.input)
+			if err != nil {
+				t.Fatalf("resolveProjectPath(%q): %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveProjectPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSaveProjectUpdatesPath verifies that editing an existing project's
+// directory in the settings form persists the new path.
+func TestSaveProjectUpdatesPath(t *testing.T) {
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
+
+	proj := &db.Project{Name: "myapp", Path: oldDir, UseWorktrees: false}
+	if err := database.CreateProject(proj); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	m := &SettingsModel{db: database, width: 100, height: 40}
+	m.loadSettings()
+
+	// Simulate opening the edit form for the project and changing the directory.
+	m.showProjectForm(proj)
+	m.projectFormPath = newDir
+	m.saveProject()
+
+	if m.err != nil {
+		t.Fatalf("saveProject returned error: %v", m.err)
+	}
+
+	updated, err := database.GetProjectByName("myapp")
+	if err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	if updated.Path != newDir {
+		t.Errorf("project path = %q, want %q", updated.Path, newDir)
+	}
+}
+
+// TestSaveProjectRejectsMissingPath verifies that editing a project to point at
+// a non-existent directory surfaces an error rather than creating it.
+func TestSaveProjectRejectsMissingPath(t *testing.T) {
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	oldDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	proj := &db.Project{Name: "myapp", Path: oldDir, UseWorktrees: false}
+	if err := database.CreateProject(proj); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	m := &SettingsModel{db: database, width: 100, height: 40}
+	m.loadSettings()
+
+	m.showProjectForm(proj)
+	m.projectFormPath = missing
+	m.saveProject()
+
+	if m.err == nil {
+		t.Fatal("expected error for missing path, got nil")
+	}
+
+	// Path should remain unchanged in the database.
+	updated, err := database.GetProjectByName("myapp")
+	if err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	if updated.Path != oldDir {
+		t.Errorf("project path = %q, want unchanged %q", updated.Path, oldDir)
+	}
+
+	// The bad directory must not have been created.
+	if _, statErr := os.Stat(missing); !os.IsNotExist(statErr) {
+		t.Errorf("expected %q to not exist", missing)
+	}
+}
+
+// TestShowProjectFormIncludesPathForExisting verifies the edit form pre-fills
+// the editable directory field for an existing project.
+func TestShowProjectFormIncludesPathForExisting(t *testing.T) {
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	dir := t.TempDir()
+	proj := &db.Project{Name: "myapp", Path: dir, UseWorktrees: false}
+	if err := database.CreateProject(proj); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	m := &SettingsModel{db: database, width: 100, height: 40}
+	m.showProjectForm(proj)
+
+	if m.projectFormPath != dir {
+		t.Errorf("projectFormPath = %q, want %q", m.projectFormPath, dir)
+	}
+	if m.projectForm == nil {
+		t.Fatal("expected project form to be created")
+	}
+}


### PR DESCRIPTION
## Problem

Once a project was created, there was no way to change its directory in the TUI. The only workaround was to delete the project and recreate it — losing history and config.

## Changes

The CLI already supported `ty projects update <name> --path <dir>`. The gap was in the TUI: the **Edit Project** form showed the directory as a read-only description.

- **Editable directory in the TUI** — the Edit Project form now has an editable `Directory` field, pre-filled with the current path. (New projects still choose their directory via the file browser, unchanged.)
- **`~` expansion** — a leading `~` resolves to the user's home directory; the path is stored absolute.
- **Existence guard** — when repointing an existing project to a new directory, that directory must already exist, so a mistyped path doesn't silently create and git-init a stray directory (mirrors the CLI's behavior).

## Migration / consistency

Tasks reference projects by **name** and store an **absolute worktree path per task**. Worktree locations are derived from the project path only at task-creation time. So after a path change:

- Existing tasks keep working — their stored worktree paths are untouched.
- New tasks create worktrees under the new directory.

No data migration is required.

## Tests

Added `internal/ui/settings_test.go`:
- `resolveProjectPath` expands `~`/`~/...` and absolutizes paths.
- Editing a project's directory persists the new path.
- Repointing to a non-existent directory errors and leaves the path unchanged (and does not create the directory).
- The edit form pre-fills the directory field for existing projects.

All `internal/ui`, `internal/db`, and `cmd/task` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
