### PR TITLE
Reconcile orphaned (processing) tasks on daemon startup

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -71,6 +71,10 @@ type Executor struct {
 
 	executorSlug string
 	executorName string
+
+	// windowExistsFn reports whether a live executor tmux window exists for a
+	// task. Overridable in tests; nil means use tmuxWindowExistsForTask.
+	windowExistsFn func(taskID int64) bool
 }
 
 // DefaultSuspendIdleTimeout is the default time a blocked task must be idle before being suspended.
@@ -242,6 +246,11 @@ func (e *Executor) Start(ctx context.Context) {
 	// Recover stale tmux references on startup (handles crash recovery)
 	e.recoverStaleTmuxRefs()
 
+	// Reconcile tasks left in 'processing' with no live executor (e.g. after a
+	// daemon restart killed the executor panes). Without this they stay stuck in
+	// 'processing' forever and the board lies about them still running.
+	e.reconcileOrphanedTasks()
+
 	// Run stale worktree cleanup on startup (and then periodically in worker loop)
 	go e.cleanupStaleWorktrees()
 
@@ -290,6 +299,91 @@ func (e *Executor) recoverStaleTmuxRefs() {
 			"window_ids", staleWindow,
 		)
 	}
+}
+
+// reconcileOrphanedTasks moves tasks that are stuck in 'processing' but have no
+// live executor window back to 'blocked' so the board reflects reality. This
+// happens when the daemon is restarted (or crashes) while tasks are executing:
+// the executor tmux windows/processes are killed, but nothing transitions the
+// task out of 'processing', so it appears to be running forever.
+//
+// Tasks are moved to 'blocked' (rather than silently re-queued) so the failure
+// is visible and the user can retry, which resumes the saved Claude session.
+// Uncommitted work in the worktree is left untouched.
+func (e *Executor) reconcileOrphanedTasks() {
+	tasks, err := e.db.ListTasks(db.ListTasksOptions{Status: db.StatusProcessing, Limit: 1000})
+	if err != nil {
+		e.logger.Error("Failed to list processing tasks for orphan reconciliation", "error", err)
+		return
+	}
+
+	reconciled := 0
+	for _, task := range tasks {
+		// Skip tasks this executor is actively running (defensive: at startup the
+		// running set is empty, but reconcile must never touch a live task).
+		e.mu.RLock()
+		running := e.runningTasks[task.ID]
+		e.mu.RUnlock()
+		if running {
+			continue
+		}
+
+		// A processing task with a live executor window is genuinely still
+		// running (e.g. the tmux server survived a daemon restart) - leave it.
+		windowExists := tmuxWindowExistsForTask
+		if e.windowExistsFn != nil {
+			windowExists = e.windowExistsFn
+		}
+		if windowExists(task.ID) {
+			continue
+		}
+
+		msg := "Executor terminated (daemon restart) - task was 'processing' with no live executor. Moved to blocked; retry to resume."
+		if err := e.updateStatus(task.ID, db.StatusBlocked); err != nil {
+			e.logger.Error("Failed to reconcile orphaned task", "id", task.ID, "error", err)
+			continue
+		}
+		e.logLine(task.ID, "error", msg)
+		e.hooks.OnStatusChange(task, db.StatusBlocked, msg)
+		e.logger.Info("Reconciled orphaned processing task", "id", task.ID, "title", task.Title)
+		reconciled++
+	}
+
+	if reconciled > 0 {
+		e.logger.Info("Reconciled orphaned processing tasks", "count", reconciled)
+	}
+}
+
+// tmuxWindowExistsForTask reports whether a live executor tmux window exists for
+// the task in any daemon session. The executor runs inside a window named
+// "task-<id>" within a "task-daemon-*" session; if that window is gone, the
+// executor process is gone too.
+func tmuxWindowExistsForTask(taskID int64) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "tmux", "list-windows",
+		"-a", "-F", "#{session_name}:#{window_name}").Output()
+	if err != nil {
+		// tmux not running / no server => no windows exist.
+		return false
+	}
+
+	windowName := TmuxWindowName(taskID)
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		sessionName, name := parts[0], parts[1]
+		if strings.HasPrefix(sessionName, "task-daemon-") && name == windowName {
+			return true
+		}
+	}
+	return false
 }
 
 // Stop stops the background worker.

--- a/internal/executor/reconcile_test.go
+++ b/internal/executor/reconcile_test.go
@@ -1,0 +1,155 @@
+package executor
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+func newTestExecutor(t *testing.T) (*Executor, *db.DB) {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp("", "test-reconcile-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	if err := database.CreateProject(&db.Project{Name: "test", Path: "/tmp/test"}); err != nil {
+		t.Fatal(err)
+	}
+
+	exec := New(database, &config.Config{})
+	return exec, database
+}
+
+func createProcessingTask(t *testing.T, database *db.DB, title string) *db.Task {
+	t.Helper()
+	task := &db.Task{Title: title, Type: "task", Project: "test"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateTaskStatus(task.ID, db.StatusProcessing); err != nil {
+		t.Fatal(err)
+	}
+	return task
+}
+
+// TestReconcileOrphanedTasksMovesDeadTasksToBlocked verifies that a task stuck in
+// 'processing' with no live executor window is moved to 'blocked' on startup,
+// with a log entry recording why.
+func TestReconcileOrphanedTasksMovesDeadTasksToBlocked(t *testing.T) {
+	exec, database := newTestExecutor(t)
+
+	orphan := createProcessingTask(t, database, "orphaned task")
+
+	// No live executor window for any task.
+	exec.windowExistsFn = func(taskID int64) bool { return false }
+
+	exec.reconcileOrphanedTasks()
+
+	got, err := database.GetTask(orphan.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.StatusBlocked {
+		t.Fatalf("expected orphaned task to be blocked, got %q", got.Status)
+	}
+
+	// A log entry should record the reconciliation.
+	logs, err := database.GetTaskLogs(orphan.ID, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, l := range logs {
+		if l.LineType == "error" && strings.Contains(l.Content, "daemon restart") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a log entry recording the orphan reconciliation, got %+v", logs)
+	}
+}
+
+// TestReconcileOrphanedTasksLeavesLiveTasksAlone verifies that a processing task
+// whose executor window is still alive is not touched.
+func TestReconcileOrphanedTasksLeavesLiveTasksAlone(t *testing.T) {
+	exec, database := newTestExecutor(t)
+
+	live := createProcessingTask(t, database, "live task")
+
+	// The executor window exists for this task - it's genuinely running.
+	exec.windowExistsFn = func(taskID int64) bool { return true }
+
+	exec.reconcileOrphanedTasks()
+
+	got, err := database.GetTask(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.StatusProcessing {
+		t.Fatalf("expected live task to stay processing, got %q", got.Status)
+	}
+}
+
+// TestReconcileOrphanedTasksSkipsRunningTasks verifies that a task this executor
+// is actively running is never reconciled, even if no window is detected.
+func TestReconcileOrphanedTasksSkipsRunningTasks(t *testing.T) {
+	exec, database := newTestExecutor(t)
+
+	running := createProcessingTask(t, database, "running task")
+
+	exec.mu.Lock()
+	exec.runningTasks[running.ID] = true
+	exec.mu.Unlock()
+
+	exec.windowExistsFn = func(taskID int64) bool { return false }
+
+	exec.reconcileOrphanedTasks()
+
+	got, err := database.GetTask(running.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.StatusProcessing {
+		t.Fatalf("expected actively-running task to stay processing, got %q", got.Status)
+	}
+}
+
+// TestReconcileOrphanedTasksOnlyTouchesProcessing verifies non-processing tasks
+// are ignored.
+func TestReconcileOrphanedTasksOnlyTouchesProcessing(t *testing.T) {
+	exec, database := newTestExecutor(t)
+
+	queued := &db.Task{Title: "queued task", Type: "task", Project: "test"}
+	if err := database.CreateTask(queued); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateTaskStatus(queued.ID, db.StatusQueued); err != nil {
+		t.Fatal(err)
+	}
+
+	exec.windowExistsFn = func(taskID int64) bool { return false }
+
+	exec.reconcileOrphanedTasks()
+
+	got, err := database.GetTask(queued.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.StatusQueued {
+		t.Fatalf("expected queued task to stay queued, got %q", got.Status)
+	}
+}


### PR DESCRIPTION
## Problem

When the daemon is restarted (e.g. `ty daemon restart`) while tasks are executing, the executor tmux windows/processes are killed, but the affected tasks remain in status `processing` indefinitely. There's no transition to `blocked`/`failed` and no log entry recording that the executor died.

The result is an **invisible failure**:
- `ty board` / `ty show` report `processing` (the board lies — nothing is running)
- `ty output <id>` returns *"Executor pane no longer exists"*
- Uncommitted work sits in the worktree with no commit/PR
- Re-running is awkward: `ty execute` refuses with *"already processing"*; you had to manually `ty status <id> queued` to recover

The only way to detect it was to manually cross-check tmux windows/processes against task status.

## Fix

On daemon startup — right after the existing `recoverStaleTmuxRefs()` — `Start()` now calls `reconcileOrphanedTasks()`:

1. List all tasks in `processing`.
2. Skip any task this executor is actively running (defensive; the running set is empty at startup).
3. Skip any task whose executor tmux window (`task-<id>` in a `task-daemon-*` session) still exists — the tmux server may have survived the restart, so the task is genuinely still running.
4. For the rest (stuck `processing`, no live executor), move them to `blocked`, append an `error` log line, and fire the status-change hook:
   > `Executor terminated (daemon restart) - task was 'processing' with no live executor. Moved to blocked; retry to resume.`

### Why `blocked` rather than auto-requeue

- Makes the failure **visible** (the primary complaint) instead of silently restarting.
- Frees the task from `processing`, so retry/execute work instead of refusing with "already processing".
- Leaves the worktree contents **untouched**, so a retry resumes the saved Claude session (`claude_session_id` persists across restarts) rather than discarding in-flight work.

## Implementation notes

- `tmuxWindowExistsForTask(taskID)` checks all `task-daemon-*` sessions for a `task-<id>` window — robust across the daemon-session rename that a restart causes (the session name includes the daemon PID).
- The liveness check is injected via an overridable `windowExistsFn` field on `Executor` so the reconciliation logic is unit-testable without a live tmux server.

## Tests

`internal/executor/reconcile_test.go`:
- dead task (no window) -> moved to `blocked` with a log entry
- live task (window exists) -> left `processing`
- actively-running task -> left `processing`
- non-`processing` task (e.g. `queued`) -> untouched

## Out of scope (noted in the ticket as related / lower priority)

- Worktree-reset consistency on requeue.
- Preserving daemon permission mode (safe vs dangerous) across restart.
- gh GraphQL->REST fallback for PR creation when rate-limited (this PR itself had to use the REST fallback after `gh pr create` hit the GraphQL limit — concrete evidence for that item).

These are independent of the orphan-reconciliation bug and can be tackled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
