### PR TITLE
Don't false-block tasks when a tmux status check transiently fails

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3176,6 +3176,31 @@ func (e *Executor) RenameClaudeSessionForTask(task *db.Task, newName string) {
 	}
 }
 
+// windowMissTracker debounces transient tmux window-check failures.
+//
+// A single failed `tmux list-panes` must NOT be treated as "window gone". That
+// command also fails when the tmux server is briefly busy or the 3s timeout trips
+// under load, and because every concurrent poller shares one tmux server they trip
+// together — producing a false, simultaneous mass-block of healthy tasks with
+// "Task needs review". The tracker requires `threshold` consecutive misses (reset
+// on any successful check) before concluding the window is actually gone.
+type windowMissTracker struct {
+	consecutive int
+	threshold   int
+}
+
+// record feeds a single window-check result and reports whether the window
+// should now be considered genuinely gone. Any successful check resets the
+// run of consecutive misses, so only `threshold` failures in a row trip it.
+func (w *windowMissTracker) record(windowExists bool) (gone bool) {
+	if windowExists {
+		w.consecutive = 0
+		return false
+	}
+	w.consecutive++
+	return w.consecutive >= w.threshold
+}
+
 // pollTmuxSession waits for the tmux session to end or task status to change.
 // Status is managed entirely by Claude hooks - we just wait and check the result.
 // Task only goes to "done" if user/MCP explicitly marks it done.
@@ -3185,14 +3210,8 @@ func (e *Executor) pollTmuxSession(ctx context.Context, taskID int64, sessionNam
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	// A single failed `tmux list-panes` must NOT be treated as "window gone". That
-	// command also fails when the tmux server is briefly busy or the 3s timeout trips
-	// under load, and because every concurrent poller shares one tmux server they trip
-	// together — producing a false, simultaneous mass-block of healthy tasks with
-	// "Task needs review". Require several consecutive misses (reset on any success)
-	// before concluding the window is actually gone.
-	missingChecks := 0
 	const missingThreshold = 3
+	misses := windowMissTracker{threshold: missingThreshold}
 
 	for {
 		select {
@@ -3236,18 +3255,13 @@ func (e *Executor) pollTmuxSession(ctx context.Context, taskID int64, sessionNam
 				checkCancel()
 			}
 
-			if windowExists {
-				// Healthy check — reset the transient-failure counter.
-				missingChecks = 0
-				continue
-			}
-
-			// Window appears gone. This may be a transient tmux failure, so only
-			// act after several consecutive misses.
-			missingChecks++
-			if missingChecks < missingThreshold {
-				e.logger.Debug("pollTmuxSession: window check failed, retrying",
-					"taskID", taskID, "miss", missingChecks, "threshold", missingThreshold)
+			// Feed the check result to the tracker. A healthy check resets the
+			// run of misses; a miss only "counts" once we've seen enough in a row.
+			if !misses.record(windowExists) {
+				if !windowExists {
+					e.logger.Debug("pollTmuxSession: window check failed, retrying",
+						"taskID", taskID, "miss", misses.consecutive, "threshold", missingThreshold)
+				}
 				continue
 			}
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3185,6 +3185,15 @@ func (e *Executor) pollTmuxSession(ctx context.Context, taskID int64, sessionNam
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
+	// A single failed `tmux list-panes` must NOT be treated as "window gone". That
+	// command also fails when the tmux server is briefly busy or the 3s timeout trips
+	// under load, and because every concurrent poller shares one tmux server they trip
+	// together — producing a false, simultaneous mass-block of healthy tasks with
+	// "Task needs review". Require several consecutive misses (reset on any success)
+	// before concluding the window is actually gone.
+	missingChecks := 0
+	const missingThreshold = 3
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -3227,20 +3236,34 @@ func (e *Executor) pollTmuxSession(ctx context.Context, taskID int64, sessionNam
 				checkCancel()
 			}
 
-			if !windowExists {
-				// Window closed - check final status from hooks
-				task, _ := e.db.GetTask(taskID)
-				if task != nil {
-					if task.Status == db.StatusDone {
-						return execResult{Success: true}
-					}
-					if task.Status == db.StatusBacklog {
-						return execResult{Interrupted: true}
-					}
-				}
-				// Default: blocked (user must mark done or retry)
-				return execResult{NeedsInput: true, Message: "Task needs review"}
+			if windowExists {
+				// Healthy check — reset the transient-failure counter.
+				missingChecks = 0
+				continue
 			}
+
+			// Window appears gone. This may be a transient tmux failure, so only
+			// act after several consecutive misses.
+			missingChecks++
+			if missingChecks < missingThreshold {
+				e.logger.Debug("pollTmuxSession: window check failed, retrying",
+					"taskID", taskID, "miss", missingChecks, "threshold", missingThreshold)
+				continue
+			}
+
+			// Window genuinely gone for missingThreshold consecutive checks —
+			// check final status from hooks.
+			finalTask, _ := e.db.GetTask(taskID)
+			if finalTask != nil {
+				if finalTask.Status == db.StatusDone {
+					return execResult{Success: true}
+				}
+				if finalTask.Status == db.StatusBacklog {
+					return execResult{Interrupted: true}
+				}
+			}
+			// Default: blocked (user must mark done or retry)
+			return execResult{NeedsInput: true, Message: "Task needs review"}
 		}
 	}
 }

--- a/internal/executor/poll_tmux_repro_test.go
+++ b/internal/executor/poll_tmux_repro_test.go
@@ -1,0 +1,128 @@
+//go:build qa_repro
+
+// QA repro for PR #558 — "Don't false-block tasks on a transient tmux check failure".
+//
+// This is NOT part of the normal unit suite (build tag `qa_repro`). It is a live,
+// deterministic demonstration that:
+//
+//  1. The exact window-check command pollTmuxSession runs (`tmux list-panes -t
+//     <session>` with a 3s timeout) succeeds against a real, alive tmux session.
+//  2. A realistic *transient* failure — the command's context deadline tripping
+//     "under load" — makes that same check fail even though the window is alive.
+//     This is the failure mode that caused the mass false-block.
+//  3. The real windowMissTracker debounces that transient failure (alive →
+//     transient-fail → alive never blocks), yet still reports "gone" after the
+//     session is genuinely killed (threshold consecutive real failures).
+//
+// Isolation: runs on a DEDICATED tmux server (`tmux -L <socket>`) so it can never
+// disturb a live ty instance on the default socket. The ONLY deviation from the
+// production command is that `-L <socket>` flag; flags, 3s timeout, and the
+// windowMissTracker decision logic are identical to executor.go.
+//
+// Run: go test ./internal/executor/ -tags=qa_repro -run TestQAReproTransientTmux -v
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestQAReproTransientTmux(t *testing.T) {
+	const socket = "taskyou-qa-558"
+	const session = "pr558-repro"
+
+	tmux := func(timeout time.Duration, args ...string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		full := append([]string{"-L", socket}, args...)
+		return exec.CommandContext(ctx, "tmux", full...).Run()
+	}
+
+	// windowCheck mirrors executor.go:pollTmuxSession exactly: `tmux list-panes
+	// -t <session>` under a 3s timeout, windowExists := (err == nil).
+	windowCheck := func(timeout time.Duration) bool {
+		return tmux(timeout, "list-panes", "-t", session) == nil
+	}
+
+	// Clean slate + guaranteed teardown of the isolated server.
+	_ = tmux(3*time.Second, "kill-session", "-t", session)
+	t.Cleanup(func() { _ = tmux(3*time.Second, "kill-server") })
+
+	if err := tmux(5*time.Second, "new-session", "-d", "-s", session, "-x", "80", "-y", "24"); err != nil {
+		t.Skipf("cannot start isolated tmux server (tmux required for this repro): %v", err)
+	}
+	t.Logf("[setup] started isolated tmux session %q on socket %q", session, socket)
+
+	misses := windowMissTracker{threshold: 3}
+
+	// helper to run one poll "tick" and report the decision the way pollTmuxSession would.
+	tick := func(label string, exists bool) (blocked bool) {
+		gone := misses.record(exists)
+		state := "ALIVE  ✓ (counter reset)"
+		if !exists {
+			state = fmt.Sprintf("MISS   ✗ (consecutive=%d/%d)", misses.consecutive, misses.threshold)
+		}
+		decision := "keep polling"
+		if gone {
+			decision = ">>> BLOCK: \"Task needs review\""
+		}
+		t.Logf("[tick] %-28s window=%s  -> %s", label, state, decision)
+		return gone
+	}
+
+	// 1) Real alive check — the genuine command against the live session.
+	if got := windowCheck(3 * time.Second); !got {
+		t.Fatalf("alive session: real `tmux list-panes` failed; expected success")
+	}
+	if tick("healthy check", true) {
+		t.Fatalf("healthy check blocked the task")
+	}
+
+	// 2) Transient failure: SAME command, but the deadline trips (simulating the
+	//    3s timeout failing under load). The session is still alive.
+	if got := windowCheck(1 * time.Nanosecond); got {
+		t.Fatalf("expected transient timeout to fail the check, but it succeeded")
+	}
+	t.Logf("[note] real `tmux list-panes` returned an ERROR under a tripped deadline while the window is ALIVE")
+	if tick("transient timeout (load)", false) {
+		t.Fatalf("OLD BEHAVIOR REGRESSION: a single transient failure blocked the task")
+	}
+
+	// 3) Recovery — server responsive again. The streak must reset.
+	if got := windowCheck(3 * time.Second); !got {
+		t.Fatalf("post-blip alive check failed unexpectedly")
+	}
+	if tick("recovered", true) {
+		t.Fatalf("recovered check blocked the task")
+	}
+	if misses.consecutive != 0 {
+		t.Fatalf("counter not reset after recovery: consecutive=%d", misses.consecutive)
+	}
+	t.Logf("[PASS] transient blip did NOT false-block the healthy task")
+
+	// 4) Genuine death — kill the session; now the real check fails for real.
+	if err := tmux(3*time.Second, "kill-session", "-t", session); err != nil {
+		t.Fatalf("failed to kill session: %v", err)
+	}
+	t.Logf("[setup] killed session %q — window is now genuinely gone", session)
+
+	blockedAt := 0
+	for i := 1; i <= 3; i++ {
+		got := windowCheck(3 * time.Second) // real failure: session no longer exists
+		if got {
+			t.Fatalf("killed session still reported as alive on check %d", i)
+		}
+		if tick(fmt.Sprintf("genuine death #%d", i), false) {
+			blockedAt = i
+			break
+		}
+	}
+	if blockedAt != 3 {
+		t.Fatalf("genuine death should block on the 3rd consecutive miss; blocked at %d", blockedAt)
+	}
+	t.Logf("[PASS] genuinely-closed window still detected after %d consecutive real failures", blockedAt)
+}

--- a/internal/executor/poll_tmux_test.go
+++ b/internal/executor/poll_tmux_test.go
@@ -1,0 +1,79 @@
+package executor
+
+import "testing"
+
+// TestWindowMissTracker covers the transient-failure debounce used by
+// pollTmuxSession (PR #558). The whole point of the change is that a single
+// failed `tmux list-panes` — which also happens when the shared tmux server is
+// briefly busy or the 3s timeout trips under load — must NOT immediately block a
+// healthy task. Only `threshold` consecutive misses should be treated as
+// "window genuinely gone".
+func TestWindowMissTracker(t *testing.T) {
+	const threshold = 3
+
+	t.Run("single transient miss does not block", func(t *testing.T) {
+		w := windowMissTracker{threshold: threshold}
+		if gone := w.record(false); gone {
+			t.Fatalf("one miss reported window gone; want healthy (transient blip must not block)")
+		}
+	})
+
+	t.Run("misses below threshold do not block", func(t *testing.T) {
+		w := windowMissTracker{threshold: threshold}
+		for i := 1; i < threshold; i++ {
+			if gone := w.record(false); gone {
+				t.Fatalf("miss #%d reported window gone; want still healthy until threshold (%d)", i, threshold)
+			}
+		}
+	})
+
+	t.Run("threshold consecutive misses block", func(t *testing.T) {
+		w := windowMissTracker{threshold: threshold}
+		var gone bool
+		for i := 0; i < threshold; i++ {
+			gone = w.record(false)
+		}
+		if !gone {
+			t.Fatalf("%d consecutive misses did not report window gone; want gone", threshold)
+		}
+	})
+
+	t.Run("a success resets the run of misses", func(t *testing.T) {
+		w := windowMissTracker{threshold: threshold}
+		// Two misses, then a healthy check — the streak must reset so we are
+		// nowhere near blocking.
+		w.record(false)
+		w.record(false)
+		if gone := w.record(true); gone {
+			t.Fatalf("healthy check reported window gone")
+		}
+		if w.consecutive != 0 {
+			t.Fatalf("consecutive = %d after success; want 0", w.consecutive)
+		}
+		// After the reset it must take a *fresh* full run of misses to block —
+		// proving the failures are required to be consecutive, not cumulative.
+		if gone := w.record(false); gone {
+			t.Fatalf("first miss after reset blocked; want threshold misses required again")
+		}
+		if gone := w.record(false); gone {
+			t.Fatalf("second miss after reset blocked; want threshold misses required again")
+		}
+		if gone := w.record(false); !gone {
+			t.Fatalf("third consecutive miss after reset did not block; want gone")
+		}
+	})
+
+	t.Run("flapping never accumulates to a block", func(t *testing.T) {
+		w := windowMissTracker{threshold: threshold}
+		// miss, ok, miss, ok, ... a server that intermittently recovers must
+		// never trip the threshold because the run never reaches `threshold`.
+		for i := 0; i < 10; i++ {
+			if gone := w.record(false); gone {
+				t.Fatalf("flapping miss tripped block at iteration %d; want never", i)
+			}
+			if gone := w.record(true); gone {
+				t.Fatalf("flapping success reported gone at iteration %d", i)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Problem
`pollTmuxSession` marks a task **blocked** ("Task needs review") the moment a single `tmux list-panes` check fails. But that command also fails *transiently* — when the tmux server is briefly busy, or its 3s timeout trips under load. Because every running task's poller hits the same tmux server, a momentary stall makes them **all** misfire at once, false-blocking healthy, actively-running tasks simultaneously (regardless of permission mode).

## Fix
Require `missingThreshold` (3) **consecutive** failed window checks before concluding the window is gone, and reset the counter on any successful check. A transient blip can no longer false-block a healthy task; a genuinely-closed window is still detected (~3s later).

## Testing
`go build ./...` and `go vet ./...` clean; `go test ./internal/executor/...` passes. No behavior change for the legitimate "window really closed" path — same final-status resolution, just gated behind the consecutive-miss threshold.
