### PR TITLE
Improve new project creation with git repos

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -48,6 +48,7 @@ const (
 	ViewAttachments
 	ViewChangeStatus
 	ViewCommandPalette
+	ViewProjectDetectConfirm // Offer to create a project for the current git repo
 )
 
 // KeyMap defines key bindings.
@@ -450,6 +451,13 @@ type AppModel struct {
 	pendingProjectChangeTask  *db.Task // The updated task data with new project
 	originalProjectChangeTask *db.Task // The original task to delete
 
+	// Project detection state (offer to create a project for the current git repo)
+	projectDetectConfirm      *huh.Form
+	projectDetectConfirmValue bool
+	detectedProject           *db.Project // Inferred project pending user confirmation
+	detectedInstructionSource string      // File the inferred instructions came from
+	projectDetectionOffered   bool        // Guard so we only offer once per session
+
 	// Delete confirmation state
 	deleteConfirm      *huh.Form
 	deleteConfirmValue bool
@@ -728,6 +736,9 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.currentView == ViewProjectChangeConfirm && m.projectChangeConfirm != nil {
 			return m.updateProjectChangeConfirm(msg)
 		}
+		if m.currentView == ViewProjectDetectConfirm && m.projectDetectConfirm != nil {
+			return m.updateProjectDetectConfirm(msg)
+		}
 		if m.currentView == ViewDeleteConfirm && m.deleteConfirm != nil {
 			return m.updateDeleteConfirm(msg)
 		}
@@ -825,6 +836,13 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.isFirstLoad {
 			m.isFirstLoad = false
 			m.showWelcome = len(msg.tasks) == 0
+
+			// If we're inside a git repo that has no TaskYou project yet, offer to
+			// create one (inferring details from the repo). This takes priority over
+			// the generic onboarding form since it's more directly useful.
+			if model, cmd, offered := m.maybeOfferProjectCreation(); offered {
+				return model, cmd
+			}
 
 			// If this is the very first run (no tasks, onboarding not completed), auto-open new task form
 			if len(msg.tasks) == 0 && m.db.IsFirstRun() && !m.onboardingShown {
@@ -1473,6 +1491,8 @@ func (m *AppModel) View() string {
 		return m.viewNewTaskConfirm()
 	case ViewProjectChangeConfirm:
 		return m.viewProjectChangeConfirm()
+	case ViewProjectDetectConfirm:
+		return m.viewProjectDetectConfirm()
 	case ViewDeleteConfirm:
 		return m.viewDeleteConfirm()
 	case ViewCloseConfirm:
@@ -3119,6 +3139,181 @@ func (m *AppModel) updateProjectChangeConfirm(msg tea.Msg) (tea.Model, tea.Cmd) 
 	}
 
 	return m, cmd
+}
+
+// maybeOfferProjectCreation checks whether the current working directory is a git
+// repo without an associated TaskYou project and, if so, opens a confirmation
+// modal offering to create one (with details inferred from the repo). The third
+// return value reports whether the offer was made; when false the caller should
+// continue with its normal flow.
+func (m *AppModel) maybeOfferProjectCreation() (tea.Model, tea.Cmd, bool) {
+	if m.projectDetectionOffered || m.db == nil || m.workingDir == "" {
+		return m, nil, false
+	}
+
+	// Only offer for git repos - non-git directories don't benefit from the
+	// worktree-based project model and aren't a clear signal of intent.
+	if !dirIsGitRepo(m.workingDir) {
+		return m, nil, false
+	}
+
+	// Skip if a project already covers this directory.
+	if proj, err := m.db.GetProjectByPath(m.workingDir); err == nil && proj != nil {
+		return m, nil, false
+	}
+
+	// Respect a previous decline for this path.
+	if v, _ := m.db.GetSetting(projectSuggestionDismissedKey(m.workingDir)); v != "" {
+		return m, nil, false
+	}
+
+	detected, source := detectProjectFromDir(m.workingDir)
+	if detected == nil {
+		return m, nil, false
+	}
+	detected.Name = uniqueProjectName(m.db, detected.Name)
+
+	m.projectDetectionOffered = true
+	model, cmd := m.showProjectDetectConfirm(detected, source)
+	return model, cmd, true
+}
+
+func (m *AppModel) showProjectDetectConfirm(project *db.Project, instructionSource string) (tea.Model, tea.Cmd) {
+	m.detectedProject = project
+	m.detectedInstructionSource = instructionSource
+	m.projectDetectConfirmValue = true
+
+	var desc strings.Builder
+	desc.WriteString(fmt.Sprintf("This directory is a git repo with no TaskYou project yet.\n\nName: %s\nPath: %s\n", project.Name, project.Path))
+	if instructionSource != "" {
+		desc.WriteString(fmt.Sprintf("Instructions: imported from %s\n", instructionSource))
+	} else {
+		desc.WriteString("Instructions: none found (add later in Settings)\n")
+	}
+	desc.WriteString("\nYou can edit any of this later in Settings.")
+
+	modalWidth := min(64, m.width-8)
+	m.projectDetectConfirm = huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Key("create_project").
+				Title("Create a TaskYou project for this repo?").
+				Description(desc.String()).
+				Affirmative("Create Project").
+				Negative("Not Now").
+				Value(&m.projectDetectConfirmValue),
+		),
+	).WithTheme(huh.ThemeDracula()).
+		WithWidth(modalWidth - 6).
+		WithShowHelp(true)
+
+	m.previousView = m.currentView
+	m.currentView = ViewProjectDetectConfirm
+	return m, m.projectDetectConfirm.Init()
+}
+
+func (m *AppModel) viewProjectDetectConfirm() string {
+	if m.projectDetectConfirm == nil {
+		return ""
+	}
+
+	header := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ColorPrimary).
+		MarginBottom(1).
+		Render("📁 New Project Detected")
+
+	formView := m.projectDetectConfirm.View()
+
+	modalWidth := min(64, m.width-8)
+	modalBox := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary).
+		Padding(1, 2).
+		Width(modalWidth)
+
+	modalContent := modalBox.Render(lipgloss.JoinVertical(lipgloss.Center, header, formView))
+
+	return lipgloss.NewStyle().
+		Width(m.width).
+		Height(m.height).
+		Align(lipgloss.Center, lipgloss.Center).
+		Render(modalContent)
+}
+
+func (m *AppModel) updateProjectDetectConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "esc", "ctrl+c":
+			// Treat dismissal like declining so we don't nag on every startup.
+			m.dismissProjectSuggestion()
+			return m, nil
+		}
+	}
+
+	model, cmd := m.projectDetectConfirm.Update(msg)
+	m.projectDetectConfirm = model.(*huh.Form)
+
+	if m.projectDetectConfirm.State == huh.StateCompleted {
+		confirmed := m.projectDetectConfirmValue
+		detected := m.detectedProject
+		m.projectDetectConfirm = nil
+		m.currentView = m.previousView
+
+		if confirmed && detected != nil {
+			m.detectedProject = nil
+			return m, m.createDetectedProject(detected)
+		}
+		m.dismissProjectSuggestion()
+		return m, nil
+	}
+	if m.projectDetectConfirm.State == huh.StateAborted {
+		m.dismissProjectSuggestion()
+		return m, nil
+	}
+
+	return m, cmd
+}
+
+// dismissProjectSuggestion records that the user declined to create a project for
+// the current directory and closes the modal.
+func (m *AppModel) dismissProjectSuggestion() {
+	if m.db != nil && m.workingDir != "" {
+		m.db.SetSetting(projectSuggestionDismissedKey(m.workingDir), "1")
+	}
+	m.projectDetectConfirm = nil
+	m.detectedProject = nil
+	m.currentView = m.previousView
+}
+
+// createDetectedProject persists the inferred project and reloads the board.
+func (m *AppModel) createDetectedProject(project *db.Project) tea.Cmd {
+	// Worktree isolation needs at least one commit to branch from. Detected repos
+	// almost always have commits, but guard against the empty-repo edge case so the
+	// first task doesn't fail to create a worktree.
+	if project.UseWorktrees && project.Path != "" {
+		if err := ensureGitRepoHasCommit(project.Path); err != nil {
+			m.notification = fmt.Sprintf("%s Failed to prepare git repo: %s", IconBlocked(), err.Error())
+			m.notifyUntil = time.Now().Add(5 * time.Second)
+			return nil
+		}
+	}
+
+	if err := m.db.CreateProject(project); err != nil {
+		m.notification = fmt.Sprintf("%s Failed to create project: %s", IconBlocked(), err.Error())
+		m.notifyUntil = time.Now().Add(5 * time.Second)
+		return nil
+	}
+
+	// Make the new project the default selection for the next task.
+	m.db.SetLastUsedProject(project.Name)
+	// Refresh project color cache so the new project renders consistently.
+	LoadProjectColors(m.db)
+
+	m.notification = fmt.Sprintf("%s Created project \"%s\"", IconDone(), project.Name)
+	m.notifyUntil = time.Now().Add(5 * time.Second)
+
+	return m.loadTasks()
 }
 
 func (m *AppModel) showQuitConfirm() (tea.Model, tea.Cmd) {

--- a/internal/ui/debug.go
+++ b/internal/ui/debug.go
@@ -192,6 +192,8 @@ func (m *AppModel) GenerateDebugState() DebugState {
 		s.Modals = &DebugModals{ActiveConfirm: "quit_confirm"}
 	} else if m.currentView == ViewProjectChangeConfirm {
 		s.Modals = &DebugModals{ActiveConfirm: "project_change_confirm"}
+	} else if m.currentView == ViewProjectDetectConfirm {
+		s.Modals = &DebugModals{ActiveConfirm: "project_detect_confirm"}
 	}
 
 	// Filter

--- a/internal/ui/project_detect.go
+++ b/internal/ui/project_detect.go
@@ -1,0 +1,116 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// projectInstructionFiles are the files we look at, in priority order, to infer
+// project instructions when offering to create a project for a git repo.
+var projectInstructionFiles = []string{
+	"AGENTS.md",
+	"CLAUDE.md",
+	"CLAUDE.local.md",
+	".cursorrules",
+	"README.md",
+}
+
+// maxInferredInstructionLen caps how much of an instruction file we import so we
+// don't blow past the form's character limit or paste an entire README.
+const maxInferredInstructionLen = 4000
+
+// dirIsGitRepo reports whether dir is the root of a git repository.
+func dirIsGitRepo(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(dir, ".git"))
+	if err != nil {
+		return false
+	}
+	// .git is usually a directory, but for worktrees/submodules it's a file
+	// pointing at the real git dir. Either way it's a git repo.
+	return info.IsDir() || info.Mode().IsRegular()
+}
+
+// inferProjectName derives a sensible project name from a directory path,
+// falling back to the cleaned base name of the directory.
+func inferProjectName(dir string) string {
+	base := filepath.Base(filepath.Clean(dir))
+	base = strings.TrimSpace(base)
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return "project"
+	}
+	return base
+}
+
+// readProjectInstructions looks for a known instructions file in dir and returns
+// its (possibly truncated) contents along with the file name it came from.
+// Returns empty strings when nothing suitable is found.
+func readProjectInstructions(dir string) (instructions string, sourceFile string) {
+	for _, name := range projectInstructionFiles {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			continue
+		}
+		if len(content) > maxInferredInstructionLen {
+			content = strings.TrimSpace(content[:maxInferredInstructionLen]) + "\n\n…(truncated)"
+		}
+		return content, name
+	}
+	return "", ""
+}
+
+// detectProjectFromDir builds a project pre-filled with values inferred from a
+// git repository at dir. It returns nil when dir is not a git repo. The returned
+// project is NOT persisted - callers decide whether to save it.
+func detectProjectFromDir(dir string) (project *db.Project, instructionSource string) {
+	if !dirIsGitRepo(dir) {
+		return nil, ""
+	}
+
+	instructions, source := readProjectInstructions(dir)
+	return &db.Project{
+		Name:         inferProjectName(dir),
+		Path:         filepath.Clean(dir),
+		Instructions: instructions,
+		UseWorktrees: true,
+	}, source
+}
+
+// uniqueProjectName ensures the inferred name doesn't collide with an existing
+// project name (or alias), appending a numeric suffix if needed.
+func uniqueProjectName(database *db.DB, name string) string {
+	if database == nil {
+		return name
+	}
+	taken := func(candidate string) bool {
+		p, err := database.GetProjectByName(candidate)
+		return err == nil && p != nil
+	}
+	if !taken(name) {
+		return name
+	}
+	for i := 2; i < 1000; i++ {
+		candidate := name + "-" + strconv.Itoa(i)
+		if !taken(candidate) {
+			return candidate
+		}
+	}
+	return name
+}
+
+// projectSuggestionDismissedKey is the settings key used to remember that the
+// user declined the offer to create a project for a given path.
+func projectSuggestionDismissedKey(path string) string {
+	return "project_suggestion_dismissed:" + filepath.Clean(path)
+}

--- a/internal/ui/project_detect_flow_test.go
+++ b/internal/ui/project_detect_flow_test.go
@@ -1,0 +1,124 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func newDetectTestModel(t *testing.T, workingDir string) (*AppModel, *db.DB) {
+	t.Helper()
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return &AppModel{db: database, workingDir: workingDir, width: 80, height: 24}, database
+}
+
+func TestMaybeOfferProjectCreation_OffersForNewGitRepo(t *testing.T) {
+	repo := t.TempDir()
+	mkGitRepo(t, repo)
+	if err := os.WriteFile(filepath.Join(repo, "AGENTS.md"), []byte("be good"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, _ := newDetectTestModel(t, repo)
+
+	_, _, offered := m.maybeOfferProjectCreation()
+	if !offered {
+		t.Fatal("expected offer for new git repo")
+	}
+	if m.currentView != ViewProjectDetectConfirm {
+		t.Fatalf("expected ViewProjectDetectConfirm, got %v", m.currentView)
+	}
+	if m.detectedProject == nil {
+		t.Fatal("expected detectedProject to be set")
+	}
+	if m.detectedProject.Instructions != "be good" {
+		t.Errorf("instructions = %q", m.detectedProject.Instructions)
+	}
+	if m.detectedInstructionSource != "AGENTS.md" {
+		t.Errorf("source = %q", m.detectedInstructionSource)
+	}
+
+	// Should not offer a second time in the same session.
+	if _, _, offered := m.maybeOfferProjectCreation(); offered {
+		t.Fatal("should not offer twice in a session")
+	}
+}
+
+func TestMaybeOfferProjectCreation_SkipsNonGit(t *testing.T) {
+	m, _ := newDetectTestModel(t, t.TempDir())
+	if _, _, offered := m.maybeOfferProjectCreation(); offered {
+		t.Fatal("should not offer for a non-git directory")
+	}
+}
+
+func TestMaybeOfferProjectCreation_SkipsWhenDismissed(t *testing.T) {
+	repo := t.TempDir()
+	mkGitRepo(t, repo)
+	m, database := newDetectTestModel(t, repo)
+	if err := database.SetSetting(projectSuggestionDismissedKey(repo), "1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, offered := m.maybeOfferProjectCreation(); offered {
+		t.Fatal("should not offer when previously dismissed")
+	}
+}
+
+func TestMaybeOfferProjectCreation_SkipsWhenProjectExists(t *testing.T) {
+	repo := t.TempDir()
+	mkGitRepo(t, repo)
+	m, database := newDetectTestModel(t, repo)
+	if err := database.CreateProject(&db.Project{Name: "existing", Path: repo}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, offered := m.maybeOfferProjectCreation(); offered {
+		t.Fatal("should not offer when a project already covers the directory")
+	}
+}
+
+func TestDismissProjectSuggestionPersists(t *testing.T) {
+	repo := t.TempDir()
+	mkGitRepo(t, repo)
+	m, database := newDetectTestModel(t, repo)
+
+	m.dismissProjectSuggestion()
+
+	v, _ := database.GetSetting(projectSuggestionDismissedKey(repo))
+	if v != "1" {
+		t.Fatalf("expected dismissal to be persisted, got %q", v)
+	}
+	// And a fresh model should now skip the offer.
+	m2, _ := newDetectTestModel(t, repo)
+	m2.db = database
+	if _, _, offered := m2.maybeOfferProjectCreation(); offered {
+		t.Fatal("should not offer after dismissal persisted")
+	}
+}
+
+func TestCreateDetectedProjectPersists(t *testing.T) {
+	repo := t.TempDir()
+	m, database := newDetectTestModel(t, repo)
+
+	// UseWorktrees false avoids invoking git in the test; the persistence,
+	// last-used-project, and notification logic is what we're verifying here.
+	project := &db.Project{Name: "myrepo", Path: repo, Instructions: "x", UseWorktrees: false}
+
+	m.createDetectedProject(project)
+
+	got, err := database.GetProjectByName("myrepo")
+	if err != nil || got == nil {
+		t.Fatalf("expected project to be created, err=%v", err)
+	}
+	last, _ := database.GetLastUsedProject()
+	if last != "myrepo" {
+		t.Errorf("expected last-used project myrepo, got %q", last)
+	}
+	if m.notification == "" {
+		t.Error("expected a success notification")
+	}
+}

--- a/internal/ui/project_detect_test.go
+++ b/internal/ui/project_detect_test.go
@@ -1,0 +1,164 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func mkGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+}
+
+func TestDirIsGitRepo(t *testing.T) {
+	tmp := t.TempDir()
+
+	if dirIsGitRepo(tmp) {
+		t.Fatalf("expected non-git dir to be false")
+	}
+	if dirIsGitRepo("") {
+		t.Fatalf("expected empty path to be false")
+	}
+
+	mkGitRepo(t, tmp)
+	if !dirIsGitRepo(tmp) {
+		t.Fatalf("expected git dir to be true")
+	}
+
+	// A .git file (as used by worktrees/submodules) should also count.
+	fileRepo := filepath.Join(t.TempDir())
+	if err := os.WriteFile(filepath.Join(fileRepo, ".git"), []byte("gitdir: /somewhere\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	if !dirIsGitRepo(fileRepo) {
+		t.Fatalf("expected dir with .git file to be a git repo")
+	}
+}
+
+func TestInferProjectName(t *testing.T) {
+	cases := map[string]string{
+		"/Users/bruno/Projects/my-app": "my-app",
+		"/tmp/foo/":                    "foo",
+		"my-app":                       "my-app",
+	}
+	for in, want := range cases {
+		if got := inferProjectName(in); got != want {
+			t.Errorf("inferProjectName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestReadProjectInstructions(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Nothing present yet.
+	if got, src := readProjectInstructions(tmp); got != "" || src != "" {
+		t.Fatalf("expected empty result, got %q from %q", got, src)
+	}
+
+	// CLAUDE.md present but AGENTS.md takes priority when both exist.
+	if err := os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("claude instructions"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, src := readProjectInstructions(tmp)
+	if got != "claude instructions" || src != "CLAUDE.md" {
+		t.Fatalf("got (%q, %q), want claude instructions from CLAUDE.md", got, src)
+	}
+
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte("  agents instructions  "), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, src = readProjectInstructions(tmp)
+	if got != "agents instructions" || src != "AGENTS.md" {
+		t.Fatalf("got (%q, %q), want agents instructions from AGENTS.md", got, src)
+	}
+}
+
+func TestReadProjectInstructionsTruncates(t *testing.T) {
+	tmp := t.TempDir()
+	big := make([]byte, maxInferredInstructionLen+500)
+	for i := range big {
+		big[i] = 'a'
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), big, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := readProjectInstructions(tmp)
+	// The raw content must have been cut down to roughly the cap (plus the
+	// truncation marker).
+	if len(got) > maxInferredInstructionLen+len("\n\n…(truncated)") {
+		t.Fatalf("instructions not truncated: len=%d", len(got))
+	}
+	if !strings.HasSuffix(got, "…(truncated)") {
+		t.Fatalf("expected truncation marker, got suffix %q", got[len(got)-20:])
+	}
+}
+
+func TestDetectProjectFromDir(t *testing.T) {
+	tmp := t.TempDir()
+	// Not a git repo -> nil.
+	if p, _ := detectProjectFromDir(tmp); p != nil {
+		t.Fatalf("expected nil for non-git dir")
+	}
+
+	mkGitRepo(t, tmp)
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte("do the thing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, src := detectProjectFromDir(tmp)
+	if p == nil {
+		t.Fatal("expected project, got nil")
+	}
+	if !p.UseWorktrees {
+		t.Errorf("expected UseWorktrees true")
+	}
+	if p.Instructions != "do the thing" {
+		t.Errorf("instructions = %q", p.Instructions)
+	}
+	if src != "AGENTS.md" {
+		t.Errorf("source = %q", src)
+	}
+	if p.Name != filepath.Base(tmp) {
+		t.Errorf("name = %q, want %q", p.Name, filepath.Base(tmp))
+	}
+}
+
+func TestUniqueProjectName(t *testing.T) {
+	tmpDir := t.TempDir()
+	database, err := db.Open(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	// nil-safe
+	if got := uniqueProjectName(nil, "foo"); got != "foo" {
+		t.Fatalf("nil db should return name unchanged, got %q", got)
+	}
+
+	if got := uniqueProjectName(database, "myproj"); got != "myproj" {
+		t.Fatalf("expected myproj, got %q", got)
+	}
+
+	if err := database.CreateProject(&db.Project{Name: "myproj", Path: tmpDir}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if got := uniqueProjectName(database, "myproj"); got != "myproj-2" {
+		t.Fatalf("expected myproj-2 after collision, got %q", got)
+	}
+}
+
+func TestProjectSuggestionDismissedKey(t *testing.T) {
+	k1 := projectSuggestionDismissedKey("/tmp/foo/")
+	k2 := projectSuggestionDismissedKey("/tmp/foo")
+	if k1 != k2 {
+		t.Fatalf("expected cleaned paths to produce equal keys: %q vs %q", k1, k2)
+	}
+}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -266,6 +265,7 @@ func (m *SettingsModel) updateBrowser(msg tea.Msg) (*SettingsModel, tea.Cmd) {
 func (m *SettingsModel) showProjectForm(project *db.Project) (*SettingsModel, tea.Cmd) {
 	m.editingProject = true
 	m.editProject = project
+	m.err = nil
 
 	// Initialize form values
 	m.projectFormName = project.Name
@@ -461,27 +461,6 @@ func ensureGitRepoHasCommit(path string) error {
 	return nil
 }
 
-// findNestedGitRepos searches for .git directories inside the given path (excluding root)
-func findNestedGitRepos(rootPath string) []string {
-	var nested []string
-	filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || !d.IsDir() {
-			return nil
-		}
-		// Skip common dependency/build directories
-		if d.Name() == "node_modules" || d.Name() == "vendor" || d.Name() == ".task-worktrees" {
-			return filepath.SkipDir
-		}
-		// Check for nested .git (not the root one)
-		if d.Name() == ".git" && filepath.Dir(path) != rootPath {
-			nested = append(nested, filepath.Dir(path))
-			return filepath.SkipDir
-		}
-		return nil
-	})
-	return nested
-}
-
 // initGitRepo initializes a git repo with an initial commit
 func initGitRepo(path string) error {
 	// Create directory if needed
@@ -556,22 +535,17 @@ func (m *SettingsModel) saveProject() (*SettingsModel, tea.Cmd) {
 
 		if useWorktrees {
 			if isGitRepo(path) {
-				// Existing git repo - check for nested repos
-				nested := findNestedGitRepos(path)
-				if len(nested) > 0 {
-					m.err = fmt.Errorf("directory contains %d nested git repo(s) - select a single repo instead", len(nested))
-					return m, nil
-				}
-				// Valid existing git repo - ensure it has at least one commit for worktrees
+				// Existing git repo. Nested/sub git repos are allowed - they are
+				// simply left untracked by the parent repo and don't interfere
+				// with worktree isolation, so there's no reason to reject them.
+				// Ensure the repo has at least one commit so worktrees have a base.
 				if err := ensureGitRepoHasCommit(path); err != nil {
-					m.err = fmt.Errorf("failed to initialize git commit: %w", err)
-					return m, nil
+					return m.reshowProjectFormWithError(fmt.Errorf("failed to initialize git commit: %w", err))
 				}
 			} else {
 				// Not a git repo - initialize it (required for worktree isolation)
 				if err := initGitRepo(path); err != nil {
-					m.err = fmt.Errorf("failed to initialize git: %w", err)
-					return m, nil
+					return m.reshowProjectFormWithError(fmt.Errorf("failed to initialize git: %w", err))
 				}
 			}
 		}
@@ -580,14 +554,12 @@ func (m *SettingsModel) saveProject() (*SettingsModel, tea.Cmd) {
 		if useWorktrees {
 			// Path doesn't exist - create and initialize git repo
 			if err := initGitRepo(path); err != nil {
-				m.err = fmt.Errorf("failed to create project: %w", err)
-				return m, nil
+				return m.reshowProjectFormWithError(fmt.Errorf("failed to create project: %w", err))
 			}
 		} else {
 			// Path doesn't exist - just create the directory
 			if err := os.MkdirAll(path, 0755); err != nil {
-				m.err = fmt.Errorf("failed to create project directory: %w", err)
-				return m, nil
+				return m.reshowProjectFormWithError(fmt.Errorf("failed to create project directory: %w", err))
 			}
 		}
 	}
@@ -620,6 +592,25 @@ func (m *SettingsModel) saveProject() (*SettingsModel, tea.Cmd) {
 	m.err = nil
 	m.loadSettings()
 	return m, nil
+}
+
+// reshowProjectFormWithError re-opens the project form preserving the values the
+// user already entered, displaying err. This avoids dropping the user back to the
+// settings list (and losing their work) when saving fails - e.g. a git init error
+// that surfaces only after a directory has been selected in the file browser.
+func (m *SettingsModel) reshowProjectFormWithError(err error) (*SettingsModel, tea.Cmd) {
+	if m.editProject == nil {
+		m.editProject = &db.Project{}
+	}
+	m.editProject.Name = strings.TrimSpace(m.projectFormName)
+	m.editProject.Aliases = strings.TrimSpace(m.projectFormAliases)
+	m.editProject.Instructions = strings.TrimSpace(m.projectFormInstructions)
+	m.editProject.ClaudeConfigDir = strings.TrimSpace(m.projectFormClaudeConfigDir)
+	m.editProject.UseWorktrees = m.projectFormUseWorktrees
+
+	model, cmd := m.showProjectForm(m.editProject)
+	model.err = err
+	return model, cmd
 }
 
 func (m *SettingsModel) saveTaskType() (*SettingsModel, tea.Cmd) {
@@ -787,6 +778,15 @@ func (m *SettingsModel) viewProjectFormModal() string {
 	}
 
 	formView := m.projectForm.View()
+
+	// Surface any save error inline so the user can fix it without losing work.
+	if m.err != nil {
+		formView = lipgloss.JoinVertical(lipgloss.Left,
+			formView,
+			"",
+			Error.Render(m.err.Error()),
+		)
+	}
 
 	// Modal box with border
 	modalWidth := min(70, m.width-8)


### PR DESCRIPTION
## Summary

Addresses two pain points when creating TaskYou projects from git repos.

### 1. Nested git repos no longer destroy your work
Previously, creating a project in a directory that was a git repo **but also contained sub-repos** failed outright with `directory contains N nested git repo(s)`, dumping you back to the settings list and **losing everything you'd typed**.

- Sub/nested git repos are now **allowed** — they're left untracked by the parent and don't interfere with worktree isolation, so there was no good reason to reject them.
- As a general safety net, any *other* save failure (git init/commit error) now **re-shows the form with the error inline and your values preserved**, instead of discarding your work.

### 2. Auto-detect project on startup
When `ty` launches inside a git repo that has **no TaskYou project yet**, it now offers to create one:

- **Name** inferred from the directory (deduped against existing project names).
- **Instructions** imported from the first of `AGENTS.md`, `CLAUDE.md`, `CLAUDE.local.md`, `.cursorrules`, `README.md` (truncated to a sane length).
- Declining is **remembered per-path** so it won't nag on every launch.
- Skips cleanly when a project already covers the directory, when not a git repo, or when previously dismissed.

## Files changed
- `internal/ui/project_detect.go` *(new)* — git-repo detection + inference helpers.
- `internal/ui/app.go` — `ViewProjectDetectConfirm` modal, offer/confirm/dismiss/create flow, wired into first-load.
- `internal/ui/settings.go` — allow nested repos; `reshowProjectFormWithError` to preserve work; inline error in the form modal; removed the now-unused `findNestedGitRepos`.
- `internal/ui/debug.go` — expose the new modal in debug state.
- `internal/ui/project_detect_test.go`, `internal/ui/project_detect_flow_test.go` *(new)* — unit + flow tests.

## Testing
- `go build ./...` ✅
- `go test ./internal/ui/ ./internal/db/` ✅
- `golangci-lint run ./internal/ui/` → 0 issues ✅

## Notes / follow-ups
- The detect flow creates the project directly (with inferred values) on confirm; users can fine-tune name/aliases/instructions afterward in Settings. A future enhancement could open the editable project form pre-filled instead of creating immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)