### PR TITLE
Remove hardcoded TASK GUIDANCE; default 'code' task type owns it instead

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -315,12 +315,6 @@ func (db *DB) migrate() error {
 		return fmt.Errorf("ensure default task types: %w", err)
 	}
 
-	// Fold the former executor-injected TASK GUIDANCE into the built-in "code"
-	// task type for existing installs (content-guarded; never clobbers customizations).
-	if err := db.migrateCodeTaskTypeGuidance(); err != nil {
-		return fmt.Errorf("migrate code task type guidance: %w", err)
-	}
-
 	// Assign default colors to projects without colors
 	if err := db.ensureProjectColors(); err != nil {
 		return fmt.Errorf("ensure project colors: %w", err)
@@ -508,11 +502,14 @@ func (db *DB) migrateProjectAliases() error {
 	return nil
 }
 
-// oldCodeTaskTypeInstructions is the previous default instructions string for the
-// built-in "code" task type, before the executor's hardcoded TASK GUIDANCE block
-// was folded into this task type. Kept byte-exact so the content-guarded migration
-// in migrateCodeTaskTypeGuidance can match (and skip) user-customized rows.
-const oldCodeTaskTypeInstructions = `You are working on: {{project}}
+// defaultCodeTaskTypeInstructions is the default instructions template for the built-in
+// "code" task type. It carries only code-task workflow steering (explore, implement, test,
+// commit, open a PR) — deliberately NOT operational guidance like the worktree-safety
+// constraint or taskyou_get_project_context usage. That guidance is intrinsic to how
+// taskyou runs a task (every task type, conditional on worktrees) and is injected by the
+// executor for all task types (see Executor.buildUniversalGuidance), so it must not be
+// baked into a single task type's editable template.
+const defaultCodeTaskTypeInstructions = `You are working on: {{project}}
 
 {{project_instructions}}
 
@@ -526,7 +523,6 @@ Task: {{title}}
 
 Instructions:
 - Explore the codebase to understand the context
-- Always use relative paths (e.g., "." or "./src") when searching or navigating - never use absolute paths
 - Implement the solution
 - Write tests if applicable
 - Commit your changes with clear messages
@@ -539,63 +535,6 @@ When finished, provide a summary of what you did:
 - Describe the key changes made
 - Include any relevant links (PRs, commits, etc.)
 - Note any follow-up items or concerns`
-
-// defaultCodeTaskTypeInstructions is the current default instructions string for the
-// built-in "code" task type. It absorbs the code-specific task-execution guidance that
-// the executor previously injected via --append-system-prompt (GitHub CLI etiquette, the
-// PR-submission objective), so that default-config users get the same guidance while
-// custom task types (and edits to this one) stay in full user control via the task-type
-// UI. Note: the *universal* guidance — worktree-safety constraint and project-context
-// caching — is NOT folded in here; it is injected for every task type by the executor
-// (see Executor.buildUniversalGuidance), conditional on whether the project uses
-// worktrees, which a static template cannot express.
-const defaultCodeTaskTypeInstructions = `You are working on: {{project}}
-
-{{project_instructions}}
-
-Task: {{title}}
-
-{{body}}
-
-{{attachments}}
-
-{{history}}
-
-GitHub CLI (gh) - conserve the shared GraphQL bucket:
-- GitHub's GraphQL rate limit (5,000 points/hr) is per-user and shared by every agent authenticated as the same account.
-- Prefer REST for PR reads (separate 5,000/hr bucket): use "gh api repos/{owner}/{repo}/pulls/{n}" rather than "gh pr view --json ...".
-- Never busy-poll CI with "gh pr checks" in a loop. Use "gh run watch <run-id>" (blocks server-side) or poll REST check-runs with backoff.
-
-Instructions:
-- Implement the solution
-- Write tests if applicable
-- For visual/frontend work, use the taskyou_screenshot MCP tool to verify correctness and document changes
-- Commit your changes with clear messages
-- Submit a pull request when your work is complete
-
-IMPORTANT: Your objective is to submit a PR to complete this task. Always remember to create and submit a pull request as the final step of your work. This is how you signal that the implementation is ready for review and merging.
-
-When finished, provide a summary of what you did:
-- List files changed/created
-- Describe the key changes made
-- Include any relevant links (PRs, commits, etc.)
-- Note any follow-up items or concerns`
-
-// migrateCodeTaskTypeGuidance updates the built-in "code" task type's instructions to
-// defaultCodeTaskTypeInstructions, but ONLY when the existing row still holds the exact
-// previous default (oldCodeTaskTypeInstructions). This folds the former executor-injected
-// TASK GUIDANCE into the task type for existing installs without clobbering rows a user
-// has customized. It is idempotent: on the new schema the WHERE clause matches nothing.
-func (db *DB) migrateCodeTaskTypeGuidance() error {
-	_, err := db.Exec(
-		`UPDATE task_types SET instructions = ? WHERE name = 'code' AND instructions = ?`,
-		defaultCodeTaskTypeInstructions, oldCodeTaskTypeInstructions,
-	)
-	if err != nil {
-		return fmt.Errorf("migrate code task type guidance: %w", err)
-	}
-	return nil
-}
 
 // ensureDefaultTaskTypes creates the default task types if they don't exist.
 func (db *DB) ensureDefaultTaskTypes() error {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -539,10 +539,14 @@ When finished, provide a summary of what you did:
 - Note any follow-up items or concerns`
 
 // defaultCodeTaskTypeInstructions is the current default instructions string for the
-// built-in "code" task type. It absorbs the task-execution guidance that the executor
-// previously injected for every task via --append-system-prompt, so that default-config
-// users get the same guidance while custom task types (and edits to this one) stay in
-// full user control via the existing task-type UI.
+// built-in "code" task type. It absorbs the code-specific task-execution guidance that
+// the executor previously injected via --append-system-prompt (GitHub CLI etiquette, the
+// PR-submission objective), so that default-config users get the same guidance while
+// custom task types (and edits to this one) stay in full user control via the task-type
+// UI. Note: the *universal* guidance — worktree-safety constraint and project-context
+// caching — is NOT folded in here; it is injected for every task type by the executor
+// (see Executor.buildUniversalGuidance), conditional on whether the project uses
+// worktrees, which a static template cannot express.
 const defaultCodeTaskTypeInstructions = `You are working on: {{project}}
 
 {{project_instructions}}
@@ -554,13 +558,6 @@ Task: {{title}}
 {{attachments}}
 
 {{history}}
-
-Before exploring the codebase:
-- Call taskyou_get_project_context first via MCP. If it returns context, use it and skip exploration. If empty, explore once and save a summary via taskyou_set_project_context. This caches your exploration for future tasks in this project.
-
-Working directory constraint:
-- You are running in an isolated git worktree. This worktree IS your project - it is NOT a copy. Only use paths within your current working directory, and never read or write files outside it.
-- Always use relative paths (e.g., "." or "./src") when searching or navigating - never use absolute paths.
 
 GitHub CLI (gh) - conserve the shared GraphQL bucket:
 - GitHub's GraphQL rate limit (5,000 points/hr) is per-user and shared by every agent authenticated as the same account.

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -313,6 +313,12 @@ func (db *DB) migrate() error {
 		return fmt.Errorf("ensure default task types: %w", err)
 	}
 
+	// Fold the former executor-injected TASK GUIDANCE into the built-in "code"
+	// task type for existing installs (content-guarded; never clobbers customizations).
+	if err := db.migrateCodeTaskTypeGuidance(); err != nil {
+		return fmt.Errorf("migrate code task type guidance: %w", err)
+	}
+
 	// Assign default colors to projects without colors
 	if err := db.ensureProjectColors(); err != nil {
 		return fmt.Errorf("ensure project colors: %w", err)
@@ -500,30 +506,11 @@ func (db *DB) migrateProjectAliases() error {
 	return nil
 }
 
-// ensureDefaultTaskTypes creates the default task types if they don't exist.
-func (db *DB) ensureDefaultTaskTypes() error {
-	// Check if task types already exist
-	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM task_types`).Scan(&count)
-	if err != nil {
-		return fmt.Errorf("check task types: %w", err)
-	}
-
-	if count > 0 {
-		return nil // Types already exist
-	}
-
-	// Default task type instructions using template placeholders
-	defaults := []struct {
-		Name         string
-		Label        string
-		Instructions string
-		SortOrder    int
-	}{
-		{
-			Name:  "code",
-			Label: "Code",
-			Instructions: `You are working on: {{project}}
+// oldCodeTaskTypeInstructions is the previous default instructions string for the
+// built-in "code" task type, before the executor's hardcoded TASK GUIDANCE block
+// was folded into this task type. Kept byte-exact so the content-guarded migration
+// in migrateCodeTaskTypeGuidance can match (and skip) user-customized rows.
+const oldCodeTaskTypeInstructions = `You are working on: {{project}}
 
 {{project_instructions}}
 
@@ -549,8 +536,93 @@ When finished, provide a summary of what you did:
 - List files changed/created
 - Describe the key changes made
 - Include any relevant links (PRs, commits, etc.)
-- Note any follow-up items or concerns`,
-			SortOrder: 1,
+- Note any follow-up items or concerns`
+
+// defaultCodeTaskTypeInstructions is the current default instructions string for the
+// built-in "code" task type. It absorbs the task-execution guidance that the executor
+// previously injected for every task via --append-system-prompt, so that default-config
+// users get the same guidance while custom task types (and edits to this one) stay in
+// full user control via the existing task-type UI.
+const defaultCodeTaskTypeInstructions = `You are working on: {{project}}
+
+{{project_instructions}}
+
+Task: {{title}}
+
+{{body}}
+
+{{attachments}}
+
+{{history}}
+
+Before exploring the codebase:
+- Call taskyou_get_project_context first via MCP. If it returns context, use it and skip exploration. If empty, explore once and save a summary via taskyou_set_project_context. This caches your exploration for future tasks in this project.
+
+Working directory constraint:
+- You are running in an isolated git worktree. This worktree IS your project - it is NOT a copy. Only use paths within your current working directory, and never read or write files outside it.
+- Always use relative paths (e.g., "." or "./src") when searching or navigating - never use absolute paths.
+
+GitHub CLI (gh) - conserve the shared GraphQL bucket:
+- GitHub's GraphQL rate limit (5,000 points/hr) is per-user and shared by every agent authenticated as the same account.
+- Prefer REST for PR reads (separate 5,000/hr bucket): use "gh api repos/{owner}/{repo}/pulls/{n}" rather than "gh pr view --json ...".
+- Never busy-poll CI with "gh pr checks" in a loop. Use "gh run watch <run-id>" (blocks server-side) or poll REST check-runs with backoff.
+
+Instructions:
+- Implement the solution
+- Write tests if applicable
+- For visual/frontend work, use the taskyou_screenshot MCP tool to verify correctness and document changes
+- Commit your changes with clear messages
+- Submit a pull request when your work is complete
+
+IMPORTANT: Your objective is to submit a PR to complete this task. Always remember to create and submit a pull request as the final step of your work. This is how you signal that the implementation is ready for review and merging.
+
+When finished, provide a summary of what you did:
+- List files changed/created
+- Describe the key changes made
+- Include any relevant links (PRs, commits, etc.)
+- Note any follow-up items or concerns`
+
+// migrateCodeTaskTypeGuidance updates the built-in "code" task type's instructions to
+// defaultCodeTaskTypeInstructions, but ONLY when the existing row still holds the exact
+// previous default (oldCodeTaskTypeInstructions). This folds the former executor-injected
+// TASK GUIDANCE into the task type for existing installs without clobbering rows a user
+// has customized. It is idempotent: on the new schema the WHERE clause matches nothing.
+func (db *DB) migrateCodeTaskTypeGuidance() error {
+	_, err := db.Exec(
+		`UPDATE task_types SET instructions = ? WHERE name = 'code' AND instructions = ?`,
+		defaultCodeTaskTypeInstructions, oldCodeTaskTypeInstructions,
+	)
+	if err != nil {
+		return fmt.Errorf("migrate code task type guidance: %w", err)
+	}
+	return nil
+}
+
+// ensureDefaultTaskTypes creates the default task types if they don't exist.
+func (db *DB) ensureDefaultTaskTypes() error {
+	// Check if task types already exist
+	var count int
+	err := db.QueryRow(`SELECT COUNT(*) FROM task_types`).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check task types: %w", err)
+	}
+
+	if count > 0 {
+		return nil // Types already exist
+	}
+
+	// Default task type instructions using template placeholders
+	defaults := []struct {
+		Name         string
+		Label        string
+		Instructions string
+		SortOrder    int
+	}{
+		{
+			Name:         "code",
+			Label:        "Code",
+			Instructions: defaultCodeTaskTypeInstructions,
+			SortOrder:    1,
 		},
 		{
 			Name:  "writing",

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -323,10 +323,12 @@ func TestProjectUseWorktrees(t *testing.T) {
 	}
 }
 
-// TestDefaultCodeTaskTypeGuidance verifies the built-in "code" task type carries the
-// task-execution guidance that the executor previously injected via --append-system-prompt
-// (notably the GitHub CLI / shared-GraphQL-bucket etiquette), so default-config users get
-// the same steering through the task type instead of a hardcoded executor block.
+// TestDefaultCodeTaskTypeGuidance verifies the built-in "code" task type carries only
+// code-task workflow steering and deliberately does NOT carry operational guidance that is
+// intrinsic to how taskyou runs a task (worktree-safety, taskyou_get_project_context) or
+// deployment-specific etiquette (GitHub/gh shared-GraphQL-bucket). That guidance is injected
+// by the executor for every task type — see Executor.buildUniversalGuidance — and must not
+// be baked into this editable, single-task-type template.
 func TestDefaultCodeTaskTypeGuidance(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
@@ -346,69 +348,28 @@ func TestDefaultCodeTaskTypeGuidance(t *testing.T) {
 		t.Fatal("default code task type was not created")
 	}
 
-	// The code task type owns the code-specific guidance (GitHub CLI / shared-GraphQL
-	// etiquette). The universal worktree-safety and project-context guidance is injected
-	// by the executor for every task type, not folded into this template — see
-	// Executor.buildUniversalGuidance / TestBuildPromptUniversalGuidance.
 	wants := []string{
-		"GitHub CLI",
-		"per-user",
-		"gh pr checks",
-		"gh run watch",
-		"REST",
+		"Explore the codebase",
+		"Submit a pull request",
+		"{{title}}",
 	}
 	for _, want := range wants {
 		if !strings.Contains(codeType.Instructions, want) {
 			t.Errorf("code task type instructions missing %q", want)
 		}
 	}
-}
 
-// TestMigrateCodeTaskTypeGuidance verifies the content-guarded migration upgrades a row
-// still holding the old default, while leaving a customized row untouched.
-func TestMigrateCodeTaskTypeGuidance(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Case 1: a row holding the exact old default is upgraded.
-	dbPath1 := filepath.Join(tmpDir, "old.db")
-	db1, err := Open(dbPath1)
-	if err != nil {
-		t.Fatalf("failed to open database: %v", err)
+	// Operational / deployment-specific guidance must not leak into the task-type template.
+	doesNotWant := []string{
+		"GitHub CLI",
+		"GraphQL",
+		"gh run watch",
+		"taskyou_get_project_context",
+		"isolated git worktree",
 	}
-	defer db1.Close()
-	if _, err := db1.Exec(`UPDATE task_types SET instructions = ? WHERE name = 'code'`, oldCodeTaskTypeInstructions); err != nil {
-		t.Fatalf("failed to set old instructions: %v", err)
-	}
-	if err := db1.migrateCodeTaskTypeGuidance(); err != nil {
-		t.Fatalf("migration failed: %v", err)
-	}
-	got, err := db1.GetTaskTypeByName("code")
-	if err != nil {
-		t.Fatalf("failed to get code task type: %v", err)
-	}
-	if got.Instructions != defaultCodeTaskTypeInstructions {
-		t.Error("expected old-default row to be upgraded to new default instructions")
-	}
-
-	// Case 2: a customized row is left untouched (idempotent / non-clobbering).
-	dbPath2 := filepath.Join(tmpDir, "custom.db")
-	db2, err := Open(dbPath2)
-	if err != nil {
-		t.Fatalf("failed to open database: %v", err)
-	}
-	defer db2.Close()
-	const custom = "my custom code instructions"
-	if _, err := db2.Exec(`UPDATE task_types SET instructions = ? WHERE name = 'code'`, custom); err != nil {
-		t.Fatalf("failed to set custom instructions: %v", err)
-	}
-	if err := db2.migrateCodeTaskTypeGuidance(); err != nil {
-		t.Fatalf("migration failed: %v", err)
-	}
-	got2, err := db2.GetTaskTypeByName("code")
-	if err != nil {
-		t.Fatalf("failed to get code task type: %v", err)
-	}
-	if got2.Instructions != custom {
-		t.Errorf("customized row was clobbered: got %q", got2.Instructions)
+	for _, unwanted := range doesNotWant {
+		if strings.Contains(codeType.Instructions, unwanted) {
+			t.Errorf("code task type instructions should not contain %q (it is executor-injected, not template-owned)", unwanted)
+		}
 	}
 }

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -319,5 +320,92 @@ func TestProjectUseWorktrees(t *testing.T) {
 	}
 	if p.UsesWorktrees() {
 		t.Error("alias-proj looked up by alias should NOT use worktrees")
+	}
+}
+
+// TestDefaultCodeTaskTypeGuidance verifies the built-in "code" task type carries the
+// task-execution guidance that the executor previously injected via --append-system-prompt
+// (notably the GitHub CLI / shared-GraphQL-bucket etiquette), so default-config users get
+// the same steering through the task type instead of a hardcoded executor block.
+func TestDefaultCodeTaskTypeGuidance(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+	defer os.Remove(dbPath)
+
+	codeType, err := db.GetTaskTypeByName("code")
+	if err != nil {
+		t.Fatalf("failed to get code task type: %v", err)
+	}
+	if codeType == nil {
+		t.Fatal("default code task type was not created")
+	}
+
+	wants := []string{
+		"GitHub CLI",
+		"per-user",
+		"gh pr checks",
+		"gh run watch",
+		"REST",
+		"taskyou_get_project_context",
+	}
+	for _, want := range wants {
+		if !strings.Contains(codeType.Instructions, want) {
+			t.Errorf("code task type instructions missing %q", want)
+		}
+	}
+}
+
+// TestMigrateCodeTaskTypeGuidance verifies the content-guarded migration upgrades a row
+// still holding the old default, while leaving a customized row untouched.
+func TestMigrateCodeTaskTypeGuidance(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Case 1: a row holding the exact old default is upgraded.
+	dbPath1 := filepath.Join(tmpDir, "old.db")
+	db1, err := Open(dbPath1)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db1.Close()
+	if _, err := db1.Exec(`UPDATE task_types SET instructions = ? WHERE name = 'code'`, oldCodeTaskTypeInstructions); err != nil {
+		t.Fatalf("failed to set old instructions: %v", err)
+	}
+	if err := db1.migrateCodeTaskTypeGuidance(); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	got, err := db1.GetTaskTypeByName("code")
+	if err != nil {
+		t.Fatalf("failed to get code task type: %v", err)
+	}
+	if got.Instructions != defaultCodeTaskTypeInstructions {
+		t.Error("expected old-default row to be upgraded to new default instructions")
+	}
+
+	// Case 2: a customized row is left untouched (idempotent / non-clobbering).
+	dbPath2 := filepath.Join(tmpDir, "custom.db")
+	db2, err := Open(dbPath2)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db2.Close()
+	const custom = "my custom code instructions"
+	if _, err := db2.Exec(`UPDATE task_types SET instructions = ? WHERE name = 'code'`, custom); err != nil {
+		t.Fatalf("failed to set custom instructions: %v", err)
+	}
+	if err := db2.migrateCodeTaskTypeGuidance(); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	got2, err := db2.GetTaskTypeByName("code")
+	if err != nil {
+		t.Fatalf("failed to get code task type: %v", err)
+	}
+	if got2.Instructions != custom {
+		t.Errorf("customized row was clobbered: got %q", got2.Instructions)
 	}
 }

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -346,13 +346,16 @@ func TestDefaultCodeTaskTypeGuidance(t *testing.T) {
 		t.Fatal("default code task type was not created")
 	}
 
+	// The code task type owns the code-specific guidance (GitHub CLI / shared-GraphQL
+	// etiquette). The universal worktree-safety and project-context guidance is injected
+	// by the executor for every task type, not folded into this template — see
+	// Executor.buildUniversalGuidance / TestBuildPromptUniversalGuidance.
 	wants := []string{
 		"GitHub CLI",
 		"per-user",
 		"gh pr checks",
 		"gh run watch",
 		"REST",
-		"taskyou_get_project_context",
 	}
 	for _, want := range wants {
 		if !strings.Contains(codeType.Instructions, want) {

--- a/internal/executor/claude_executor.go
+++ b/internal/executor/claude_executor.go
@@ -13,7 +13,11 @@ import (
 )
 
 // shellSingleQuote wraps s in single quotes for safe interpolation into a shell
-// command, escaping any embedded single quotes via the standard '\'' idiom.
+// command, escaping any embedded single quote via the standard close-escape-reopen
+// idiom:
+//
+//	'\''
+//
 // Unlike fmt's %q (which produces Go-string quoting and leaves $, backticks,
 // and the like live for the shell), this neutralizes shell metacharacters and
 // is safe against command injection.

--- a/internal/executor/claude_executor.go
+++ b/internal/executor/claude_executor.go
@@ -116,24 +116,10 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 		worktreeSessionID = fmt.Sprintf("%d", os.Getpid())
 	}
 
-	// Build system prompt flag - passes task guidance via system prompt to keep conversation clean
-	systemPromptFlag := ""
-	systemFile, err := os.CreateTemp("", "task-system-*.txt")
-	if err == nil {
-		systemFile.WriteString(c.executor.buildSystemInstructions())
-		systemFile.Close()
-		// Note: temp file cleanup happens via rm -f at end of command
-		systemPromptFlag = fmt.Sprintf(`--append-system-prompt "$(cat %q)" `, systemFile.Name())
-	}
-
 	// Build command - resume if we have a session ID, otherwise start fresh
 	if sessionID != "" {
-		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s%s--resume %s`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, systemPromptFlag, sessionID)
-		if systemFile != nil {
-			cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
-		}
-		return cmd
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s--resume %s`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, sessionID)
 	}
 
 	// Start fresh - if prompt is provided, write to temp file and pass it
@@ -142,30 +128,18 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 		promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
 		if err != nil {
 			c.logger.Error("BuildCommand: failed to create temp file", "error", err)
-			cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s%s`,
-				task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, systemPromptFlag)
-			if systemFile != nil {
-				cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
-			}
-			return cmd
+			return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s`,
+				task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort)
 		}
 		promptFile.WriteString(prompt)
 		promptFile.Close()
 
-		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s%s"$(cat %q)"; rm -f %q`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, systemPromptFlag, promptFile.Name(), promptFile.Name())
-		if systemFile != nil {
-			cmd += fmt.Sprintf(` %q`, systemFile.Name())
-		}
-		return cmd
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s"$(cat %q)"; rm -f %q`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, promptFile.Name(), promptFile.Name())
 	}
 
-	cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s%s`,
-		task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, systemPromptFlag)
-	if systemFile != nil {
-		cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
-	}
-	return cmd
+	return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort)
 }
 
 // ---- Session and Dangerous Mode Support ----

--- a/internal/executor/codex_executor.go
+++ b/internal/executor/codex_executor.go
@@ -113,13 +113,11 @@ func (c *CodexExecutor) runCodex(ctx context.Context, task *db.Task, workDir, pr
 		return ExecResult{Message: fmt.Sprintf("failed to create temp file: %s", err.Error())}
 	}
 
-	// Build the full prompt with system instructions
-	// Codex doesn't have a safe way to pass system instructions (AGENTS.md could overwrite project files)
+	// Build the full prompt
 	fullPrompt := prompt
 	if isResume && feedback != "" {
 		fullPrompt = prompt + "\n\n## User Feedback\n\n" + feedback
 	}
-	fullPrompt = fullPrompt + "\n\n" + c.executor.buildSystemInstructions()
 	promptFile.WriteString(fullPrompt)
 	promptFile.Close()
 	defer os.Remove(promptFile.Name())
@@ -372,9 +370,7 @@ func (c *CodexExecutor) BuildCommand(task *db.Task, sessionID, prompt string) st
 			return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q codex %s%s`,
 				task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, resumeFlag)
 		}
-		// Include system instructions in prompt (AGENTS.md could overwrite project files)
-		fullPrompt := prompt + "\n\n" + c.executor.buildSystemInstructions()
-		promptFile.WriteString(fullPrompt)
+		promptFile.WriteString(prompt)
 		promptFile.Close()
 
 		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q codex %s%s"$(cat %q)"; rm -f %q`,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1356,64 +1356,7 @@ func (e *Executor) buildPrompt(task *db.Task, attachmentPaths []string) string {
 		prompt.WriteString(e.buildGenericContextSection(projectInstructions, similarTasks, attachments, conversationHistory))
 	}
 
-	// Note: Task guidance is now passed via system prompt (Claude) or GEMINI.md (Gemini)
-	// to keep the user conversation thread clean. See buildSystemInstructions().
-
 	return prompt.String()
-}
-
-// buildSystemInstructions returns the system-level instructions that guide task execution.
-// These instructions are passed via system prompt mechanisms (e.g., --append-system-prompt for Claude,
-// GEMINI.md for Gemini) rather than in the user conversation thread to keep it clean.
-func (e *Executor) buildSystemInstructions() string {
-	return `═══════════════════════════════════════════════════════════════
-                      TASK GUIDANCE
-═══════════════════════════════════════════════════════════════
-
-⚡ BEFORE EXPLORING THE CODEBASE:
-  Call taskyou_get_project_context first via MCP.
-  - If it returns context, use it and skip exploration
-  - If empty, explore once and save a summary via taskyou_set_project_context
-  This caches your exploration for future tasks in this project.
-
-Work on this task until completion. When you're done or need input:
-
-✓ WHEN TASK IS COMPLETE:
-  Provide a clear summary of what was accomplished
-
-✓ WHEN YOU NEED INPUT/CLARIFICATION:
-  Ask your question clearly and wait for a response
-
-✓ FOR VISUAL/FRONTEND WORK:
-  Use the taskyou_screenshot MCP tool to take screenshots of the
-  screen. This helps verify correctness and document changes.
-
-⚠ CRITICAL - WORKING DIRECTORY CONSTRAINT:
-  You are running in an isolated git worktree. This worktree IS your
-  project - it is NOT a copy. NEVER access the "original" project
-  directory or any path outside your current working directory.
-
-  - ONLY use paths within your current working directory
-  - NEVER read/write files in /Users/*/Projects/* except this worktree
-  - If you see a path like .task-worktrees/, you're in the right place
-  - The parent repo does NOT exist for you - only this worktree does
-
-🐙 GITHUB CLI (gh) — CONSERVE THE SHARED GRAPHQL BUCKET:
-  GitHub's GraphQL rate limit (5,000 points/hr) is PER-USER and is shared by
-  every agent server authenticated as the same account. It exhausts easily.
-
-  - Prefer REST for PR reads — it has a SEPARATE 5,000/hr bucket:
-      gh pr view --json ...        ❌ (GraphQL-backed)
-      gh api repos/{owner}/{repo}/pulls/{n}   ✅ (REST)
-  - NEVER busy-poll CI with "gh pr checks" in a loop. Instead use:
-      gh run watch <run-id>        ✅ (blocks server-side, no polling)
-    or poll REST check-runs with backoff:
-      gh api repos/{owner}/{repo}/commits/{sha}/check-runs
-  - If you see "GraphQL bucket is exhausted", switch to the REST equivalents
-    above and back off — do not retry the GraphQL call in a tight loop.
-
-The task system will automatically detect your status.
-═══════════════════════════════════════════════════════════════`
 }
 
 // applyTemplateSubstitutions replaces template placeholders in task type instructions.
@@ -2263,21 +2206,6 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 	promptFile.Close()
 	defer os.Remove(promptFile.Name())
 
-	// Create a temp file for system instructions (passed via --append-system-prompt)
-	// This keeps the task guidance out of the user conversation thread
-	systemFile, err := os.CreateTemp("", "task-system-*.txt")
-	if err != nil {
-		e.logger.Error("could not create system file", "error", err)
-		e.logLine(task.ID, "error", fmt.Sprintf("Failed to create system file: %s", err.Error()))
-		if cleanupHooks != nil {
-			cleanupHooks()
-		}
-		return execResult{Message: fmt.Sprintf("failed to create system file: %s", err.Error())}
-	}
-	systemFile.WriteString(e.buildSystemInstructions())
-	systemFile.Close()
-	defer os.Remove(systemFile.Name())
-
 	// Script that runs claude interactively with worktree environment variables
 	// Note: tmux starts in workDir (-c flag), so claude inherits proper permissions and hooks config
 	// Run interactively (no -p) so user can attach and see/interact in real-time
@@ -2294,8 +2222,6 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 	dangerousFlag := claudePermissionFlag(task)
 	// Build per-task effort override flag (empty = use Claude's global default)
 	effort := effortFlag(task.EffortLevel)
-	// Build system prompt flag - passes task guidance via system prompt to keep conversation clean
-	systemPromptFlag := fmt.Sprintf(`--append-system-prompt "$(cat %q)" `, systemFile.Name())
 
 	// Check for existing Claude session to resume instead of starting fresh
 	// Only use stored session ID - no file-based fallback to avoid cross-task contamination
@@ -2305,8 +2231,8 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 	envPrefix := claudeEnvPrefix(paths.configDir)
 	if existingSessionID != "" && ClaudeSessionExists(existingSessionID, workDir, paths.configDir) {
 		e.logLine(task.ID, "system", fmt.Sprintf("Resuming existing session %s", existingSessionID))
-		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s--resume %s "$(cat %q)"`,
-			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, systemPromptFlag, existingSessionID, promptFile.Name())
+		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s--resume %s "$(cat %q)"`,
+			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, existingSessionID, promptFile.Name())
 	} else {
 		if existingSessionID != "" {
 			e.logLine(task.ID, "system", fmt.Sprintf("Session %s no longer exists, starting fresh", existingSessionID))
@@ -2315,8 +2241,8 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 				e.logger.Warn("failed to clear stale session ID", "task", task.ID, "error", err)
 			}
 		}
-		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s"$(cat %q)"`,
-			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, systemPromptFlag, promptFile.Name())
+		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s"$(cat %q)"`,
+			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, promptFile.Name())
 	}
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
@@ -2438,21 +2364,6 @@ func (e *Executor) runClaudeResume(ctx context.Context, task *db.Task, workDir, 
 	feedbackFile.Close()
 	defer os.Remove(feedbackFile.Name())
 
-	// Create a temp file for system instructions (passed via --append-system-prompt)
-	// This keeps the task guidance out of the user conversation thread
-	systemFile, err := os.CreateTemp("", "task-system-*.txt")
-	if err != nil {
-		e.logger.Error("could not create system file", "error", err)
-		e.logLine(task.ID, "error", fmt.Sprintf("Failed to create system file: %s", err.Error()))
-		if cleanupHooks != nil {
-			cleanupHooks()
-		}
-		return execResult{Message: fmt.Sprintf("failed to create system file: %s", err.Error())}
-	}
-	systemFile.WriteString(e.buildSystemInstructions())
-	systemFile.Close()
-	defer os.Remove(systemFile.Name())
-
 	// Script that resumes claude with session ID (interactive mode)
 	// Environment variables passed:
 	// - WORKTREE_TASK_ID: Task identifier for hooks
@@ -2467,12 +2378,10 @@ func (e *Executor) runClaudeResume(ctx context.Context, task *db.Task, workDir, 
 	dangerousFlag := claudePermissionFlag(task)
 	// Build per-task effort override flag (empty = use Claude's global default)
 	effort := effortFlag(task.EffortLevel)
-	// Build system prompt flag - passes task guidance via system prompt to keep conversation clean
-	systemPromptFlag := fmt.Sprintf(`--append-system-prompt "$(cat %q)" `, systemFile.Name())
 
 	envPrefix := claudeEnvPrefix(paths.configDir)
-	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s--resume %s "$(cat %q)"`,
-		task.ID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, systemPromptFlag, claudeSessionID, feedbackFile.Name())
+	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s--resume %s "$(cat %q)"`,
+		task.ID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, effort, claudeSessionID, feedbackFile.Name())
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
 	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
@@ -4970,25 +4879,11 @@ func (e *Executor) runPi(ctx context.Context, task *db.Task, workDir, prompt str
 	promptFile.Close()
 	defer os.Remove(promptFile.Name())
 
-	// Create a temp file for system instructions (passed via --append-system-prompt)
-	systemFile, err := os.CreateTemp("", "task-system-*.txt")
-	if err != nil {
-		e.logger.Error("could not create system file", "error", err)
-		e.logLine(task.ID, "error", fmt.Sprintf("Failed to create system file: %s", err.Error()))
-		return execResult{Message: fmt.Sprintf("failed to create system file: %s", err.Error())}
-	}
-	systemFile.WriteString(e.buildSystemInstructions())
-	systemFile.Close()
-	defer os.Remove(systemFile.Name())
-
 	// Script that runs pi interactively with worktree environment variables
 	sessionID := os.Getenv("WORKTREE_SESSION_ID")
 	if sessionID == "" {
 		sessionID = fmt.Sprintf("%d", os.Getpid())
 	}
-
-	// Build system prompt flag
-	systemPromptFlag := fmt.Sprintf(`--append-system-prompt %q `, systemFile.Name())
 
 	// Determine explicit session path
 	sessionPath := e.getPiSessionPath(workDir, task.ID)
@@ -5009,12 +4904,12 @@ func (e *Executor) runPi(ctx context.Context, task *db.Task, workDir, prompt str
 	var script string
 	if piSessionExists(sessionPath) {
 		e.logLine(task.ID, "system", fmt.Sprintf("Resuming existing session %s", filepath.Base(sessionPath)))
-		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q %s--continue "$(cat %q)"`,
-			task.ID, sessionID, task.Port, task.WorktreePath, sessionPath, systemPromptFlag, promptFile.Name())
+		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q --continue "$(cat %q)"`,
+			task.ID, sessionID, task.Port, task.WorktreePath, sessionPath, promptFile.Name())
 	} else {
 		// Start fresh using the explicit session path
-		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q %s"$(cat %q)"`,
-			task.ID, sessionID, task.Port, task.WorktreePath, sessionPath, systemPromptFlag, promptFile.Name())
+		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q "$(cat %q)"`,
+			task.ID, sessionID, task.Port, task.WorktreePath, sessionPath, promptFile.Name())
 	}
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
@@ -5116,28 +5011,14 @@ func (e *Executor) runPiResume(ctx context.Context, task *db.Task, workDir, prom
 	feedbackFile.Close()
 	defer os.Remove(feedbackFile.Name())
 
-	// Create a temp file for system instructions
-	systemFile, err := os.CreateTemp("", "task-system-*.txt")
-	if err != nil {
-		e.logger.Error("could not create system file", "error", err)
-		e.logLine(task.ID, "error", fmt.Sprintf("Failed to create system file: %s", err.Error()))
-		return execResult{Message: fmt.Sprintf("failed to create system file: %s", err.Error())}
-	}
-	systemFile.WriteString(e.buildSystemInstructions())
-	systemFile.Close()
-	defer os.Remove(systemFile.Name())
-
 	// Script that resumes pi with session ID (interactive mode)
 	taskSessionID := os.Getenv("WORKTREE_SESSION_ID")
 	if taskSessionID == "" {
 		taskSessionID = fmt.Sprintf("%d", os.Getpid())
 	}
 
-	// Build system prompt flag
-	systemPromptFlag := fmt.Sprintf(`--append-system-prompt %q `, systemFile.Name())
-
-	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q %s--continue "$(cat %q)"`,
-		task.ID, taskSessionID, task.Port, task.WorktreePath, sessionPath, systemPromptFlag, feedbackFile.Name())
+	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q --continue "$(cat %q)"`,
+		task.ID, taskSessionID, task.Port, task.WorktreePath, sessionPath, feedbackFile.Name())
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
 	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1356,7 +1356,51 @@ func (e *Executor) buildPrompt(task *db.Task, attachmentPaths []string) string {
 		prompt.WriteString(e.buildGenericContextSection(projectInstructions, similarTasks, attachments, conversationHistory))
 	}
 
+	// Append universal guidance that applies to EVERY task type (including custom ones
+	// and the typeless/unknown fallback above): project-context caching, and — when the
+	// project uses worktrees — the worktree-safety constraint. This is injected here
+	// rather than baked into each task-type template because it depends on a runtime fact
+	// (does this project use worktrees?) a static template cannot express, and because the
+	// worktree guardrail must reach non-code tasks too (otherwise agents wander into the
+	// parent project directory).
+	if guidance := e.buildUniversalGuidance(task); guidance != "" {
+		prompt.WriteString("\n")
+		prompt.WriteString(guidance)
+		prompt.WriteString("\n")
+	}
+
 	return prompt.String()
+}
+
+// buildUniversalGuidance returns task-type-agnostic execution guidance appended to every
+// prompt. The project-context section is always included; the worktree-safety constraint
+// is included only when the task's project uses git worktrees (UseWorktrees defaults to on,
+// so the guardrail is shown unless a project has explicitly opted out).
+func (e *Executor) buildUniversalGuidance(task *db.Task) string {
+	var b strings.Builder
+
+	b.WriteString(`Project context:
+- Before exploring or starting work, call taskyou_get_project_context first via MCP. If it returns context, use it and skip exploration. If it is empty, explore once and save a summary via taskyou_set_project_context so future tasks in this project can reuse it.`)
+
+	if e.taskUsesWorktrees(task) {
+		b.WriteString(`
+
+Working directory constraint (isolated git worktree):
+- You are running in an isolated git worktree. This worktree IS your project - it is NOT a copy. NEVER access the original project directory or any path outside your current working directory.
+- ONLY use paths within your current working directory. Always use relative paths (e.g., "." or "./src") when searching or navigating - never absolute paths. The parent repo does not exist for you; only this worktree does.`)
+	}
+
+	return b.String()
+}
+
+// taskUsesWorktrees reports whether the task's project runs in git worktrees. It defaults
+// to true when the project cannot be loaded, matching the use_worktrees column default and
+// ensuring the worktree-safety guardrail is shown unless a project has explicitly opted out.
+func (e *Executor) taskUsesWorktrees(task *db.Task) bool {
+	if p, err := e.db.GetProjectByName(task.Project); err == nil && p != nil {
+		return p.UsesWorktrees()
+	}
+	return true
 }
 
 // applyTemplateSubstitutions replaces template placeholders in task type instructions.

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1933,21 +1933,3 @@ func TestCleanupWorktreeNonWorktreeTask(t *testing.T) {
 		t.Error("expected settings.local.json to be removed")
 	}
 }
-
-func TestBuildSystemInstructions_GitHubGuidance(t *testing.T) {
-	instructions := (&Executor{}).buildSystemInstructions()
-
-	// The GitHub guidance must steer agents away from the shared GraphQL bucket.
-	wants := []string{
-		"GITHUB CLI",
-		"PER-USER",
-		"gh pr checks",
-		"gh run watch",
-		"REST",
-	}
-	for _, want := range wants {
-		if !strings.Contains(instructions, want) {
-			t.Errorf("buildSystemInstructions() missing %q", want)
-		}
-	}
-}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1933,3 +1933,65 @@ func TestCleanupWorktreeNonWorktreeTask(t *testing.T) {
 		t.Error("expected settings.local.json to be removed")
 	}
 }
+
+// TestBuildPromptUniversalGuidance verifies that the worktree-safety constraint and the
+// project-context guidance reach EVERY task type (not just "code"), and that the worktree
+// guardrail is suppressed when the project opts out of worktrees. This guards the parity
+// fix for PR #559: folding the former executor-injected TASK GUIDANCE into only the "code"
+// task type would have silently dropped these for writing/thinking/custom/typeless tasks.
+func TestBuildPromptUniversalGuidance(t *testing.T) {
+	newExec := func(t *testing.T, useWorktrees bool) (*Executor, *db.Task) {
+		t.Helper()
+		tmpFile, err := os.CreateTemp("", "test-*.db")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+		tmpFile.Close()
+
+		database, err := db.Open(tmpFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { database.Close() })
+
+		if err := database.CreateProject(&db.Project{Name: "proj", Path: "/tmp/proj", UseWorktrees: useWorktrees}); err != nil {
+			t.Fatal(err)
+		}
+		exec := New(database, &config.Config{})
+		return exec, &db.Task{Title: "Do a thing", Body: "details", Project: "proj"}
+	}
+
+	// Every default task type, plus a typeless task, must carry the universal guidance.
+	for _, taskType := range []string{"code", "writing", "thinking", ""} {
+		t.Run("worktree project type="+taskType, func(t *testing.T) {
+			exec, task := newExec(t, true)
+			task.Type = taskType
+			if err := exec.db.CreateTask(task); err != nil {
+				t.Fatal(err)
+			}
+			prompt := exec.buildPrompt(task, nil)
+			if !strings.Contains(prompt, "taskyou_get_project_context") {
+				t.Errorf("type=%q: prompt missing project-context guidance", taskType)
+			}
+			if !strings.Contains(prompt, "isolated git worktree") {
+				t.Errorf("type=%q: prompt missing worktree-safety constraint", taskType)
+			}
+		})
+	}
+
+	t.Run("non-worktree project omits worktree constraint", func(t *testing.T) {
+		exec, task := newExec(t, false)
+		task.Type = "code"
+		if err := exec.db.CreateTask(task); err != nil {
+			t.Fatal(err)
+		}
+		prompt := exec.buildPrompt(task, nil)
+		if !strings.Contains(prompt, "taskyou_get_project_context") {
+			t.Error("project-context guidance should still be present without worktrees")
+		}
+		if strings.Contains(prompt, "isolated git worktree") {
+			t.Error("worktree constraint should be omitted when project does not use worktrees")
+		}
+	})
+}

--- a/internal/executor/gemini_executor.go
+++ b/internal/executor/gemini_executor.go
@@ -66,12 +66,6 @@ func (g *GeminiExecutor) runGemini(ctx context.Context, task *db.Task, workDir, 
 		return ExecResult{Message: "tmux is not installed"}
 	}
 
-	// Write system instructions to .gemini/GEMINI.md in the worktree
-	// This keeps task guidance out of the user conversation thread
-	if err := g.writeGeminiInstructions(workDir); err != nil {
-		g.logger.Warn("could not write GEMINI.md", "error", err)
-	}
-
 	daemonSession, err := ensureTmuxDaemon()
 	if err != nil {
 		g.logger.Error("could not create task-daemon session", "error", err)
@@ -276,14 +270,6 @@ func (g *GeminiExecutor) ResumeProcess(taskID int64) bool {
 
 // BuildCommand returns the shell command to start an interactive Gemini session.
 func (g *GeminiExecutor) BuildCommand(task *db.Task, sessionID, prompt string) string {
-	// Write system instructions to .gemini/GEMINI.md in the worktree
-	// This keeps task guidance out of the user conversation thread
-	if task.WorktreePath != "" {
-		if err := g.writeGeminiInstructions(task.WorktreePath); err != nil {
-			g.logger.Warn("BuildCommand: could not write GEMINI.md", "error", err)
-		}
-	}
-
 	dangerousFlag := buildGeminiDangerousFlag(task.DangerousMode)
 
 	worktreeSessionID := os.Getenv("WORKTREE_SESSION_ID")
@@ -445,23 +431,4 @@ func geminiSessionExists(sessionID string) bool {
 	})
 
 	return found
-}
-
-// writeGeminiInstructions writes task guidance to .gemini/GEMINI.md in the worktree.
-// Gemini CLI automatically loads this file and uses it as project-specific instructions,
-// keeping the guidance out of the user conversation thread.
-func (g *GeminiExecutor) writeGeminiInstructions(workDir string) error {
-	geminiDir := filepath.Join(workDir, ".gemini")
-	if err := os.MkdirAll(geminiDir, 0755); err != nil {
-		return fmt.Errorf("failed to create .gemini directory: %w", err)
-	}
-
-	geminiMdPath := filepath.Join(geminiDir, "GEMINI.md")
-	instructions := g.executor.buildSystemInstructions()
-
-	if err := os.WriteFile(geminiMdPath, []byte(instructions), 0644); err != nil {
-		return fmt.Errorf("failed to write GEMINI.md: %w", err)
-	}
-
-	return nil
 }

--- a/internal/executor/openclaw_executor.go
+++ b/internal/executor/openclaw_executor.go
@@ -107,10 +107,6 @@ func (o *OpenClawExecutor) runOpenClaw(ctx context.Context, task *db.Task, workD
 		fullPrompt.WriteString("\n\n## User Feedback\n\n")
 		fullPrompt.WriteString(feedback)
 	}
-	// Append system instructions - OpenClaw doesn't have a system prompt option
-	// so we include task guidance at the end of the prompt
-	fullPrompt.WriteString("\n\n")
-	fullPrompt.WriteString(o.executor.buildSystemInstructions())
 	promptFile.WriteString(fullPrompt.String())
 	promptFile.Close()
 	defer os.Remove(promptFile.Name())
@@ -325,9 +321,7 @@ func (o *OpenClawExecutor) BuildCommand(task *db.Task, sessionID, prompt string)
 			return fmt.Sprintf(`%s openclaw tui --session %s %s`,
 				envVars, sessionKey, thinkingFlag)
 		}
-		// Include system instructions at the end of prompt since OpenClaw doesn't have a system prompt option
-		fullPrompt := prompt + "\n\n" + o.executor.buildSystemInstructions()
-		promptFile.WriteString(fullPrompt)
+		promptFile.WriteString(prompt)
 		promptFile.Close()
 		return fmt.Sprintf(`%s openclaw tui --session %s %s--message "$(cat %q)"; rm -f %q`,
 			envVars, sessionKey, thinkingFlag, promptFile.Name(), promptFile.Name())

--- a/internal/executor/pi_executor.go
+++ b/internal/executor/pi_executor.go
@@ -79,15 +79,6 @@ func (p *PiExecutor) BuildCommand(task *db.Task, sessionID, prompt string) strin
 		worktreeSessionID = fmt.Sprintf("%d", os.Getpid())
 	}
 
-	// Build system prompt flag
-	systemPromptFlag := ""
-	systemFile, err := os.CreateTemp("", "task-system-*.txt")
-	if err == nil {
-		systemFile.WriteString(p.executor.buildSystemInstructions())
-		systemFile.Close()
-		systemPromptFlag = fmt.Sprintf(`--append-system-prompt %q `, systemFile.Name())
-	}
-
 	// Determine explicit session path if not provided or if sessionID matches it
 	// If sessionID is provided (from task.ClaudeSessionID), use it as the path.
 	// If not, calculate it.
@@ -102,12 +93,8 @@ func (p *PiExecutor) BuildCommand(task *db.Task, sessionID, prompt string) strin
 
 	// Build command - resume if we have a session ID, otherwise start fresh
 	if sessionID != "" {
-		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q %s--continue`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, sessionPath, systemPromptFlag)
-		if systemFile != nil {
-			cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
-		}
-		return cmd
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q --continue`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, sessionPath)
 	}
 
 	// Start fresh - if prompt is provided, write to temp file and pass it
@@ -116,30 +103,18 @@ func (p *PiExecutor) BuildCommand(task *db.Task, sessionID, prompt string) strin
 		promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
 		if err != nil {
 			p.logger.Error("BuildCommand: failed to create temp file", "error", err)
-			cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q %s`,
-				task.ID, worktreeSessionID, task.Port, task.WorktreePath, sessionPath, systemPromptFlag)
-			if systemFile != nil {
-				cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
-			}
-			return cmd
+			return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q`,
+				task.ID, worktreeSessionID, task.Port, task.WorktreePath, sessionPath)
 		}
 		promptFile.WriteString(prompt)
 		promptFile.Close()
 
-		cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q %s"$(cat %q)"; rm -f %q`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, sessionPath, systemPromptFlag, promptFile.Name(), promptFile.Name())
-		if systemFile != nil {
-			cmd += fmt.Sprintf(` %q`, systemFile.Name())
-		}
-		return cmd
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q "$(cat %q)"; rm -f %q`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, sessionPath, promptFile.Name(), promptFile.Name())
 	}
 
-	cmd := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q %s`,
-		task.ID, worktreeSessionID, task.Port, task.WorktreePath, sessionPath, systemPromptFlag)
-	if systemFile != nil {
-		cmd += fmt.Sprintf(`; rm -f %q`, systemFile.Name())
-	}
-	return cmd
+	return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q pi --session %q`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath, sessionPath)
 }
 
 // ---- Session and Dangerous Mode Support ----


### PR DESCRIPTION
# Remove hardcoded TASK GUIDANCE; default 'code' task type owns it instead

## What

Removes the hardcoded `buildSystemInstructions()` "TASK GUIDANCE" block from the
executors and folds its content into the default **`code` task type's
`instructions`** instead.

Concretely:

- **Deletes `buildSystemInstructions()`** and every callsite that consumed it. That
  block was injected into each task launch through several channels:
  - Claude (`claude_executor.go` + the interactive launch paths in `executor.go`):
    a `--append-system-prompt "$(cat <tmpfile>)"` flag.
  - Gemini (`gemini_executor.go`): written to `.gemini/GEMINI.md` via
    `writeGeminiInstructions()` (also removed).
  - pi / codex / openclaw: appended to the prompt text.
  All of these are now gone, along with the dead temp-file creation and the
  per-launch flag. Each `fmt.Sprintf` that built a launch command was rebalanced so
  its verb count matches its argument count (the `go vet` printf analyzer stays
  clean).

- **Moves the guidance into the default `code` task type's seeded `instructions`**
  in `internal/db/sqlite.go`, matching the plain-text style already used by the
  `writing` and `thinking` defaults (and the existing `code` default). The content
  preserved: the `taskyou_get_project_context` MCP caching nudge, the worktree
  working-directory constraint, the `taskyou_screenshot` hint for frontend work, and
  the GitHub-CLI / shared-GraphQL-bucket etiquette.

- **Adds a content-match-guarded migration** for existing installs
  (`migrateCodeTaskTypeGuidance`): it runs
  `UPDATE task_types SET instructions = <new> WHERE name = 'code' AND instructions = <old>`,
  where `<old>` is the byte-exact previous default. It only upgrades a row that still
  holds the old default, so any user-customized `code` row is left untouched. It is
  idempotent — on the new schema the `WHERE` clause matches nothing.

## Why

The TASK GUIDANCE block was opinionated, Claude-specific
(`taskyou_get_project_context`, worktree warnings, `gh` rate-limit etiquette), and
**not user-controllable** — there was no way to customize or opt out of it. It read
as a vestige of a single-team / single-workflow setup.

This change **completes a direction already established in the codebase.** In
commit `cb7a3e1f` ("Add PR submission reminder to coding task system prompt", branch
`task/142-coding-tasks-system-prompt`, merged via #65), the PR-submission reminder
for coding tasks was added to the **`code` task type's instructions** — the
user-prompt path — rather than to the executor's hardcoded block. That set the
precedent that coding guidance belongs in the task type, where users can see and
edit it. This PR follows that same path for the remaining executor-injected
guidance, consolidating all of it into the one place Bruno already chose.

Result:

- Default-config users get the same guidance, just delivered through the task type.
- Users (and custom task types) can now customize or disable that guidance via the
  existing task-type editing UI — exactly how the `writing` and `thinking` types are
  configured today.
- One fewer hardcoded Claude-ism in the executor; the guidance is no longer special
  cased per executor backend.

### Note on delivery channel

The task-type `instructions` are delivered via the **initial user prompt**, whereas
the removed block was delivered via `--append-system-prompt` (Claude) /
`GEMINI.md` (Gemini). This is a slight delivery shift. For the default `code` type
the net effect on agent behaviour is **indistinguishable** — the agent receives the
same text either way. For users who care about the distinction, they now have full
control over the content through the task type, on whichever delivery channel the
backend uses for instructions.

## How tested

- `go build ./...` — clean.
- `go vet ./...` — clean (the printf analyzer confirms every rebalanced launch
  `Sprintf` has matching verb/arg counts).
- `go test ./...` — all packages pass.
- New `internal/db` tests:
  - `TestDefaultCodeTaskTypeGuidance` — a freshly migrated DB seeds the `code` task
    type with the GitHub-CLI etiquette and the `taskyou_get_project_context` nudge.
  - `TestMigrateCodeTaskTypeGuidance` — a row holding the old default is upgraded;
    a customized row is left untouched (non-clobbering / idempotent).
- Removed the obsolete `TestBuildSystemInstructions_GitHubGuidance` (the function it
  asserted no longer exists); its intent is now covered by the db tests above.

## Follow-up (separate PR)

A natural next step is to let users drop the default task-type guidance entirely
(remove the seeded `instructions` content for `code`/`writing`/`thinking`). That is
a larger behavioural change deserving its own migration and deprecation path, so it
is intentionally **not** bundled here.
