### PR TITLE
Detect logged-out executor sessions and surface stuck tasks

### DIFF
--- a/examples/hooks/README.md
+++ b/examples/hooks/README.md
@@ -16,6 +16,7 @@ chmod +x ~/.config/task/hooks/task.completed
 - `task.deleted` - Task removed
 - `task.started` - Execution begins
 - `task.blocked` - Task needs user input (also fires on failure via the status change)
+- `task.auth_required` - A processing task stalled because its executor session is logged out (e.g. expired Claude `/login`); fires alongside `task.blocked`. Use this to notify yourself to re-authenticate.
 - `task.completed` - Agent finished successfully (task moves to backlog for human review)
 - `task.failed` - Agent execution failed (distinct signal from the `task.blocked` fired by the status change)
 - `task.worktree_ready` - Worktree ready for the agent

--- a/examples/hooks/task.auth_required
+++ b/examples/hooks/task.auth_required
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Example hook: task.auth_required
+# Runs when a processing task stalls because its executor session is logged out
+# (e.g., the Claude cloud/login session expired). TASK_MESSAGE explains why.
+#
+# Re-authenticate by attaching to the task and running /login, then resume it.
+
+# Desktop notification (macOS)
+if command -v osascript &> /dev/null; then
+  osascript -e "display notification \"${TASK_MESSAGE:-Re-authentication required}\" with title \"Re-authenticate\" subtitle \"#$TASK_ID $TASK_TITLE\" sound name \"Sosumi\""
+fi
+
+# Desktop notification (Linux)
+if command -v notify-send &> /dev/null; then
+  notify-send -u critical "Re-authenticate" "#$TASK_ID $TASK_TITLE: ${TASK_MESSAGE:-session logged out}"
+fi

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -21,7 +21,8 @@ const (
 	TaskDeleted       = "task.deleted"
 	TaskStarted       = "task.started"
 	TaskWorktreeReady = "task.worktree_ready"
-	TaskBlocked       = "task.blocked" // Task needs input from user
+	TaskBlocked       = "task.blocked"       // Task needs input from user
+	TaskAuthRequired  = "task.auth_required" // Executor session needs re-authentication
 	TaskCompleted     = "task.completed"
 	TaskFailed        = "task.failed"
 )
@@ -150,6 +151,10 @@ func (e *Emitter) EmitTaskWorktreeReady(task *db.Task) {
 
 func (e *Emitter) EmitTaskBlocked(task *db.Task, reason string) {
 	e.Emit(Event{Type: TaskBlocked, TaskID: task.ID, Task: task, Message: reason})
+}
+
+func (e *Emitter) EmitTaskAuthRequired(task *db.Task, reason string) {
+	e.Emit(Event{Type: TaskAuthRequired, TaskID: task.ID, Task: task, Message: reason})
 }
 
 func (e *Emitter) EmitTaskCompleted(task *db.Task) {

--- a/internal/executor/auth_check.go
+++ b/internal/executor/auth_check.go
@@ -1,0 +1,94 @@
+package executor
+
+import (
+	"strings"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/hooks"
+)
+
+// authPattern maps a distinctive substring found in an executor's terminal
+// output to a human-readable explanation of why the session needs attention.
+type authPattern struct {
+	needle string // lowercased substring to search for in pane content
+	reason string // human-readable explanation surfaced to the user
+}
+
+// authRequiredPatterns are phrases Claude Code prints when its login/cloud
+// session has expired or is otherwise unauthenticated. Multi-word phrases are
+// used deliberately to avoid false positives from ordinary task output (e.g. a
+// diff that happens to mention "login").
+var authRequiredPatterns = []authPattern{
+	{"please run /login", "Claude session expired — run /login to re-authenticate"},
+	{"run `/login`", "Claude session expired — run /login to re-authenticate"},
+	{"oauth token has expired", "Claude OAuth token expired — run /login to re-authenticate"},
+	{"oauth token expired", "Claude OAuth token expired — run /login to re-authenticate"},
+	{"session has expired", "Claude session expired — run /login to re-authenticate"},
+	{"invalid api key", "Claude reported an invalid API key — re-authentication required"},
+	{"select login method", "Claude is showing the login screen — re-authentication required"},
+	{"log in with your claude account", "Claude is showing the login screen — re-authentication required"},
+	{"you are not logged in", "Claude is not logged in — run /login to re-authenticate"},
+	{"authentication_error", "Claude returned an authentication error — re-authentication required"},
+}
+
+// DetectAuthPrompt scans captured pane content for signs that the executor's
+// session has been logged out. It returns a human-readable reason and true when
+// a known re-authentication prompt is present.
+func DetectAuthPrompt(content string) (string, bool) {
+	if content == "" {
+		return "", false
+	}
+	lower := strings.ToLower(content)
+	for _, p := range authRequiredPatterns {
+		if strings.Contains(lower, p.needle) {
+			return p.reason, true
+		}
+	}
+	return "", false
+}
+
+// checkAuthStuckTasks scans tasks that should be executing and detects ones that
+// are silently stalled because their executor session is logged out. Detected
+// tasks are moved to blocked (surfacing them on the board and firing the
+// task.blocked hook) and additionally fire the dedicated task.auth_required
+// event/hook so re-authentication can be notified separately from generic input.
+func (e *Executor) checkAuthStuckTasks() {
+	tasks, err := e.db.ListTasks(db.ListTasksOptions{Status: db.StatusProcessing, Limit: 100})
+	if err != nil {
+		return
+	}
+
+	for _, task := range tasks {
+		// Capture the executor pane. Prefer the stable pane ID, which survives
+		// tmux join-pane moving the pane between the daemon and task-ui sessions;
+		// fall back to the daemon window target.
+		captureTarget := task.ClaudePaneID
+		if captureTarget == "" {
+			captureTarget = TmuxSessionName(task.ID)
+		}
+
+		content := CapturePaneContent(captureTarget, 25)
+		reason, stuck := DetectAuthPrompt(content)
+		if !stuck {
+			continue
+		}
+
+		e.logger.Info("Detected logged-out executor session on processing task",
+			"task", task.ID, "reason", reason)
+		e.logLine(task.ID, "error", reason)
+
+		// Move to blocked so it surfaces on the board and fires task.blocked.
+		if err := e.updateStatus(task.ID, db.StatusBlocked); err != nil {
+			e.logger.Error("Failed to block auth-stuck task", "task", task.ID, "error", err)
+		}
+
+		// Re-fetch so hooks/events see the updated status, then fire the
+		// dedicated re-authentication event and hook.
+		updated, gerr := e.db.GetTask(task.ID)
+		if gerr != nil || updated == nil {
+			updated = task
+		}
+		e.events.EmitTaskAuthRequired(updated, reason)
+		e.hooks.Run(hooks.EventAuthRequired, updated, reason)
+	}
+}

--- a/internal/executor/auth_check_test.go
+++ b/internal/executor/auth_check_test.go
@@ -1,0 +1,70 @@
+package executor
+
+import "testing"
+
+func TestDetectAuthPrompt(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "empty content",
+			content: "",
+			want:    false,
+		},
+		{
+			name:    "normal working output",
+			content: "Editing main.go\nRunning tests...\nAll tests passed.",
+			want:    false,
+		},
+		{
+			name:    "please run /login",
+			content: "Your session has ended.\nPlease run /login to continue.",
+			want:    true,
+		},
+		{
+			name:    "oauth token expired",
+			content: "Error: OAuth token has expired. Please re-authenticate.",
+			want:    true,
+		},
+		{
+			name:    "invalid api key",
+			content: "API Error: Invalid API key · Please run /login",
+			want:    true,
+		},
+		{
+			name:    "login screen",
+			content: "Select login method:\n1. Claude account with subscription\n2. Anthropic Console account",
+			want:    true,
+		},
+		{
+			name:    "authentication error",
+			content: `{"type":"error","error":{"type":"authentication_error"}}`,
+			want:    true,
+		},
+		{
+			name:    "case insensitive",
+			content: "PLEASE RUN /LOGIN",
+			want:    true,
+		},
+		{
+			// A diff that merely mentions login should not trip detection.
+			name:    "false positive guard - code mentioning login",
+			content: "func handleLogin() {\n  // redirect to /login on failure\n}",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, got := DetectAuthPrompt(tt.content)
+			if got != tt.want {
+				t.Errorf("DetectAuthPrompt() = %v, want %v (reason=%q)", got, tt.want, reason)
+			}
+			if got && reason == "" {
+				t.Errorf("DetectAuthPrompt() returned match with empty reason")
+			}
+		})
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -734,6 +734,7 @@ func (e *Executor) worker(ctx context.Context) {
 	const suspendCheckInterval = 30
 	const doneCleanupInterval = 150   // 5 minutes at 2 second ticks
 	const staleWorktreeInterval = 300 // 10 minutes at 2 second ticks
+	const authCheckInterval = 15      // 30 seconds at 2 second ticks
 
 	for {
 		select {
@@ -752,6 +753,12 @@ func (e *Executor) worker(ctx context.Context) {
 			// Periodically check for idle blocked tasks to suspend
 			if tickCount%suspendCheckInterval == 0 {
 				e.suspendIdleBlockedTasks()
+			}
+
+			// Periodically check for processing tasks stalled on a logged-out
+			// executor session (e.g. expired Claude login) and surface them.
+			if tickCount%authCheckInterval == 0 {
+				e.checkAuthStuckTasks()
 			}
 
 			// Periodically cleanup Claude processes for inactive done tasks

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -17,10 +17,11 @@ import (
 
 // Event types for hooks
 const (
-	EventTaskBlocked = "task.blocked"
-	EventTaskDone    = "task.done"
-	EventTaskFailed  = "task.failed"
-	EventTaskStarted = "task.started"
+	EventTaskBlocked  = "task.blocked"
+	EventTaskDone     = "task.done"
+	EventTaskFailed   = "task.failed"
+	EventTaskStarted  = "task.started"
+	EventAuthRequired = "task.auth_required" // Executor session needs re-authentication
 )
 
 // Runner executes hooks for task events.


### PR DESCRIPTION
## Problem

When the Claude cloud/login session expires mid-run, a task stays in `processing` forever — nothing surfaces the stall, so it sits idle waiting for a human to notice and re-authenticate.

## Solution

The daemon `worker()` loop now scans `processing` tasks' tmux pane output every **30s** for re-auth prompts (`please run /login`, expired OAuth token, invalid API key, the login screen, `authentication_error`, etc.). When detected, the task is moved to **blocked** (surfacing it on the board + firing the existing `task.blocked` hook) and a **new dedicated `task.auth_required` event/hook** fires so you can wire a re-auth-specific notification separate from generic blocked tasks.

Capture uses the stable `ClaudePaneID` (survives tmux `join-pane` moving the pane between the daemon and `task-ui`), falling back to the daemon window target.

### Design decisions
- **Dedicated event/hook** (`task.auth_required`) fires alongside `task.blocked` — board surfacing *and* a distinct notification channel.
- **Runtime detection only** — no pre-flight check; a task queued while logged out starts and gets caught on the next scan.

## Changes
- `internal/executor/auth_check.go` (new) — `DetectAuthPrompt()` + `checkAuthStuckTasks()`
- `internal/executor/executor.go` — 30s periodic check in `worker()`
- `internal/hooks/hooks.go`, `internal/events/events.go` — new `task.auth_required` event/hook
- `examples/hooks/task.auth_required` (new) + `README.md` — ready-to-use desktop notification
- `internal/executor/auth_check_test.go` (new) — pattern coverage incl. false-positive guard

## Testing
- `go build ./...` green, `gofmt` clean
- `go test ./internal/executor/ ./internal/events/` pass

## Note
The exact wording Claude prints on expiry varies by version. If a logged-out state isn't caught, the pattern list in `auth_check.go` is a one-line addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)