### PR TITLE
Add shift+arrow support to list view

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -776,6 +776,13 @@ func (m *AppModel) updateListNav(msg tea.KeyMsg) (bool, tea.Cmd) {
 	case key.Matches(msg, m.keys.Right):
 		m.listView.NextSortColumn()
 		return true, nil
+	// shift+↑/↓ jump to the pinned/unpinned boundary, matching the kanban board.
+	case key.Matches(msg, m.keys.JumpToPinned):
+		m.listView.JumpToPinned()
+		return true, nil
+	case key.Matches(msg, m.keys.JumpToUnpinned):
+		m.listView.JumpToUnpinned()
+		return true, nil
 	}
 
 	switch msg.String() {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1231,6 +1231,42 @@ func TestQueueDangerous_KanbanView(t *testing.T) {
 	}
 }
 
+func TestShiftArrowKeysRouteToListView(t *testing.T) {
+	pinned := &db.Task{ID: 1, Title: "Pinned", Status: db.StatusBacklog, Project: "personal", Pinned: true}
+	a := &db.Task{ID: 2, Title: "Alpha", Status: db.StatusBacklog, Project: "personal"}
+	b := &db.Task{ID: 3, Title: "Bravo", Status: db.StatusBacklog, Project: "personal"}
+	tasks := []*db.Task{pinned, a, b}
+
+	kanban := NewKanbanBoard(80, 24)
+	kanban.SetTasks(tasks)
+	listView := NewListView(80, 24)
+	listView.SetTasks(tasks)
+
+	m := &AppModel{
+		keys:        DefaultKeyMap(),
+		currentView: ViewDashboard,
+		viewMode:    ViewModeList,
+		tasks:       tasks,
+		kanban:      kanban,
+		listView:    listView,
+	}
+
+	// shift+down jumps to the first unpinned row (index 1, just past the pin).
+	m.updateDashboard(tea.KeyMsg{Type: tea.KeyShiftDown})
+	if got := listView.selectedRow; got != 1 {
+		t.Fatalf("shift+down: list selectedRow = %d, want 1", got)
+	}
+
+	// shift+up jumps back to the pinned prefix at the top.
+	m.updateDashboard(tea.KeyMsg{Type: tea.KeyShiftUp})
+	if got := listView.selectedRow; got != 0 {
+		t.Fatalf("shift+up: list selectedRow = %d, want 0", got)
+	}
+	if sel := m.dashboardSelectedTask(); sel == nil || sel.ID != 1 {
+		t.Fatalf("shift+up: selected task = %v, want pinned task 1", sel)
+	}
+}
+
 func TestQueueDangerous_SkipsProcessingTask(t *testing.T) {
 	database, err := db.Open(":memory:")
 	if err != nil {

--- a/internal/ui/list_view.go
+++ b/internal/ui/list_view.go
@@ -356,6 +356,32 @@ func (l *ListView) MoveDown() {
 	l.ensureSelectedVisible()
 }
 
+// JumpToPinned moves the selection to the first pinned task. Pinned tasks always
+// float to the top of the list, so this jumps to the top row. Mirrors the
+// kanban board's shift+↑ behaviour. No-op when the list is empty.
+func (l *ListView) JumpToPinned() {
+	if len(l.rows) == 0 {
+		return
+	}
+	l.selectedRow = 0
+	l.ensureSelectedVisible()
+}
+
+// JumpToUnpinned moves the selection to the first unpinned task — the row just
+// past the pinned prefix. Mirrors the kanban board's shift+↓ behaviour. Stays
+// put when the list is empty or every task is pinned.
+func (l *ListView) JumpToUnpinned() {
+	if len(l.rows) == 0 {
+		return
+	}
+	pinned, unpinned := splitPinnedTasks(l.rows)
+	if len(unpinned) == 0 {
+		return
+	}
+	l.selectedRow = len(pinned)
+	l.ensureSelectedVisible()
+}
+
 // NextSortColumn advances to the next sortable column (←/→), resetting the
 // direction to that column's natural default.
 func (l *ListView) NextSortColumn() {

--- a/internal/ui/list_view_test.go
+++ b/internal/ui/list_view_test.go
@@ -155,6 +155,96 @@ func TestListViewNavigationWraps(t *testing.T) {
 	}
 }
 
+func TestListViewJumpToPinned(t *testing.T) {
+	l := NewListView(120, 30)
+	tasks := makeListTasks()
+	tasks[1].Pinned = true // Bravo (ID 2) pinned -> floats to top
+	l.SetTasks(tasks)
+
+	// Move selection away from the top, then jump back to the pinned prefix.
+	l.selectedRow = 2
+	l.JumpToPinned()
+	if l.selectedRow != 0 {
+		t.Fatalf("JumpToPinned: selectedRow = %d, want 0", l.selectedRow)
+	}
+	if sel := l.SelectedTask(); sel == nil || sel.ID != 2 {
+		t.Fatalf("JumpToPinned: selected task = %v, want pinned task 2", sel)
+	}
+}
+
+func TestListViewJumpToPinnedNoPinnedTasks(t *testing.T) {
+	l := NewListView(120, 30)
+	l.SetTasks(makeListTasks())
+	l.selectedRow = 3
+	// With no pinned tasks, jumping to pinned still lands on the top row.
+	l.JumpToPinned()
+	if l.selectedRow != 0 {
+		t.Fatalf("JumpToPinned with no pinned tasks: selectedRow = %d, want 0", l.selectedRow)
+	}
+}
+
+func TestListViewJumpToPinnedEmpty(t *testing.T) {
+	l := NewListView(120, 30)
+	l.SetTasks(nil)
+	l.JumpToPinned() // must not panic
+	if l.selectedRow != 0 {
+		t.Fatalf("JumpToPinned on empty list: selectedRow = %d, want 0", l.selectedRow)
+	}
+}
+
+func TestListViewJumpToUnpinned(t *testing.T) {
+	l := NewListView(120, 30)
+	tasks := makeListTasks()
+	tasks[0].Pinned = true // Alpha (ID 1)
+	tasks[1].Pinned = true // Bravo (ID 2)
+	l.SetTasks(tasks)
+
+	// Two pinned tasks float to the top, so the first unpinned row is index 2.
+	l.selectedRow = 0
+	l.JumpToUnpinned()
+	if l.selectedRow != 2 {
+		t.Fatalf("JumpToUnpinned: selectedRow = %d, want 2", l.selectedRow)
+	}
+	if sel := l.SelectedTask(); sel == nil || sel.Pinned {
+		t.Fatalf("JumpToUnpinned: selected task = %v, want first unpinned task", sel)
+	}
+}
+
+func TestListViewJumpToUnpinnedAllPinned(t *testing.T) {
+	l := NewListView(120, 30)
+	tasks := makeListTasks()
+	for _, task := range tasks {
+		task.Pinned = true
+	}
+	l.SetTasks(tasks)
+	l.selectedRow = 1
+	// No unpinned tasks: selection stays put.
+	l.JumpToUnpinned()
+	if l.selectedRow != 1 {
+		t.Fatalf("JumpToUnpinned with all pinned: selectedRow = %d, want 1", l.selectedRow)
+	}
+}
+
+func TestListViewJumpToUnpinnedNoPinnedTasks(t *testing.T) {
+	l := NewListView(120, 30)
+	l.SetTasks(makeListTasks())
+	l.selectedRow = 3
+	// First row is already unpinned, so jump lands on row 0.
+	l.JumpToUnpinned()
+	if l.selectedRow != 0 {
+		t.Fatalf("JumpToUnpinned with no pinned tasks: selectedRow = %d, want 0", l.selectedRow)
+	}
+}
+
+func TestListViewJumpToUnpinnedEmpty(t *testing.T) {
+	l := NewListView(120, 30)
+	l.SetTasks(nil)
+	l.JumpToUnpinned() // must not panic
+	if l.selectedRow != 0 {
+		t.Fatalf("JumpToUnpinned on empty list: selectedRow = %d, want 0", l.selectedRow)
+	}
+}
+
 func TestListViewRendersWithoutPanic(t *testing.T) {
 	for _, w := range []int{40, 80, 120, 200} {
 		l := NewListView(w, 24)


### PR DESCRIPTION
## Summary

The list view now supports the same `shift+↑` / `shift+↓` shortcuts the kanban board already has:

- **`shift+↑`** — jump to the first pinned task (top of the list)
- **`shift+↓`** — jump to the first unpinned task (the row just past the pinned prefix)

Previously, while the list view was active these keys fell through to the *hidden* kanban board's `JumpToPinned`/`JumpToUnpinned` handlers, so they did nothing visible. `updateListNav` now intercepts them and applies them to the list selection before the board handlers run.

## Changes

- `internal/ui/list_view.go` — added `JumpToPinned()` and `JumpToUnpinned()` methods to `ListView`, mirroring the board's semantics. Since list rows are already sorted pinned-first, they reuse the existing `splitPinnedTasks` helper.
- `internal/ui/app.go` — `updateListNav` now routes `shift+↑`/`shift+↓` (the configurable `JumpToPinned`/`JumpToUnpinned` bindings) to the list view.
- `internal/ui/list_view_test.go` — unit tests for the new methods (pinned present / none / all-pinned / empty list).
- `internal/ui/app_test.go` — integration test verifying the keys route to the list view (not the hidden board) when in list mode.

The shift+arrow help entries already live in the shared global keymap's `FullHelp`, so they surface under `?` in both views without further changes.

## Testing

- `go build ./...` ✅
- `go vet ./internal/ui/` ✅
- `go test ./internal/ui/` ✅ (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)