### PR TITLE
Add Claude Code auto mode as 4th permission set + disambiguate "accept-edits"

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -746,7 +746,7 @@ Examples:
 	createCmd.Flags().String("effort", "", "Per-task Claude effort override: low, medium, high, xhigh, max (default: Claude's global default)")
 	createCmd.Flags().BoolP("execute", "x", false, "Queue task for immediate execution")
 	createCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (alias for --permission-mode dangerous)")
-	createCmd.Flags().String("permission-mode", "", "Permission mode: default (prompt), accept-edits (auto-accept file edits, still prompt for risky actions; alias: auto), dangerous (skip all). Defaults to the project's setting")
+	createCmd.Flags().String("permission-mode", "", "Permission mode: default (prompt), accept-edits (auto-accept file edits), auto (Claude Code auto mode: auto-approve safe actions, block risky ones), dangerous (skip all). Defaults to the project's setting")
 	createCmd.Flags().String("tags", "", "Task tags (comma-separated)")
 	createCmd.Flags().Bool("pinned", false, "Pin the task to the top of its column")
 	createCmd.Flags().StringP("branch", "b", "", "Existing branch to checkout for worktree (e.g., fix/ui-overflow)")
@@ -1602,13 +1602,15 @@ Examples:
 			case db.PermissionModeDangerous:
 				msg += " (dangerous mode)"
 			case db.PermissionModeAuto:
+				msg += " (auto mode)"
+			case db.PermissionModeAcceptEdits:
 				msg += " (accept-edits mode)"
 			}
 			fmt.Println(successStyle.Render(msg))
 		},
 	}
 	executeCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (alias for --permission-mode dangerous)")
-	executeCmd.Flags().String("permission-mode", "", "Override permission mode: default (prompt), accept-edits (auto-accept file edits; alias: auto), dangerous (skip all)")
+	executeCmd.Flags().String("permission-mode", "", "Override permission mode: default (prompt), accept-edits (auto-accept file edits), auto (Claude Code auto mode), dangerous (skip all)")
 	rootCmd.AddCommand(executeCmd)
 
 	statusCmd := &cobra.Command{
@@ -2532,7 +2534,7 @@ Examples:
 	projectsCreateCmd.Flags().StringP("color", "c", "", "Hex color for display (e.g., #61AFEF)")
 	projectsCreateCmd.Flags().StringP("aliases", "a", "", "Comma-separated aliases for lookup")
 	projectsCreateCmd.Flags().String("claude-config-dir", "", "Override CLAUDE_CONFIG_DIR for this project")
-	projectsCreateCmd.Flags().String("permission-mode", "", "Default permission mode for tasks: default (prompt), accept-edits (auto-accept file edits; alias: auto), dangerous (skip all)")
+	projectsCreateCmd.Flags().String("permission-mode", "", "Default permission mode for tasks: default (prompt), accept-edits (auto-accept file edits), auto (Claude Code auto mode), dangerous (skip all)")
 	projectsCreateCmd.Flags().Bool("no-git", false, "Disable git worktrees (for non-git projects)")
 	projectsCreateCmd.Flags().Bool("json", false, "Output in JSON format")
 	projectsCreateCmd.MarkFlagRequired("path")
@@ -2590,7 +2592,7 @@ Examples:
 	projectsUpdateCmd.Flags().StringP("aliases", "a", "", "Comma-separated aliases for lookup")
 	projectsUpdateCmd.Flags().String("claude-config-dir", "", "Override CLAUDE_CONFIG_DIR for this project")
 	projectsUpdateCmd.Flags().String("context", "", "Cached project context summary")
-	projectsUpdateCmd.Flags().String("permission-mode", "", "Default permission mode for tasks: default (prompt), accept-edits (auto-accept file edits; alias: auto), dangerous (skip all)")
+	projectsUpdateCmd.Flags().String("permission-mode", "", "Default permission mode for tasks: default (prompt), accept-edits (auto-accept file edits), auto (Claude Code auto mode), dangerous (skip all)")
 	projectsUpdateCmd.Flags().Bool("no-git", false, "Disable git worktrees (for non-git projects)")
 	projectsUpdateCmd.Flags().Bool("git", false, "Enable git worktrees (default)")
 	projectsUpdateCmd.Flags().Bool("json", false, "Output in JSON format")
@@ -5700,7 +5702,7 @@ func updateProjectCLI(currentName, newName, path, instructions, color, aliases, 
 	if permissionMode != "" {
 		normalized := db.NormalizePermissionMode(permissionMode)
 		if normalized == "" {
-			fmt.Fprintln(os.Stderr, errorStyle.Render("Error: invalid permission mode (use default, accept-edits, or dangerous)"))
+			fmt.Fprintln(os.Stderr, errorStyle.Render("Error: invalid permission mode (use default, accept-edits, auto, or dangerous)"))
 			os.Exit(1)
 		}
 		project.DefaultPermissionMode = normalized

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -746,7 +746,7 @@ Examples:
 	createCmd.Flags().String("effort", "", "Per-task Claude effort override: low, medium, high, xhigh, max (default: Claude's global default)")
 	createCmd.Flags().BoolP("execute", "x", false, "Queue task for immediate execution")
 	createCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (alias for --permission-mode dangerous)")
-	createCmd.Flags().String("permission-mode", "", "Permission mode: default (prompt), auto (auto-accept edits), dangerous (skip all). Defaults to the project's setting")
+	createCmd.Flags().String("permission-mode", "", "Permission mode: default (prompt), accept-edits (auto-accept file edits, still prompt for risky actions; alias: auto), dangerous (skip all). Defaults to the project's setting")
 	createCmd.Flags().String("tags", "", "Task tags (comma-separated)")
 	createCmd.Flags().Bool("pinned", false, "Pin the task to the top of its column")
 	createCmd.Flags().StringP("branch", "b", "", "Existing branch to checkout for worktree (e.g., fix/ui-overflow)")
@@ -1602,13 +1602,13 @@ Examples:
 			case db.PermissionModeDangerous:
 				msg += " (dangerous mode)"
 			case db.PermissionModeAuto:
-				msg += " (auto mode)"
+				msg += " (accept-edits mode)"
 			}
 			fmt.Println(successStyle.Render(msg))
 		},
 	}
 	executeCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (alias for --permission-mode dangerous)")
-	executeCmd.Flags().String("permission-mode", "", "Override permission mode: default (prompt), auto (auto-accept edits), dangerous (skip all)")
+	executeCmd.Flags().String("permission-mode", "", "Override permission mode: default (prompt), accept-edits (auto-accept file edits; alias: auto), dangerous (skip all)")
 	rootCmd.AddCommand(executeCmd)
 
 	statusCmd := &cobra.Command{
@@ -2532,7 +2532,7 @@ Examples:
 	projectsCreateCmd.Flags().StringP("color", "c", "", "Hex color for display (e.g., #61AFEF)")
 	projectsCreateCmd.Flags().StringP("aliases", "a", "", "Comma-separated aliases for lookup")
 	projectsCreateCmd.Flags().String("claude-config-dir", "", "Override CLAUDE_CONFIG_DIR for this project")
-	projectsCreateCmd.Flags().String("permission-mode", "", "Default permission mode for tasks: default (prompt), auto (auto-accept edits), dangerous (skip all)")
+	projectsCreateCmd.Flags().String("permission-mode", "", "Default permission mode for tasks: default (prompt), accept-edits (auto-accept file edits; alias: auto), dangerous (skip all)")
 	projectsCreateCmd.Flags().Bool("no-git", false, "Disable git worktrees (for non-git projects)")
 	projectsCreateCmd.Flags().Bool("json", false, "Output in JSON format")
 	projectsCreateCmd.MarkFlagRequired("path")
@@ -2590,7 +2590,7 @@ Examples:
 	projectsUpdateCmd.Flags().StringP("aliases", "a", "", "Comma-separated aliases for lookup")
 	projectsUpdateCmd.Flags().String("claude-config-dir", "", "Override CLAUDE_CONFIG_DIR for this project")
 	projectsUpdateCmd.Flags().String("context", "", "Cached project context summary")
-	projectsUpdateCmd.Flags().String("permission-mode", "", "Default permission mode for tasks: default (prompt), auto (auto-accept edits), dangerous (skip all)")
+	projectsUpdateCmd.Flags().String("permission-mode", "", "Default permission mode for tasks: default (prompt), accept-edits (auto-accept file edits; alias: auto), dangerous (skip all)")
 	projectsUpdateCmd.Flags().Bool("no-git", false, "Disable git worktrees (for non-git projects)")
 	projectsUpdateCmd.Flags().Bool("git", false, "Enable git worktrees (default)")
 	projectsUpdateCmd.Flags().Bool("json", false, "Output in JSON format")
@@ -5700,7 +5700,7 @@ func updateProjectCLI(currentName, newName, path, instructions, color, aliases, 
 	if permissionMode != "" {
 		normalized := db.NormalizePermissionMode(permissionMode)
 		if normalized == "" {
-			fmt.Fprintln(os.Stderr, errorStyle.Render("Error: invalid permission mode (use default, auto, or dangerous)"))
+			fmt.Fprintln(os.Stderr, errorStyle.Render("Error: invalid permission mode (use default, accept-edits, or dangerous)"))
 			os.Exit(1)
 		}
 		project.DefaultPermissionMode = normalized

--- a/internal/db/permission_mode_test.go
+++ b/internal/db/permission_mode_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestNormalizePermissionMode(t *testing.T) {
 	cases := map[string]string{
-		"auto":         PermissionModeAuto, // legacy alias, kept for back-compat
-		"accept-edits": PermissionModeAuto, // unambiguous spelling normalizes to the canonical value
-		"accept_edits": PermissionModeAuto,
-		"acceptEdits":  PermissionModeAuto, // Claude Code's own spelling
-		"  Auto  ":     PermissionModeAuto, // trimmed + case-insensitive
+		"auto":         PermissionModeAuto,        // Claude Code's auto mode
+		"  Auto  ":     PermissionModeAuto,        // trimmed + case-insensitive
+		"accept-edits": PermissionModeAcceptEdits, // canonical acceptEdits value
+		"accept_edits": PermissionModeAcceptEdits,
+		"acceptEdits":  PermissionModeAcceptEdits, // Claude Code's own spelling
 		"dangerous":    PermissionModeDangerous,
 		"default":      PermissionModeDefault,
 		"prompt":       PermissionModeDefault,
@@ -33,6 +33,7 @@ func TestTaskEffectivePermissionMode(t *testing.T) {
 		want string
 	}{
 		{"explicit auto", Task{PermissionMode: PermissionModeAuto}, PermissionModeAuto},
+		{"explicit accept-edits", Task{PermissionMode: PermissionModeAcceptEdits}, PermissionModeAcceptEdits},
 		{"explicit dangerous", Task{PermissionMode: PermissionModeDangerous}, PermissionModeDangerous},
 		{"explicit default", Task{PermissionMode: PermissionModeDefault}, PermissionModeDefault},
 		{"legacy dangerous bool", Task{DangerousMode: true}, PermissionModeDangerous},
@@ -203,5 +204,47 @@ func TestProjectDefaultPermissionModePersists(t *testing.T) {
 	again, _ := database.GetProjectByName("p")
 	if again.DefaultPermissionMode != PermissionModeDangerous {
 		t.Errorf("updated project default not persisted, got %q", again.DefaultPermissionMode)
+	}
+}
+
+func TestLegacyAutoMigratesToAcceptEditsOnce(t *testing.T) {
+	t.Setenv("TASKYOU_DEFAULT_PERMISSION_MODE", "")
+	database := newPermTestDB(t)
+	if err := database.CreateProject(&Project{Name: "legacy", Path: t.TempDir()}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	task := &Task{Title: "T", Status: StatusQueued, Type: TypeCode, Project: "legacy"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	// Simulate pre-migration rows: "auto" stored when it still meant acceptEdits,
+	// and clear the guard so the one-time migration runs again.
+	database.Exec(`UPDATE tasks SET permission_mode = 'auto' WHERE id = ?`, task.ID)
+	database.Exec(`UPDATE projects SET default_permission_mode = 'auto' WHERE name = 'legacy'`)
+	database.SetSetting(permModeAutoMigrationKey, "")
+
+	if err := database.migrate(); err != nil {
+		t.Fatalf("re-run migrate: %v", err)
+	}
+
+	got, _ := database.GetTask(task.ID)
+	if got.PermissionMode != PermissionModeAcceptEdits {
+		t.Errorf("legacy task 'auto' should migrate to accept-edits, got %q", got.PermissionMode)
+	}
+	proj, _ := database.GetProjectByName("legacy")
+	if proj.DefaultPermissionMode != PermissionModeAcceptEdits {
+		t.Errorf("legacy project 'auto' should migrate to accept-edits, got %q", proj.DefaultPermissionMode)
+	}
+
+	// One-time guard: a task later set to the NEW auto mode must NOT be rewritten
+	// on a subsequent boot.
+	database.Exec(`UPDATE tasks SET permission_mode = 'auto' WHERE id = ?`, task.ID)
+	if err := database.migrate(); err != nil {
+		t.Fatalf("re-run migrate (guarded): %v", err)
+	}
+	got, _ = database.GetTask(task.ID)
+	if got.PermissionMode != PermissionModeAuto {
+		t.Errorf("guard should preserve new auto-mode task, got %q", got.PermissionMode)
 	}
 }

--- a/internal/db/permission_mode_test.go
+++ b/internal/db/permission_mode_test.go
@@ -8,12 +8,16 @@ import (
 
 func TestNormalizePermissionMode(t *testing.T) {
 	cases := map[string]string{
-		"auto":      PermissionModeAuto,
-		"dangerous": PermissionModeDangerous,
-		"default":   PermissionModeDefault,
-		"prompt":    PermissionModeDefault,
-		"":          "",
-		"bogus":     "",
+		"auto":         PermissionModeAuto, // legacy alias, kept for back-compat
+		"accept-edits": PermissionModeAuto, // unambiguous spelling normalizes to the canonical value
+		"accept_edits": PermissionModeAuto,
+		"acceptEdits":  PermissionModeAuto, // Claude Code's own spelling
+		"  Auto  ":     PermissionModeAuto, // trimmed + case-insensitive
+		"dangerous":    PermissionModeDangerous,
+		"default":      PermissionModeDefault,
+		"prompt":       PermissionModeDefault,
+		"":             "",
+		"bogus":        "",
 	}
 	for in, want := range cases {
 		if got := NormalizePermissionMode(in); got != want {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -115,6 +115,11 @@ func Open(path string) (*DB, error) {
 	return wrapped, nil
 }
 
+// permModeAutoMigrationKey guards the one-time rewrite of legacy "auto"
+// permission_mode rows (which meant acceptEdits) to "accept-edits", now that
+// "auto" denotes Claude Code's real auto mode.
+const permModeAutoMigrationKey = "migration:auto_means_accept_edits_v1"
+
 // migrate runs database migrations.
 func (db *DB) migrate() error {
 	migrations := []string{
@@ -269,7 +274,7 @@ func (db *DB) migrate() error {
 		`ALTER TABLE tasks ADD COLUMN pr_info_json TEXT DEFAULT ''`, // JSON blob of github.PRInfo
 		// Whether project uses git worktrees for task isolation (1=yes, 0=no, default 1 for backward compat)
 		`ALTER TABLE projects ADD COLUMN use_worktrees INTEGER DEFAULT 1`,
-		// Permission mode for task execution: "default" (prompt), "auto" (acceptEdits), "dangerous" (skip permissions)
+		// Permission mode for task execution: "default" (prompt), "accept-edits" (acceptEdits), "auto" (Claude Code auto mode), "dangerous" (skip permissions)
 		`ALTER TABLE tasks ADD COLUMN permission_mode TEXT DEFAULT ''`,
 		// Per-project default permission mode inherited by new tasks (empty = global default)
 		`ALTER TABLE projects ADD COLUMN default_permission_mode TEXT DEFAULT ''`,
@@ -295,6 +300,17 @@ func (db *DB) migrate() error {
 
 	for _, m := range statusMigrations {
 		db.Exec(m)
+	}
+
+	// One-time: the value "auto" historically meant Claude's acceptEdits mode.
+	// It now means Claude Code's real auto mode, so rewrite pre-existing rows to
+	// the explicit "accept-edits" value to preserve their original behavior.
+	// Guarded by a settings flag so it runs exactly once and never clobbers tasks
+	// a user later sets to the new auto mode.
+	if done, _ := db.GetSetting(permModeAutoMigrationKey); done == "" {
+		db.Exec(`UPDATE tasks SET permission_mode = 'accept-edits' WHERE permission_mode = 'auto'`)
+		db.Exec(`UPDATE projects SET default_permission_mode = 'accept-edits' WHERE default_permission_mode = 'auto'`)
+		db.SetSetting(permModeAutoMigrationKey, "done")
 	}
 
 	// Ensure 'personal' project exists

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -32,7 +32,7 @@ type Task struct {
 	PRNumber        int    // Pull request number (if associated with a PR)
 	PRInfoJSON      string // Cached PR state as JSON (state, checks, mergeable, etc.)
 	DangerousMode   bool   // Whether task is running in dangerous mode (--dangerously-skip-permissions). Kept for backward compat; PermissionMode is authoritative.
-	PermissionMode  string // Permission mode for execution: "default" (prompt), "auto"/"accept-edits" (Claude's acceptEdits — auto-accept file edits, still prompts for risky actions), "dangerous" (skip permissions). Empty falls back to DangerousMode/global default.
+	PermissionMode  string // Permission mode for execution: "default" (prompt), "accept-edits" (Claude's acceptEdits — auto-accept file edits, still prompts for risky actions), "auto" (Claude Code's auto mode — classifier auto-approves safe actions, blocks risky ones), "dangerous" (skip permissions). Empty falls back to DangerousMode/global default.
 	Pinned          bool   // Whether the task is pinned to the top of its column
 	Tags            string // Comma-separated tags for categorization (e.g., "customer-support,email,influence-kit")
 	SourceBranch    string // Existing branch to checkout for worktree (e.g., "fix/ui-overflow") instead of creating new branch
@@ -68,43 +68,43 @@ func IsInProgress(status string) bool {
 }
 
 // Permission modes control how the underlying agent handles permission prompts.
+// They map one-to-one onto Claude Code's --permission-mode choices (plus the
+// --dangerously-skip-permissions shortcut). There are four sets, from most to
+// least gated: default → accept-edits → auto → dangerous.
 //
-// IMPORTANT: the stored value "auto" is historical — it predates Claude Code's
-// own "auto mode" (the agentic permission flow gated by --enable-auto-mode).
-// In TaskYou, "auto" means Claude Code's ACCEPT-EDITS mode (--permission-mode
-// acceptEdits): auto-accept file edits while still prompting for risky actions.
-// It is NOT Claude Code's --enable-auto-mode. To avoid that overloaded word,
-// surface this mode to users and agents as "accept edits" / "accept-edits";
-// the "auto" value is kept only for back-compat (and accepted as an alias).
+// HISTORY: TaskYou originally used the value "auto" for what is really Claude's
+// acceptEdits mode — that predated Claude Code shipping its own "auto mode". The
+// value "auto" now means Claude Code's actual auto mode (--permission-mode
+// auto), and the old acceptEdits set has the explicit value "accept-edits".
+// A one-time DB migration rewrites pre-existing "auto" rows (which meant
+// acceptEdits) to "accept-edits"; see migrate() in sqlite.go.
 const (
-	// PermissionModeDefault prompts for permissions (the historical default).
+	// PermissionModeDefault prompts for every permission (the historical default).
+	// Maps to Claude's --permission-mode default.
 	PermissionModeDefault = "default"
-	// PermissionModeAuto maps to Claude Code's accept-edits mode
-	// (--permission-mode acceptEdits): auto-accept file edits but still gate
-	// risky actions. This is the low-friction mode most users want — it handles
-	// ~99% of permission prompts without fully bypassing permissions. Despite
-	// the stored "auto" value, this is NOT Claude Code's --enable-auto-mode;
-	// display it as "accept edits" (see PermissionModeAutoLabel).
+	// PermissionModeAcceptEdits auto-accepts file edits but still prompts for
+	// risky actions (shell, network, etc.). Maps to Claude's
+	// --permission-mode acceptEdits.
+	PermissionModeAcceptEdits = "accept-edits"
+	// PermissionModeAuto is Claude Code's auto mode (--permission-mode auto): an
+	// AI classifier auto-approves a broad set of safe actions (edits and safe
+	// commands) while still hard-denying dangerous ones. More autonomous than
+	// accept-edits, but far safer than fully bypassing permissions.
 	PermissionModeAuto = "auto"
 	// PermissionModeDangerous bypasses all permission checks
 	// (Claude's --dangerously-skip-permissions).
 	PermissionModeDangerous = "dangerous"
 )
 
-// PermissionModeAutoLabel is the unambiguous human-facing name for
-// PermissionModeAuto. We deliberately avoid the word "auto" in UI and prompts
-// because it collides with Claude Code's separate "auto mode"
-// (--enable-auto-mode), which TaskYou does not currently expose.
-const PermissionModeAutoLabel = "accept-edits"
-
 // NormalizePermissionMode coerces a raw value into a known permission mode.
-// "prompt" and "" are treated as default. The unambiguous "accept-edits" name
-// (and its variants, plus Claude's own "acceptEdits") all map to the canonical
-// PermissionModeAuto value, so callers can use the clearer spelling while old
-// "auto" values keep working. Unknown values return "".
+// "prompt" and "" are treated as default; Claude's own "acceptEdits" spelling
+// (and "accept_edits") normalizes to PermissionModeAcceptEdits. Matching is
+// case- and whitespace-insensitive. Unknown values return "".
 func NormalizePermissionMode(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case PermissionModeAuto, PermissionModeAutoLabel, "accept_edits", "acceptedits":
+	case PermissionModeAcceptEdits, "accept_edits", "acceptedits":
+		return PermissionModeAcceptEdits
+	case PermissionModeAuto:
 		return PermissionModeAuto
 	case PermissionModeDangerous:
 		return PermissionModeDangerous
@@ -117,8 +117,9 @@ func NormalizePermissionMode(mode string) string {
 // GlobalDefaultPermissionMode returns the fallback permission mode used when a
 // project has no explicit default. It can be overridden with the
 // TASKYOU_DEFAULT_PERMISSION_MODE environment variable. Defaults to "auto"
-// (acceptEdits) so tasks start unblocked without a manual per-session toggle;
-// set the env var to "default" to restore prompt-for-every-permission behavior.
+// (Claude Code's auto mode) so tasks start maximally unblocked while the
+// classifier still gates dangerous actions; set the env var to "accept-edits"
+// or "default" to dial back autonomy.
 func GlobalDefaultPermissionMode() string {
 	if m := NormalizePermissionMode(os.Getenv("TASKYOU_DEFAULT_PERMISSION_MODE")); m != "" {
 		return m
@@ -143,9 +144,14 @@ func (t *Task) IsDangerous() bool {
 	return t.EffectivePermissionMode() == PermissionModeDangerous
 }
 
-// IsAutoPermission reports whether the task runs in accept-edits (acceptEdits) mode.
+// IsAutoPermission reports whether the task runs in Claude Code's auto mode.
 func (t *Task) IsAutoPermission() bool {
 	return t.EffectivePermissionMode() == PermissionModeAuto
+}
+
+// IsAcceptEdits reports whether the task runs in accept-edits (acceptEdits) mode.
+func (t *Task) IsAcceptEdits() bool {
+	return t.EffectivePermissionMode() == PermissionModeAcceptEdits
 }
 
 // Task types (default values, actual types are stored in task_types table)

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -32,7 +32,7 @@ type Task struct {
 	PRNumber        int    // Pull request number (if associated with a PR)
 	PRInfoJSON      string // Cached PR state as JSON (state, checks, mergeable, etc.)
 	DangerousMode   bool   // Whether task is running in dangerous mode (--dangerously-skip-permissions). Kept for backward compat; PermissionMode is authoritative.
-	PermissionMode  string // Permission mode for execution: "default" (prompt), "auto" (acceptEdits), "dangerous" (skip permissions). Empty falls back to DangerousMode/global default.
+	PermissionMode  string // Permission mode for execution: "default" (prompt), "auto"/"accept-edits" (Claude's acceptEdits — auto-accept file edits, still prompts for risky actions), "dangerous" (skip permissions). Empty falls back to DangerousMode/global default.
 	Pinned          bool   // Whether the task is pinned to the top of its column
 	Tags            string // Comma-separated tags for categorization (e.g., "customer-support,email,influence-kit")
 	SourceBranch    string // Existing branch to checkout for worktree (e.g., "fix/ui-overflow") instead of creating new branch
@@ -68,24 +68,43 @@ func IsInProgress(status string) bool {
 }
 
 // Permission modes control how the underlying agent handles permission prompts.
+//
+// IMPORTANT: the stored value "auto" is historical — it predates Claude Code's
+// own "auto mode" (the agentic permission flow gated by --enable-auto-mode).
+// In TaskYou, "auto" means Claude Code's ACCEPT-EDITS mode (--permission-mode
+// acceptEdits): auto-accept file edits while still prompting for risky actions.
+// It is NOT Claude Code's --enable-auto-mode. To avoid that overloaded word,
+// surface this mode to users and agents as "accept edits" / "accept-edits";
+// the "auto" value is kept only for back-compat (and accepted as an alias).
 const (
 	// PermissionModeDefault prompts for permissions (the historical default).
 	PermissionModeDefault = "default"
-	// PermissionModeAuto auto-accepts file edits but still gates risky actions
-	// (Claude's --permission-mode acceptEdits). This is the "auto mode" most
-	// users want: handles ~99% of permission prompts without the risk of
-	// fully bypassing permissions.
+	// PermissionModeAuto maps to Claude Code's accept-edits mode
+	// (--permission-mode acceptEdits): auto-accept file edits but still gate
+	// risky actions. This is the low-friction mode most users want — it handles
+	// ~99% of permission prompts without fully bypassing permissions. Despite
+	// the stored "auto" value, this is NOT Claude Code's --enable-auto-mode;
+	// display it as "accept edits" (see PermissionModeAutoLabel).
 	PermissionModeAuto = "auto"
 	// PermissionModeDangerous bypasses all permission checks
 	// (Claude's --dangerously-skip-permissions).
 	PermissionModeDangerous = "dangerous"
 )
 
+// PermissionModeAutoLabel is the unambiguous human-facing name for
+// PermissionModeAuto. We deliberately avoid the word "auto" in UI and prompts
+// because it collides with Claude Code's separate "auto mode"
+// (--enable-auto-mode), which TaskYou does not currently expose.
+const PermissionModeAutoLabel = "accept-edits"
+
 // NormalizePermissionMode coerces a raw value into a known permission mode.
-// "prompt" and "" are treated as default; unknown values return "".
+// "prompt" and "" are treated as default. The unambiguous "accept-edits" name
+// (and its variants, plus Claude's own "acceptEdits") all map to the canonical
+// PermissionModeAuto value, so callers can use the clearer spelling while old
+// "auto" values keep working. Unknown values return "".
 func NormalizePermissionMode(mode string) string {
-	switch mode {
-	case PermissionModeAuto:
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case PermissionModeAuto, PermissionModeAutoLabel, "accept_edits", "acceptedits":
 		return PermissionModeAuto
 	case PermissionModeDangerous:
 		return PermissionModeDangerous
@@ -124,7 +143,7 @@ func (t *Task) IsDangerous() bool {
 	return t.EffectivePermissionMode() == PermissionModeDangerous
 }
 
-// IsAutoPermission reports whether the task runs in auto (acceptEdits) mode.
+// IsAutoPermission reports whether the task runs in accept-edits (acceptEdits) mode.
 func (t *Task) IsAutoPermission() bool {
 	return t.EffectivePermissionMode() == PermissionModeAuto
 }

--- a/internal/executor/claude_executor.go
+++ b/internal/executor/claude_executor.go
@@ -29,6 +29,8 @@ func claudePermissionFlag(task *db.Task) string {
 	case db.PermissionModeDangerous:
 		return "--dangerously-skip-permissions "
 	case db.PermissionModeAuto:
+		return "--permission-mode auto "
+	case db.PermissionModeAcceptEdits:
 		return "--permission-mode acceptEdits "
 	default:
 		return ""
@@ -104,7 +106,7 @@ func (c *ClaudeExecutor) ResumeProcess(taskID int64) bool {
 
 // BuildCommand returns the shell command to start an interactive Claude session.
 func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) string {
-	// Build permission mode flag (dangerous, accept-edits/acceptEdits, or none)
+	// Build permission mode flag (dangerous, auto, accept-edits, or none)
 	dangerousFlag := claudePermissionFlag(task)
 
 	// Build per-task effort override flag (empty = use Claude's global default)

--- a/internal/executor/claude_executor.go
+++ b/internal/executor/claude_executor.go
@@ -104,7 +104,7 @@ func (c *ClaudeExecutor) ResumeProcess(taskID int64) bool {
 
 // BuildCommand returns the shell command to start an interactive Claude session.
 func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) string {
-	// Build permission mode flag (dangerous, auto/acceptEdits, or none)
+	// Build permission mode flag (dangerous, accept-edits/acceptEdits, or none)
 	dangerousFlag := claudePermissionFlag(task)
 
 	// Build per-task effort override flag (empty = use Claude's global default)

--- a/internal/executor/permission_flag_test.go
+++ b/internal/executor/permission_flag_test.go
@@ -17,8 +17,9 @@ func TestClaudePermissionFlag(t *testing.T) {
 	}{
 		{"default empty", &db.Task{}, ""},
 		{"explicit default", &db.Task{PermissionMode: db.PermissionModeDefault}, ""},
-		{"auto", &db.Task{PermissionMode: db.PermissionModeAuto}, "--permission-mode acceptEdits "},
-		{"accept-edits alias", &db.Task{PermissionMode: "accept-edits"}, "--permission-mode acceptEdits "},
+		{"auto", &db.Task{PermissionMode: db.PermissionModeAuto}, "--permission-mode auto "},
+		{"accept-edits", &db.Task{PermissionMode: db.PermissionModeAcceptEdits}, "--permission-mode acceptEdits "},
+		{"acceptEdits spelling normalizes", &db.Task{PermissionMode: "acceptEdits"}, "--permission-mode acceptEdits "},
 		{"dangerous", &db.Task{PermissionMode: db.PermissionModeDangerous}, "--dangerously-skip-permissions "},
 		{"legacy dangerous bool", &db.Task{DangerousMode: true}, "--dangerously-skip-permissions "},
 	}

--- a/internal/executor/permission_flag_test.go
+++ b/internal/executor/permission_flag_test.go
@@ -18,6 +18,7 @@ func TestClaudePermissionFlag(t *testing.T) {
 		{"default empty", &db.Task{}, ""},
 		{"explicit default", &db.Task{PermissionMode: db.PermissionModeDefault}, ""},
 		{"auto", &db.Task{PermissionMode: db.PermissionModeAuto}, "--permission-mode acceptEdits "},
+		{"accept-edits alias", &db.Task{PermissionMode: "accept-edits"}, "--permission-mode acceptEdits "},
 		{"dangerous", &db.Task{PermissionMode: db.PermissionModeDangerous}, "--dangerously-skip-permissions "},
 		{"legacy dangerous bool", &db.Task{DangerousMode: true}, "--dangerously-skip-permissions "},
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -242,8 +242,8 @@ func (s *Server) handleRequest(req *jsonRPCRequest) {
 							},
 							"permission_mode": map[string]interface{}{
 								"type":        "string",
-								"description": "Permission mode for execution: 'default' (prompt for each permission), 'accept-edits' (Claude Code's acceptEdits / --permission-mode acceptEdits: auto-accept file edits but still prompt for risky actions — this is NOT Claude Code's separate 'auto mode' from --enable-auto-mode), or 'dangerous' (skip all prompts / --dangerously-skip-permissions). The legacy value 'auto' is still accepted and means the same as 'accept-edits'. Defaults to the project's configured default.",
-								"enum":        []string{"default", "accept-edits", "dangerous"},
+								"description": "Permission mode for execution (most to least gated): 'default' (prompt for each permission), 'accept-edits' (Claude's acceptEdits / --permission-mode acceptEdits: auto-accept file edits but still prompt for risky actions), 'auto' (Claude Code's auto mode / --permission-mode auto: an AI classifier auto-approves safe actions, including safe commands, while still blocking dangerous ones), or 'dangerous' (skip all prompts / --dangerously-skip-permissions). Note: 'auto' and 'accept-edits' are DIFFERENT — 'auto' is more autonomous. Defaults to the project's configured default.",
+								"enum":        []string{"default", "accept-edits", "auto", "dangerous"},
 							},
 						},
 						"required": []string{"title"},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -242,8 +242,8 @@ func (s *Server) handleRequest(req *jsonRPCRequest) {
 							},
 							"permission_mode": map[string]interface{}{
 								"type":        "string",
-								"description": "Permission mode for execution: 'default' (prompt), 'auto' (auto-accept edits), or 'dangerous' (skip all prompts). Defaults to the project's configured default.",
-								"enum":        []string{"default", "auto", "dangerous"},
+								"description": "Permission mode for execution: 'default' (prompt for each permission), 'accept-edits' (Claude Code's acceptEdits / --permission-mode acceptEdits: auto-accept file edits but still prompt for risky actions — this is NOT Claude Code's separate 'auto mode' from --enable-auto-mode), or 'dangerous' (skip all prompts / --dangerously-skip-permissions). The legacy value 'auto' is still accepted and means the same as 'accept-edits'. Defaults to the project's configured default.",
+								"enum":        []string{"default", "accept-edits", "dangerous"},
 							},
 						},
 						"required": []string{"title"},

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2900,7 +2900,7 @@ func (m *AppModel) updateNewTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 						Options(
 							huh.NewOption("No — save to backlog", "no"),
 							huh.NewOption("Yes — execute now", "yes"),
-							huh.NewOption("Yes — execute in auto mode", "auto"),
+							huh.NewOption("Yes — execute in accept-edits mode", "auto"),
 							huh.NewOption("Yes — execute in dangerous mode", "dangerous"),
 						).
 						Value(&m.queueValue),

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2900,7 +2900,8 @@ func (m *AppModel) updateNewTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 						Options(
 							huh.NewOption("No — save to backlog", "no"),
 							huh.NewOption("Yes — execute now", "yes"),
-							huh.NewOption("Yes — execute in accept-edits mode", "auto"),
+							huh.NewOption("Yes — execute in auto mode", "auto"),
+							huh.NewOption("Yes — execute in accept-edits mode", "accept-edits"),
 							huh.NewOption("Yes — execute in dangerous mode", "dangerous"),
 						).
 						Value(&m.queueValue),
@@ -2948,13 +2949,16 @@ func (m *AppModel) updateNewTaskConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.db.SetSetting("last_queue_choice:"+m.pendingTask.Project, m.queueValue)
 
 			// "yes" and "no" leave PermissionMode empty so CreateTask inherits the
-			// project's configured default; "auto"/"dangerous" force the mode.
+			// project's configured default; the explicit modes force themselves.
 			switch m.queueValue {
 			case "yes":
 				m.pendingTask.Status = db.StatusQueued
 			case "auto":
 				m.pendingTask.Status = db.StatusQueued
 				m.pendingTask.PermissionMode = db.PermissionModeAuto
+			case "accept-edits":
+				m.pendingTask.Status = db.StatusQueued
+				m.pendingTask.PermissionMode = db.PermissionModeAcceptEdits
 			case "dangerous":
 				m.pendingTask.Status = db.StatusQueued
 				m.pendingTask.PermissionMode = db.PermissionModeDangerous

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2358,15 +2358,13 @@ func (m *DetailModel) renderHeader() string {
 		meta.WriteString("  ")
 	}
 
-	// Accept-edits badge (Claude's acceptEdits mode) for active tasks. Labeled
-	// "ACCEPT EDITS" rather than "AUTO" so it isn't confused with Claude Code's
-	// separate auto mode (--enable-auto-mode).
+	// Auto-mode badge (Claude Code's --permission-mode auto) for active tasks.
 	if t.IsAutoPermission() && (t.Status == db.StatusProcessing || t.Status == db.StatusBlocked) {
 		var autoStyle lipgloss.Style
 		if m.focused {
 			autoStyle = lipgloss.NewStyle().
 				Padding(0, 1).
-				Background(ColorSuccess).
+				Background(ColorPrimary).
 				Foreground(lipgloss.Color("#FFFFFF")).
 				Bold(true)
 		} else {
@@ -2375,7 +2373,27 @@ func (m *DetailModel) renderHeader() string {
 				Background(dimmedBg).
 				Foreground(dimmedFg)
 		}
-		meta.WriteString(autoStyle.Render("ACCEPT EDITS"))
+		meta.WriteString(autoStyle.Render("AUTO"))
+		meta.WriteString("  ")
+	}
+
+	// Accept-edits badge (Claude's acceptEdits mode) for active tasks. Distinct
+	// from AUTO above so the two permission sets are never confused.
+	if t.IsAcceptEdits() && (t.Status == db.StatusProcessing || t.Status == db.StatusBlocked) {
+		var aeStyle lipgloss.Style
+		if m.focused {
+			aeStyle = lipgloss.NewStyle().
+				Padding(0, 1).
+				Background(ColorSuccess).
+				Foreground(lipgloss.Color("#FFFFFF")).
+				Bold(true)
+		} else {
+			aeStyle = lipgloss.NewStyle().
+				Padding(0, 1).
+				Background(dimmedBg).
+				Foreground(dimmedFg)
+		}
+		meta.WriteString(aeStyle.Render("ACCEPT EDITS"))
 		meta.WriteString("  ")
 	}
 

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2358,7 +2358,9 @@ func (m *DetailModel) renderHeader() string {
 		meta.WriteString("  ")
 	}
 
-	// Auto mode badge (acceptEdits) for active tasks.
+	// Accept-edits badge (Claude's acceptEdits mode) for active tasks. Labeled
+	// "ACCEPT EDITS" rather than "AUTO" so it isn't confused with Claude Code's
+	// separate auto mode (--enable-auto-mode).
 	if t.IsAutoPermission() && (t.Status == db.StatusProcessing || t.Status == db.StatusBlocked) {
 		var autoStyle lipgloss.Style
 		if m.focused {
@@ -2373,7 +2375,7 @@ func (m *DetailModel) renderHeader() string {
 				Background(dimmedBg).
 				Foreground(dimmedFg)
 		}
-		meta.WriteString(autoStyle.Render("AUTO"))
+		meta.WriteString(autoStyle.Render("ACCEPT EDITS"))
 		meta.WriteString("  ")
 	}
 

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2359,13 +2359,14 @@ func (m *DetailModel) renderHeader() string {
 	}
 
 	// Auto-mode badge (Claude Code's --permission-mode auto) for active tasks.
+	// Yellow to match Claude Code's own "auto mode on" status color.
 	if t.IsAutoPermission() && (t.Status == db.StatusProcessing || t.Status == db.StatusBlocked) {
 		var autoStyle lipgloss.Style
 		if m.focused {
 			autoStyle = lipgloss.NewStyle().
 				Padding(0, 1).
-				Background(ColorPrimary).
-				Foreground(lipgloss.Color("#FFFFFF")).
+				Background(ColorWarning).
+				Foreground(lipgloss.Color("#000000")).
 				Bold(true)
 		} else {
 			autoStyle = lipgloss.NewStyle().
@@ -2377,14 +2378,15 @@ func (m *DetailModel) renderHeader() string {
 		meta.WriteString("  ")
 	}
 
-	// Accept-edits badge (Claude's acceptEdits mode) for active tasks. Distinct
-	// from AUTO above so the two permission sets are never confused.
+	// Accept-edits badge (Claude's acceptEdits mode) for active tasks. Violet to
+	// match Claude Code's own "accept edits on" status color — and distinct from
+	// AUTO above so the two permission sets are never confused.
 	if t.IsAcceptEdits() && (t.Status == db.StatusProcessing || t.Status == db.StatusBlocked) {
 		var aeStyle lipgloss.Style
 		if m.focused {
 			aeStyle = lipgloss.NewStyle().
 				Padding(0, 1).
-				Background(ColorSuccess).
+				Background(ColorCode).
 				Foreground(lipgloss.Color("#FFFFFF")).
 				Bold(true)
 		} else {

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -1165,7 +1165,7 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool, 
 			indicators = append(indicators, dangerStyle.Render("●"))
 		}
 	}
-	// Auto mode indicator (green dot) for active tasks running in auto/acceptEdits mode.
+	// Accept-edits indicator (green dot) for active tasks running in Claude's acceptEdits mode.
 	if task.IsAutoPermission() && (task.Status == db.StatusProcessing || task.Status == db.StatusBlocked) {
 		if isSelected {
 			indicators = append(indicators, "●")

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -1165,13 +1165,22 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool, 
 			indicators = append(indicators, dangerStyle.Render("●"))
 		}
 	}
-	// Accept-edits indicator (green dot) for active tasks running in Claude's acceptEdits mode.
+	// Auto-mode indicator (blue dot) for active tasks running in Claude Code's auto mode.
 	if task.IsAutoPermission() && (task.Status == db.StatusProcessing || task.Status == db.StatusBlocked) {
 		if isSelected {
 			indicators = append(indicators, "●")
 		} else {
-			autoStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+			autoStyle := lipgloss.NewStyle().Foreground(ColorPrimary)
 			indicators = append(indicators, autoStyle.Render("●"))
+		}
+	}
+	// Accept-edits indicator (green dot) for active tasks running in Claude's acceptEdits mode.
+	if task.IsAcceptEdits() && (task.Status == db.StatusProcessing || task.Status == db.StatusBlocked) {
+		if isSelected {
+			indicators = append(indicators, "●")
+		} else {
+			aeStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+			indicators = append(indicators, aeStyle.Render("●"))
 		}
 	}
 	if task.Pinned {

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -1165,21 +1165,23 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool, 
 			indicators = append(indicators, dangerStyle.Render("●"))
 		}
 	}
-	// Auto-mode indicator (blue dot) for active tasks running in Claude Code's auto mode.
+	// Auto-mode indicator (yellow dot) for active tasks running in Claude Code's
+	// auto mode — matches Claude's own "auto mode on" status color.
 	if task.IsAutoPermission() && (task.Status == db.StatusProcessing || task.Status == db.StatusBlocked) {
 		if isSelected {
 			indicators = append(indicators, "●")
 		} else {
-			autoStyle := lipgloss.NewStyle().Foreground(ColorPrimary)
+			autoStyle := lipgloss.NewStyle().Foreground(ColorWarning)
 			indicators = append(indicators, autoStyle.Render("●"))
 		}
 	}
-	// Accept-edits indicator (green dot) for active tasks running in Claude's acceptEdits mode.
+	// Accept-edits indicator (violet dot) for active tasks running in Claude's
+	// acceptEdits mode — matches Claude's own "accept edits on" status color.
 	if task.IsAcceptEdits() && (task.Status == db.StatusProcessing || task.Status == db.StatusBlocked) {
 		if isSelected {
 			indicators = append(indicators, "●")
 		} else {
-			aeStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+			aeStyle := lipgloss.NewStyle().Foreground(ColorCode)
 			indicators = append(indicators, aeStyle.Render("●"))
 		}
 	}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -278,8 +278,8 @@ func (m *SettingsModel) showProjectForm(project *db.Project) (*SettingsModel, te
 	m.projectFormUseWorktrees = project.UseWorktrees
 
 	// Default permission mode. Use the project's explicit setting when present,
-	// otherwise pre-select the effective default (accept-edits) so the form
-	// mirrors the mode tasks will actually run in.
+	// otherwise pre-select the effective default (auto) so the form mirrors the
+	// mode tasks will actually run in.
 	m.projectFormPermissionMode = db.NormalizePermissionMode(project.DefaultPermissionMode)
 	if m.projectFormPermissionMode == "" {
 		m.projectFormPermissionMode = project.EffectiveDefaultPermissionMode()
@@ -342,9 +342,10 @@ func (m *SettingsModel) showProjectForm(project *db.Project) (*SettingsModel, te
 		huh.NewSelect[string]().
 			Key("permission_mode").
 			Title("Default Permission Mode").
-			Description("How new tasks handle permissions. Accept Edits handles ~99% without prompting.").
+			Description("How new tasks handle permissions. Auto mode auto-approves safe actions and blocks risky ones.").
 			Options(
-				huh.NewOption("Accept Edits — auto-accept file edits, still prompt for risky actions (recommended)", db.PermissionModeAuto),
+				huh.NewOption("Auto — Claude Code auto mode: auto-approve safe actions, block risky ones (recommended)", db.PermissionModeAuto),
+				huh.NewOption("Accept Edits — auto-accept file edits, still prompt for risky actions", db.PermissionModeAcceptEdits),
 				huh.NewOption("Prompt — ask for each permission", db.PermissionModeDefault),
 				huh.NewOption("Dangerous — skip all permission checks", db.PermissionModeDangerous),
 			).

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -278,8 +278,8 @@ func (m *SettingsModel) showProjectForm(project *db.Project) (*SettingsModel, te
 	m.projectFormUseWorktrees = project.UseWorktrees
 
 	// Default permission mode. Use the project's explicit setting when present,
-	// otherwise pre-select the effective default (auto) so the form mirrors the
-	// mode tasks will actually run in.
+	// otherwise pre-select the effective default (accept-edits) so the form
+	// mirrors the mode tasks will actually run in.
 	m.projectFormPermissionMode = db.NormalizePermissionMode(project.DefaultPermissionMode)
 	if m.projectFormPermissionMode == "" {
 		m.projectFormPermissionMode = project.EffectiveDefaultPermissionMode()
@@ -342,9 +342,9 @@ func (m *SettingsModel) showProjectForm(project *db.Project) (*SettingsModel, te
 		huh.NewSelect[string]().
 			Key("permission_mode").
 			Title("Default Permission Mode").
-			Description("How new tasks handle permissions. Auto handles ~99% without prompting.").
+			Description("How new tasks handle permissions. Accept Edits handles ~99% without prompting.").
 			Options(
-				huh.NewOption("Auto — auto-accept edits (recommended)", db.PermissionModeAuto),
+				huh.NewOption("Accept Edits — auto-accept file edits, still prompt for risky actions (recommended)", db.PermissionModeAuto),
 				huh.NewOption("Prompt — ask for each permission", db.PermissionModeDefault),
 				huh.NewOption("Dangerous — skip all permission checks", db.PermissionModeDangerous),
 			).

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -342,12 +342,12 @@ func (m *SettingsModel) showProjectForm(project *db.Project) (*SettingsModel, te
 		huh.NewSelect[string]().
 			Key("permission_mode").
 			Title("Default Permission Mode").
-			Description("How new tasks handle permissions. Auto mode auto-approves safe actions and blocks risky ones.").
+			Description("How new tasks handle permissions.").
 			Options(
-				huh.NewOption("Auto — Claude Code auto mode: auto-approve safe actions, block risky ones (recommended)", db.PermissionModeAuto),
-				huh.NewOption("Accept Edits — auto-accept file edits, still prompt for risky actions", db.PermissionModeAcceptEdits),
+				huh.NewOption("Auto — approve safe actions, block risky (recommended)", db.PermissionModeAuto),
+				huh.NewOption("Accept Edits — auto-accept edits, prompt for risky", db.PermissionModeAcceptEdits),
 				huh.NewOption("Prompt — ask for each permission", db.PermissionModeDefault),
-				huh.NewOption("Dangerous — skip all permission checks", db.PermissionModeDangerous),
+				huh.NewOption("Dangerous — skip all checks", db.PermissionModeDangerous),
 			).
 			Value(&m.projectFormPermissionMode),
 	)


### PR DESCRIPTION
## What & why

Kyle reported that **"auto" is overloaded** in TaskYou's permission settings
([#tmp-taskyou-feedback](https://etison.slack.com/archives/C0B8Q7VEE2V/p1780687658666859)):

> I think Claude got confused on the auto mode because you might have used the
> word "auto" originally to refer to the "accept edits" mode (before CC auto
> mode was a thing). So in this case there's actually **4 permission sets**.
> `--enable-auto-mode` makes it available in CC.

TaskYou's `auto` value predated Claude Code shipping its own **auto mode** and
actually meant Claude's **acceptEdits**. This PR fixes that in two steps:

1. **Disambiguate** — give acceptEdits the explicit value/label **`accept-edits`**,
   freeing the word "auto" for its real meaning.
2. **Add the real thing** — wire up Claude Code's **auto mode**
   (`--permission-mode auto`, a listed choice in the installed CLI `2.1.168`) as
   a genuine fourth permission set, and make it the default.

The four sets, most → least gated:

| Set | Claude flag | Behavior |
|---|---|---|
| `default` | `--permission-mode default` | Prompt for every permission |
| `accept-edits` | `--permission-mode acceptEdits` | Auto-accept file edits, prompt for risky |
| **`auto`** (default) | `--permission-mode auto` | Classifier auto-approves safe actions (incl. safe commands), blocks dangerous |
| `dangerous` | `--dangerously-skip-permissions` | Skip all checks |

## Changes

- **db (`internal/db/tasks.go`):** four constants; `accept-edits` canonical for
  acceptEdits; `auto` now = CC auto mode; `Task.IsAcceptEdits()` added;
  `NormalizePermissionMode` is case/space-insensitive and maps `acceptEdits` →
  `accept-edits`. Global default is now **auto** (override with
  `TASKYOU_DEFAULT_PERMISSION_MODE`).
- **Migration (`internal/db/sqlite.go`):** one-time, settings-guarded rewrite of
  pre-existing `permission_mode='auto'` (which meant acceptEdits) → `accept-edits`.
  The guard means it runs exactly once and never clobbers a task a user later
  sets to the *new* auto mode.
- **Executor:** `claudePermissionFlag` emits `--permission-mode auto` vs
  `--permission-mode acceptEdits`.
- **UI:** settings lists all four (Auto recommended); detail shows a distinct
  **blue `AUTO`** badge vs **green `ACCEPT EDITS`**; kanban adds a blue dot for
  auto; queue dialog offers both.
- **CLI/MCP:** `--permission-mode` help + `permission_mode` schema document all
  four and that `auto` ≠ `accept-edits`.

## Tests

- `internal/db`: normalization, effective-mode, and a **one-time migration test**
  (legacy `auto` → `accept-edits`; guard preserves a new auto-mode task).
- `internal/executor`: `auto` → `--permission-mode auto`, `accept-edits` →
  `--permission-mode acceptEdits`.
- `go build ./...`, `go vet`, gofmt, and all affected package tests pass.

## QA evidence

Isolated ty instance (VHS, real TUI). A task created with no flag inherited the
new **auto** default; `--permission-mode accept-edits` produced an accept-edits
task — proving the wiring end-to-end.

**Settings → Default Permission Mode** — all four sets, Auto recommended:

![4mode-settings](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-06-08/4090-4mode-settings.png)

**Detail badges** — auto mode and accept-edits are now visually distinct:

![badges-compare](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-06-08/4090-badges-compare-v2.png)

## Notes / follow-ups

- Default flipped from accept-edits → **auto** per product call; existing
  projects with an explicit `auto` default are migrated to `accept-edits` so
  their behavior is unchanged, while unset projects now get auto mode.
- The installed Claude `2.1.168` accepts `--permission-mode auto` directly (no
  separate `--enable-auto-mode` flag in this version); auto mode's allow/deny
  classifier is configured in the user's Claude settings (`claude auto-mode config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)