### PR TITLE
Add per-task Claude effort override on new tasks

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -565,6 +565,7 @@ Examples:
 			taskType, _ := cmd.Flags().GetString("type")
 			project, _ := cmd.Flags().GetString("project")
 			taskExecutor, _ := cmd.Flags().GetString("executor")
+			effortLevel, _ := cmd.Flags().GetString("effort")
 			execute, _ := cmd.Flags().GetBool("execute")
 			createDangerous, _ := cmd.Flags().GetBool("dangerous")
 			tags, _ := cmd.Flags().GetString("tags")
@@ -630,6 +631,13 @@ Examples:
 				}
 			}
 
+			// Validate effort level if provided (empty = use Claude's global default)
+			effortLevel = strings.ToLower(strings.TrimSpace(effortLevel))
+			if !db.IsValidEffortLevel(effortLevel) {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Invalid effort. Must be one of: "+strings.Join(db.EffortLevels(), ", ")))
+				os.Exit(1)
+			}
+
 			// If project not specified, try to detect from cwd
 			if project == "" {
 				if cwd, err := os.Getwd(); err == nil {
@@ -678,6 +686,7 @@ Examples:
 				Type:          taskType,
 				Project:       project,
 				Executor:      taskExecutor,
+				EffortLevel:   effortLevel,
 				Tags:          tags,
 				Pinned:        pinned,
 				SourceBranch:  branch,
@@ -701,6 +710,9 @@ Examples:
 				if task.SourceBranch != "" {
 					output["source_branch"] = task.SourceBranch
 				}
+				if task.EffortLevel != "" {
+					output["effort_level"] = task.EffortLevel
+				}
 				jsonBytes, _ := json.Marshal(output)
 				fmt.Println(string(jsonBytes))
 			} else {
@@ -723,6 +735,7 @@ Examples:
 	createCmd.Flags().StringP("type", "t", "", "Task type: code, writing, thinking (default: code)")
 	createCmd.Flags().StringP("project", "p", "", "Project name (auto-detected from cwd if not specified)")
 	createCmd.Flags().StringP("executor", "e", "", "Task executor: claude, codex, gemini, pi, opencode, openclaw (default: claude)")
+	createCmd.Flags().String("effort", "", "Per-task Claude effort override: low, medium, high, xhigh, max (default: Claude's global default)")
 	createCmd.Flags().BoolP("execute", "x", false, "Queue task for immediate execution")
 	createCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (requires --execute)")
 	createCmd.Flags().String("tags", "", "Task tags (comma-separated)")
@@ -732,6 +745,9 @@ Examples:
 	createCmd.RegisterFlagCompletionFunc("project", completeFlagProjects)
 	createCmd.RegisterFlagCompletionFunc("type", completeFlagTypes)
 	createCmd.RegisterFlagCompletionFunc("executor", completeFlagExecutors)
+	createCmd.RegisterFlagCompletionFunc("effort", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return db.EffortLevels(), cobra.ShellCompDirectiveNoFileComp
+	})
 	rootCmd.AddCommand(createCmd)
 
 	// List subcommand - list tasks

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -269,6 +269,8 @@ func (db *DB) migrate() error {
 		`ALTER TABLE tasks ADD COLUMN pr_info_json TEXT DEFAULT ''`, // JSON blob of github.PRInfo
 		// Whether project uses git worktrees for task isolation (1=yes, 0=no, default 1 for backward compat)
 		`ALTER TABLE projects ADD COLUMN use_worktrees INTEGER DEFAULT 1`,
+		// Per-task Claude effort override ("" = use global/Claude default, otherwise low/medium/high/xhigh/max)
+		`ALTER TABLE tasks ADD COLUMN effort_level TEXT DEFAULT ''`,
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -18,6 +18,7 @@ type Task struct {
 	Type            string
 	Project         string
 	Executor        string // Task executor: "claude" (default), "codex", "gemini"
+	EffortLevel     string // Per-task Claude effort override ("" = use global/Claude default; otherwise low/medium/high/xhigh/max)
 	WorktreePath    string
 	BranchName      string
 	Port            int    // Unique port for running the application in this task's worktree
@@ -86,6 +87,33 @@ func DefaultExecutor() string {
 	return ExecutorClaude
 }
 
+// Effort levels are per-task overrides for Claude's reasoning effort (claude --effort).
+// An empty value means "no override" — the task uses Claude's global default, leaving
+// the user's global setting untouched.
+const (
+	EffortLow    = "low"
+	EffortMedium = "medium"
+	EffortHigh   = "high"
+	EffortXHigh  = "xhigh"
+	EffortMax    = "max"
+)
+
+// EffortLevels returns the valid per-task effort override values, in ascending order.
+func EffortLevels() []string {
+	return []string{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax}
+}
+
+// IsValidEffortLevel reports whether s is a valid effort level. The empty string is
+// valid and means "use the global/Claude default" (no per-task override).
+func IsValidEffortLevel(s string) bool {
+	switch s {
+	case "", EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax:
+		return true
+	default:
+		return false
+	}
+}
+
 // Port allocation constants
 const (
 	PortRangeStart = 3100 // First port in the allocation range
@@ -129,9 +157,9 @@ func (db *DB) CreateTask(t *Task) error {
 	t.Project = project.Name
 
 	result, err := db.Exec(`
-		INSERT INTO tasks (title, body, status, type, project, executor, pinned, tags, source_branch, dangerous_mode)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor, t.Pinned, t.Tags, t.SourceBranch, t.DangerousMode)
+		INSERT INTO tasks (title, body, status, type, project, executor, pinned, tags, source_branch, dangerous_mode, effort_level)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor, t.Pinned, t.Tags, t.SourceBranch, t.DangerousMode, t.EffortLevel)
 	if err != nil {
 		return fmt.Errorf("insert task: %w", err)
 	}
@@ -176,7 +204,7 @@ func (db *DB) GetTask(id int64) (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -188,7 +216,7 @@ func (db *DB) GetTask(id int64) (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary,
+		&t.SourceBranch, &t.Summary, &t.EffortLevel,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -221,7 +249,7 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -281,7 +309,7 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary,
+			&t.SourceBranch, &t.Summary, &t.EffortLevel,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -306,7 +334,7 @@ func (db *DB) GetMostRecentlyCreatedTask() (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -320,7 +348,7 @@ func (db *DB) GetMostRecentlyCreatedTask() (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary,
+		&t.SourceBranch, &t.Summary, &t.EffortLevel,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -349,7 +377,7 @@ func (db *DB) SearchTasks(query string, limit int) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -382,7 +410,7 @@ func (db *DB) SearchTasks(query string, limit int) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary,
+			&t.SourceBranch, &t.Summary, &t.EffortLevel,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -484,13 +512,13 @@ func (db *DB) UpdateTask(t *Task) error {
 			title = ?, body = ?, status = ?, type = ?, project = ?, executor = ?,
 			worktree_path = ?, branch_name = ?, port = ?, claude_session_id = ?,
 			daemon_session = ?, pr_url = ?, pr_number = ?, pr_info_json = ?, dangerous_mode = ?,
-			pinned = ?, tags = ?, source_branch = ?,
+			pinned = ?, tags = ?, source_branch = ?, effort_level = ?,
 			updated_at = CURRENT_TIMESTAMP
 		WHERE id = ?
 	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor,
 		t.WorktreePath, t.BranchName, t.Port, t.ClaudeSessionID,
 		t.DaemonSession, t.PRURL, t.PRNumber, t.PRInfoJSON, t.DangerousMode,
-		t.Pinned, t.Tags, t.SourceBranch, t.ID)
+		t.Pinned, t.Tags, t.SourceBranch, t.EffortLevel, t.ID)
 	if err != nil {
 		return fmt.Errorf("update task: %w", err)
 	}
@@ -793,7 +821,7 @@ func (db *DB) GetNextQueuedTask() (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -808,7 +836,7 @@ func (db *DB) GetNextQueuedTask() (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary,
+		&t.SourceBranch, &t.Summary, &t.EffortLevel,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -831,7 +859,7 @@ func (db *DB) GetQueuedTasks() ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -854,7 +882,7 @@ func (db *DB) GetQueuedTasks() ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary,
+			&t.SourceBranch, &t.Summary, &t.EffortLevel,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -1761,7 +1789,7 @@ func (db *DB) GetStaleWorktreeTasks(maxAge time.Duration) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -1788,7 +1816,7 @@ func (db *DB) GetStaleWorktreeTasks(maxAge time.Duration) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary,
+			&t.SourceBranch, &t.Summary, &t.EffortLevel,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -1482,6 +1482,84 @@ func TestUpdateTaskDangerousMode(t *testing.T) {
 	}
 }
 
+func TestEffortLevelPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+	defer os.Remove(dbPath)
+
+	// Create a task without an effort override (empty = global/Claude default)
+	task := &Task{
+		Title:   "Default effort task",
+		Status:  StatusBacklog,
+		Type:    TypeCode,
+		Project: "personal",
+	}
+	if err := db.CreateTask(task); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	retrieved, err := db.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+	if retrieved.EffortLevel != "" {
+		t.Errorf("expected empty effort level by default, got %q", retrieved.EffortLevel)
+	}
+
+	// Create a task with a per-task effort override
+	override := &Task{
+		Title:       "High effort task",
+		Status:      StatusBacklog,
+		Type:        TypeCode,
+		Project:     "personal",
+		EffortLevel: EffortHigh,
+	}
+	if err := db.CreateTask(override); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+	retrieved, err = db.GetTask(override.ID)
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+	if retrieved.EffortLevel != EffortHigh {
+		t.Errorf("expected effort level %q, got %q", EffortHigh, retrieved.EffortLevel)
+	}
+
+	// Update the effort level via UpdateTask
+	retrieved.EffortLevel = EffortMax
+	if err := db.UpdateTask(retrieved); err != nil {
+		t.Fatalf("failed to update task: %v", err)
+	}
+	updated, err := db.GetTask(override.ID)
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+	if updated.EffortLevel != EffortMax {
+		t.Errorf("expected effort level %q after update, got %q", EffortMax, updated.EffortLevel)
+	}
+}
+
+func TestIsValidEffortLevel(t *testing.T) {
+	valid := []string{"", EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax}
+	for _, v := range valid {
+		if !IsValidEffortLevel(v) {
+			t.Errorf("expected %q to be a valid effort level", v)
+		}
+	}
+	invalid := []string{"none", "LOW", "extreme", "0", "default"}
+	for _, v := range invalid {
+		if IsValidEffortLevel(v) {
+			t.Errorf("expected %q to be an invalid effort level", v)
+		}
+	}
+}
+
 func TestUpdateTaskPRInfo(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")

--- a/internal/executor/claude_executor.go
+++ b/internal/executor/claude_executor.go
@@ -18,6 +18,17 @@ type ClaudeExecutor struct {
 	logger   *log.Logger
 }
 
+// effortFlag returns the `--effort <level> ` CLI flag (with a trailing space) for a
+// per-task effort override, or an empty string when no override is set. An empty
+// override means the task uses Claude's global default, leaving the user's global
+// effort setting untouched.
+func effortFlag(level string) string {
+	if level == "" {
+		return ""
+	}
+	return fmt.Sprintf("--effort %s ", level)
+}
+
 // NewClaudeExecutor creates a new Claude executor.
 func NewClaudeExecutor(e *Executor) *ClaudeExecutor {
 	return &ClaudeExecutor{
@@ -82,6 +93,9 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 		dangerousFlag = "--dangerously-skip-permissions "
 	}
 
+	// Build per-task effort override flag (empty = use Claude's global default)
+	effort := effortFlag(task.EffortLevel)
+
 	// Get session ID for environment
 	worktreeSessionID := os.Getenv("WORKTREE_SESSION_ID")
 	if worktreeSessionID == "" {
@@ -100,8 +114,8 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 
 	// Build command - resume if we have a session ID, otherwise start fresh
 	if sessionID != "" {
-		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s--resume %s`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, systemPromptFlag, sessionID)
+		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s%s--resume %s`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, systemPromptFlag, sessionID)
 		if systemFile != nil {
 			cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
 		}
@@ -114,8 +128,8 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 		promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
 		if err != nil {
 			c.logger.Error("BuildCommand: failed to create temp file", "error", err)
-			cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s`,
-				task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, systemPromptFlag)
+			cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s%s`,
+				task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, systemPromptFlag)
 			if systemFile != nil {
 				cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
 			}
@@ -124,16 +138,16 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 		promptFile.WriteString(prompt)
 		promptFile.Close()
 
-		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s"$(cat %q)"; rm -f %q`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, systemPromptFlag, promptFile.Name(), promptFile.Name())
+		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s%s"$(cat %q)"; rm -f %q`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, systemPromptFlag, promptFile.Name(), promptFile.Name())
 		if systemFile != nil {
 			cmd += fmt.Sprintf(` %q`, systemFile.Name())
 		}
 		return cmd
 	}
 
-	cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s`,
-		task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, systemPromptFlag)
+	cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s%s`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, systemPromptFlag)
 	if systemFile != nil {
 		cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
 	}

--- a/internal/executor/effort_test.go
+++ b/internal/executor/effort_test.go
@@ -1,0 +1,63 @@
+package executor
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+// TestEffortFlag verifies the effortFlag helper produces the expected CLI flag.
+func TestEffortFlag(t *testing.T) {
+	tests := []struct {
+		level string
+		want  string
+	}{
+		{"", ""},
+		{db.EffortLow, "--effort low "},
+		{db.EffortMedium, "--effort medium "},
+		{db.EffortHigh, "--effort high "},
+		{db.EffortXHigh, "--effort xhigh "},
+		{db.EffortMax, "--effort max "},
+	}
+	for _, tt := range tests {
+		if got := effortFlag(tt.level); got != tt.want {
+			t.Errorf("effortFlag(%q) = %q, want %q", tt.level, got, tt.want)
+		}
+	}
+}
+
+// TestBuildCommandEffort verifies BuildCommand includes the --effort flag only
+// when a per-task override is set, leaving the default (empty) untouched.
+func TestBuildCommandEffort(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	exec := New(database, &config.Config{})
+	claude := exec.executorFactory.Get(db.ExecutorClaude)
+
+	// No override: command must not contain --effort.
+	task := &db.Task{ID: 1, Port: 8080, WorktreePath: "/tmp/test-worktree"}
+	if cmd := claude.BuildCommand(task, "", ""); strings.Contains(cmd, "--effort") {
+		t.Errorf("BuildCommand() with no effort override should not contain --effort, got %q", cmd)
+	}
+
+	// Override set: command must contain --effort <level>.
+	task.EffortLevel = db.EffortHigh
+	cmd := claude.BuildCommand(task, "", "")
+	if !strings.Contains(cmd, "--effort high") {
+		t.Errorf("BuildCommand() with high effort should contain %q, got %q", "--effort high", cmd)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2281,6 +2281,8 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 	if task.DangerousMode || os.Getenv("WORKTREE_DANGEROUS_MODE") == "1" {
 		dangerousFlag = "--dangerously-skip-permissions "
 	}
+	// Build per-task effort override flag (empty = use Claude's global default)
+	effort := effortFlag(task.EffortLevel)
 	// Build system prompt flag - passes task guidance via system prompt to keep conversation clean
 	systemPromptFlag := fmt.Sprintf(`--append-system-prompt "$(cat %q)" `, systemFile.Name())
 
@@ -2292,8 +2294,8 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 	envPrefix := claudeEnvPrefix(paths.configDir)
 	if existingSessionID != "" && ClaudeSessionExists(existingSessionID, workDir, paths.configDir) {
 		e.logLine(task.ID, "system", fmt.Sprintf("Resuming existing session %s", existingSessionID))
-		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s--resume %s "$(cat %q)"`,
-			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, systemPromptFlag, existingSessionID, promptFile.Name())
+		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s--resume %s "$(cat %q)"`,
+			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, systemPromptFlag, existingSessionID, promptFile.Name())
 	} else {
 		if existingSessionID != "" {
 			e.logLine(task.ID, "system", fmt.Sprintf("Session %s no longer exists, starting fresh", existingSessionID))
@@ -2302,8 +2304,8 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 				e.logger.Warn("failed to clear stale session ID", "task", task.ID, "error", err)
 			}
 		}
-		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s"$(cat %q)"`,
-			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, systemPromptFlag, promptFile.Name())
+		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s"$(cat %q)"`,
+			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, systemPromptFlag, promptFile.Name())
 	}
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
@@ -2455,12 +2457,14 @@ func (e *Executor) runClaudeResume(ctx context.Context, task *db.Task, workDir, 
 	if task.DangerousMode || os.Getenv("WORKTREE_DANGEROUS_MODE") == "1" {
 		dangerousFlag = "--dangerously-skip-permissions "
 	}
+	// Build per-task effort override flag (empty = use Claude's global default)
+	effort := effortFlag(task.EffortLevel)
 	// Build system prompt flag - passes task guidance via system prompt to keep conversation clean
 	systemPromptFlag := fmt.Sprintf(`--append-system-prompt "$(cat %q)" `, systemFile.Name())
 
 	envPrefix := claudeEnvPrefix(paths.configDir)
-	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s--resume %s "$(cat %q)"`,
-		task.ID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, systemPromptFlag, claudeSessionID, feedbackFile.Name())
+	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s--resume %s "$(cat %q)"`,
+		task.ID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, systemPromptFlag, claudeSessionID, feedbackFile.Name())
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
 	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -29,6 +29,7 @@ const (
 	FieldAttachments // Moved after body for proximity - drag works from any field
 	FieldType
 	FieldExecutor
+	FieldEffort
 	FieldCount
 )
 
@@ -65,6 +66,9 @@ type FormModel struct {
 	executorIdx        int
 	executors          []string
 	availableExecutors []string // Original list of available executors (for rebuilding when project changes)
+	effortLevel        string   // Per-task Claude effort override ("" = use global/Claude default)
+	effortIdx          int
+	effortLevels       []string // Selectable effort values; "" (first) means "default"
 	queue              bool
 	attachments        []string // Parsed file paths
 	attachmentCursor   int      // Index of the currently selected attachment chip
@@ -136,6 +140,24 @@ func buildExecutorList(availableExecutors []string, usageCounts map[string]int) 
 	return result
 }
 
+// effortLevelOptions returns the selectable effort values for the form. The first
+// entry is the empty string, which represents "default" (no per-task override —
+// uses Claude's global default).
+func effortLevelOptions() []string {
+	return append([]string{""}, db.EffortLevels()...)
+}
+
+// effortIndexFor returns the index of the given effort level in the options list,
+// defaulting to 0 ("default") when not found.
+func effortIndexFor(options []string, level string) int {
+	for i, l := range options {
+		if l == level {
+			return i
+		}
+	}
+	return 0
+}
+
 // NewEditFormModel creates a form model pre-populated with an existing task's data for editing.
 func NewEditFormModel(database *db.DB, task *db.Task, width, height int, availableExecutors []string) *FormModel {
 	// Set executor to default if not specified
@@ -200,6 +222,9 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int, availab
 		executorIdx:         executorIdx,
 		executors:           executors,
 		availableExecutors:  availableExecutors, // Store for rebuilding when project changes
+		effortLevel:         task.EffortLevel,
+		effortLevels:        effortLevelOptions(),
+		effortIdx:           effortIndexFor(effortLevelOptions(), task.EffortLevel),
 		isEdit:              true,
 		prURL:               task.PRURL,
 		prNumber:            task.PRNumber,
@@ -316,7 +341,8 @@ func NewFormModel(database *db.DB, width, height int, workingDir string, availab
 		autocompleteEnabled: autocompleteEnabled,
 		taskRefAutocomplete: NewTaskRefAutocompleteModel(database, width-24),
 		attachmentCursor:    -1,
-		showAdvanced:        showAdvanced, // Load from user preference
+		effortLevels:        effortLevelOptions(), // Defaults to "" (Claude's global default)
+		showAdvanced:        showAdvanced,         // Load from user preference
 	}
 
 	// Load task types from database
@@ -737,6 +763,11 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.executor = m.executors[m.executorIdx]
 				return m, nil
 			}
+			if m.focused == FieldEffort && len(m.effortLevels) > 0 {
+				m.effortIdx = (m.effortIdx - 1 + len(m.effortLevels)) % len(m.effortLevels)
+				m.effortLevel = m.effortLevels[m.effortIdx]
+				return m, nil
+			}
 
 		case "right":
 			if m.handleAttachmentNavigation(1) {
@@ -758,6 +789,11 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.focused == FieldExecutor && len(m.executors) > 0 {
 				m.executorIdx = (m.executorIdx + 1) % len(m.executors)
 				m.executor = m.executors[m.executorIdx]
+				return m, nil
+			}
+			if m.focused == FieldEffort && len(m.effortLevels) > 0 {
+				m.effortIdx = (m.effortIdx + 1) % len(m.effortLevels)
+				m.effortLevel = m.effortLevels[m.effortIdx]
 				return m, nil
 			}
 
@@ -813,7 +849,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			// Type-to-select for other selector fields
-			if m.focused == FieldType || m.focused == FieldExecutor {
+			if m.focused == FieldType || m.focused == FieldExecutor || m.focused == FieldEffort {
 				key := msg.String()
 				if len(key) == 1 && unicode.IsLetter(rune(key[0])) {
 					m.selectByPrefix(strings.ToLower(key))
@@ -1080,6 +1116,18 @@ func (m *FormModel) selectByPrefix(prefix string) {
 				return
 			}
 		}
+	case FieldEffort:
+		for i, l := range m.effortLevels {
+			label := l
+			if label == "" {
+				label = "default"
+			}
+			if strings.HasPrefix(strings.ToLower(label), prefix) {
+				m.effortIdx = i
+				m.effortLevel = l
+				return
+			}
+		}
 	}
 }
 
@@ -1164,6 +1212,11 @@ func (m *FormModel) rebuildExecutorListForProject() {
 // isFieldVisible returns whether a field should be shown in the current view.
 // When showAdvanced is false, only Title and Body are visible.
 func (m *FormModel) isFieldVisible(field FormField) bool {
+	if field == FieldEffort {
+		// Effort is a Claude-specific override (claude --effort), only shown in
+		// advanced mode and only when the Claude executor is selected.
+		return m.showAdvanced && m.executor == db.ExecutorClaude
+	}
 	if m.showAdvanced {
 		return true
 	}
@@ -1689,6 +1742,25 @@ func (m *FormModel) View() string {
 		}
 		b.WriteString(cursor + " " + labelStyle.Render("Executor") + m.renderSelector(m.executors, m.executorIdx, m.focused == FieldExecutor, selectedStyle, optionStyle, dimStyle))
 		b.WriteString("\n\n")
+
+		// Effort selector (Claude-specific; only shown for the Claude executor)
+		if m.isFieldVisible(FieldEffort) {
+			cursor = " "
+			if m.focused == FieldEffort {
+				cursor = cursorStyle.Render("▸")
+			}
+			// Build effort labels (replace "" with "default")
+			effortLabels := make([]string, len(m.effortLevels))
+			for i, l := range m.effortLevels {
+				if l == "" {
+					effortLabels[i] = "default"
+				} else {
+					effortLabels[i] = l
+				}
+			}
+			b.WriteString(cursor + " " + labelStyle.Render("Effort") + m.renderSelector(effortLabels, m.effortIdx, m.focused == FieldEffort, selectedStyle, optionStyle, dimStyle))
+			b.WriteString("\n\n")
+		}
 	} else {
 		// Show compact summary of defaults and toggle hint
 		b.WriteString("\n")
@@ -1785,6 +1857,11 @@ func (m *FormModel) GetDBTask() *db.Task {
 		Executor: m.executor,
 		PRURL:    m.prURL,
 		PRNumber: m.prNumber,
+	}
+
+	// Effort is a Claude-specific override; only carry it for the Claude executor.
+	if m.executor == db.ExecutorClaude {
+		task.EffortLevel = m.effortLevel
 	}
 
 	return task

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -1161,3 +1161,57 @@ func TestFilterProjectsEmptyQueryShowsAll(t *testing.T) {
 		t.Errorf("expected current project 'workflow' to be pre-selected, got %q", m.projectFiltered[m.projectFilteredIdx])
 	}
 }
+
+func TestEffortFieldDefaultsToGlobal(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", []string{db.ExecutorClaude})
+
+	// Effort options start with "" (the global/Claude default).
+	if len(m.effortLevels) == 0 || m.effortLevels[0] != "" {
+		t.Fatalf("expected first effort option to be the empty default, got %v", m.effortLevels)
+	}
+	if m.effortLevel != "" {
+		t.Errorf("expected default effort level to be empty, got %q", m.effortLevel)
+	}
+
+	// GetDBTask should not set an override when the user leaves the default.
+	if got := m.GetDBTask().EffortLevel; got != "" {
+		t.Errorf("expected GetDBTask to leave effort empty by default, got %q", got)
+	}
+}
+
+func TestEffortFieldCycleAndPersist(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", []string{db.ExecutorClaude})
+	m.showAdvanced = true
+	m.focused = FieldEffort
+
+	// Cycling right from the default lands on the first real effort level.
+	m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if m.effortLevel != db.EffortLow {
+		t.Errorf("expected effort to be %q after one right press, got %q", db.EffortLow, m.effortLevel)
+	}
+
+	if got := m.GetDBTask().EffortLevel; got != db.EffortLow {
+		t.Errorf("expected GetDBTask to carry effort %q, got %q", db.EffortLow, got)
+	}
+
+	// Cycling left returns to the default (empty) override.
+	m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if m.effortLevel != "" {
+		t.Errorf("expected effort to return to default, got %q", m.effortLevel)
+	}
+}
+
+func TestEffortFieldHiddenForNonClaude(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", []string{db.ExecutorClaude})
+	m.showAdvanced = true
+
+	m.executor = db.ExecutorClaude
+	if !m.isFieldVisible(FieldEffort) {
+		t.Error("expected effort field to be visible for the Claude executor")
+	}
+
+	m.executor = db.ExecutorCodex
+	if m.isFieldVisible(FieldEffort) {
+		t.Error("expected effort field to be hidden for non-Claude executors")
+	}
+}


### PR DESCRIPTION
## Summary

Adds an optional **effort level** setting to the task-creation flow, per Andrew's feedback. It's a per-task override that maps to `claude --effort <level>`:

- **Default is unchanged behavior.** Leaving the control on `default` passes no flag, so the task uses Claude's global default. The user's global setting is never touched.
- **Override is per-task only.** Picking `low`/`medium`/`high`/`xhigh`/`max` applies that effort to a single task's session without mutating the global default.
- Effort is Claude-specific, so the control is only shown/applied for the `claude` executor.

## What changed

**DB (`internal/db`)**
- New `Task.EffortLevel` field + `effort_level` column with an idempotent `ALTER TABLE` migration.
- Persisted on create/update; added to all task SELECT/scan sites.
- `EffortLevels()` + `IsValidEffortLevel()` helpers and constants (empty = "use global default").

**Executor (`internal/executor`)**
- `effortFlag()` helper builds `--effort <level> ` only when an override is set.
- Wired into the run, resume, and `BuildCommand` Claude code paths alongside the existing dangerous-mode flag.

**UI (`internal/ui/form.go`)**
- New "Effort" selector in the advanced new-task view, defaulting to `default`.
- Only visible/applied for the Claude executor; carried through `GetDBTask()` (and the edit form).

**CLI (`cmd/task/main.go`)**
- `ty create --effort <level>` flag with validation, shell completion, and JSON output field.

## Testing

- `go build ./...`, `go vet`, and full `go test ./...` pass.
- Added tests: DB persistence round-trip + validation, `effortFlag` helper, `BuildCommand` effort wiring, and form field cycling/visibility.
- Manually verified the CLI flag help and that invalid values are rejected.

## Notes / follow-ups

- Scope is the create flow. The MCP `taskyou_create_task` tool was intentionally left unchanged (defaults to global), but could expose `effort` later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)