### PR TITLE
List view: Active filter, decluttered header, and a live executor pane

### DIFF
--- a/docs/superpowers/plans/2026-06-07-list-view-executor-pane.md
+++ b/docs/superpowers/plans/2026-06-07-list-view-executor-pane.md
@@ -1,0 +1,1021 @@
+# List view live executor pane — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the dashboard list view, show the selected task's live, interactive executor tmux pane on the right; navigating the list swaps it (debounced), it's drag-resizable with a persisted width, and it's always broken back to the daemon (never killed) when you leave.
+
+**Architecture:** The `ty` TUI already runs inside a tmux UI session; the executor for each task runs in a window of the daemon session. A new `listExecutorPane` controller (in `internal/ui/executor_pane.go`) joins the selected task's executor pane to the right of the Bubble Tea TUI pane and breaks it back on teardown — reusing the detail view's process-preserving window logic. `AppModel` drives it: a pure `decidePreviewAction` function decides noop/collapse/swap; selection navigation triggers a **debounced, serialized, async** swap; explicit transitions (Enter→detail, `v`→board, `p` hide, quit) do a **synchronous** break-back so the executor is back in the daemon before anything else touches the UI session. Bubble Tea does NOT render the executor — tmux owns that pane; the list simply re-renders at the narrower width tmux gives it.
+
+**Tech Stack:** Go, Bubble Tea (charmbracelet), tmux CLI, SQLite settings, the repo's `scripts/qa/` TUI harness + VHS for screenshots.
+
+---
+
+## Key facts (verified against current code)
+
+- TUI runs in tmux session `task-ui-<sid>`, pane `:.0`; mouse is on (`tea.WithMouseCellMotion()` in `cmd/task/main.go:3594`) so pane borders are drag-resizable.
+- Executor windows live in `task-daemon-<sid>`, window name `executor.TmuxWindowName(taskID)` (= `task_<id>`); target via `executor.TmuxSessionName(taskID)`.
+- Detail view's `joinTmuxPanes()` (`internal/ui/detail.go:1280`) **kills every non-TUI pane in the UI session** on entry → the preview pane MUST be broken back before opening detail.
+- Detail view persists drag-resizes by capturing an initial pane size, comparing current vs initial (>2% = user drag), and saving a `%` setting (`internal/config/config.go`: `SettingShellPaneWidth`). We mirror this with a new `SettingListExecutorPaneWidth`.
+- Process-preserving break-back pattern lives in `breakTmuxPanes()` (`detail.go:1860`) using `findOrCreateTaskWindow()` (`detail.go:1770`) + `killPaneWithProcess()` (`detail.go:2171`). On join-pane failure it falls back to `break-pane` to a new window rather than killing the executor.
+- There is **no** `IsExecutorSessionRunning`; the reliable "does this task have a live executor pane" predicate is "a `task_<id>` window exists in a daemon session" — i.e. `findTaskWindow()` (`detail.go:772`) returning non-empty.
+
+---
+
+## File structure
+
+- **Create** `internal/ui/executor_pane.go` — package-level tmux helpers shared with detail (`findTaskWindowTarget`, `killTmuxPaneWithProcess`, `findOrCreateDaemonWindow`), the `listExecutorPane` controller (`join`/`breakBack`/width helpers), the pure `decidePreviewAction`, the `validatePanePct` helper, and the msg/result types.
+- **Create** `internal/ui/executor_pane_test.go` — unit tests for `decidePreviewAction` and `validatePanePct`.
+- **Modify** `internal/config/config.go` — add `SettingListExecutorPaneWidth`.
+- **Modify** `internal/ui/app.go` — preview state on `AppModel`; arm-on-navigation (debounce); `listPreviewTickMsg` / `listPreviewUpdatedMsg` handlers; `p` toggle; synchronous break-back on Enter/`v`/quit; arm-on-enter-list.
+- **Modify** `internal/ui/debug.go` — expose preview state (`preview_visible`, `preview_joined_task_id`) for QA assertions.
+- **Modify** `internal/ui/list_view.go` — show a small "· pane hidden" affordance in the summary when `p` has hidden the preview (so the toggle is discoverable). Selection accessor `SelectedTask()` already exists.
+
+> **Scope decision (deviation from spec):** to avoid destabilizing the detail view's battle-tested pane code in the same change, this plan **adds** the shared helpers as new package functions and has the list controller use them, but does **not** refactor `detail.go` to call them (beyond nothing required). Deduping detail.go onto these helpers is a follow-up once the list pane is proven. Noted here intentionally.
+
+---
+
+## Task 1: Config setting for the persisted width
+
+**Files:**
+- Modify: `internal/config/config.go` (the `Setting*` const block near line 21)
+
+- [ ] **Step 1: Add the setting constant**
+
+In the existing `const ( ... )` settings block, after `SettingShellPaneWidth`:
+
+```go
+	SettingListExecutorPaneWidth = "list_executor_pane_width"
+```
+
+- [ ] **Step 2: Build**
+
+Run: `go build ./...`
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/config/config.go
+git commit -m "config: add list_executor_pane_width setting"
+```
+
+---
+
+## Task 2: Pure decision function + width validator (TDD)
+
+**Files:**
+- Create: `internal/ui/executor_pane.go`
+- Create: `internal/ui/executor_pane_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+`internal/ui/executor_pane_test.go`:
+
+```go
+package ui
+
+import "testing"
+
+func TestDecidePreviewAction(t *testing.T) {
+	cases := []struct {
+		name        string
+		selectedID  int64
+		selHasExec  bool
+		joinedID    int64
+		visible     bool
+		want        previewAction
+	}{
+		{"hidden, nothing joined", 5, true, 0, false, previewNoop},
+		{"hidden, something joined", 5, true, 5, false, previewCollapse},
+		{"visible, no selection", 0, false, 0, true, previewNoop},
+		{"visible, selected has no executor, none joined", 7, false, 0, true, previewNoop},
+		{"visible, selected has no executor, stale joined", 7, false, 9, true, previewCollapse},
+		{"visible, selected has executor, none joined", 5, true, 0, true, previewSwap},
+		{"visible, selected has executor, different joined", 5, true, 9, true, previewSwap},
+		{"visible, selected has executor, already joined", 5, true, 5, true, previewNoop},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := decidePreviewAction(c.selectedID, c.selHasExec, c.joinedID, c.visible)
+			if got != c.want {
+				t.Fatalf("decidePreviewAction(%d,%v,%d,%v) = %v, want %v",
+					c.selectedID, c.selHasExec, c.joinedID, c.visible, got, c.want)
+			}
+		})
+	}
+}
+
+func TestValidatePanePct(t *testing.T) {
+	cases := []struct{ in, def, want string }{
+		{"", "45%", "45%"},
+		{"garbage", "45%", "45%"},
+		{"45", "45%", "45%"},   // missing %
+		{"5%", "45%", "45%"},   // below min
+		{"95%", "45%", "45%"},  // above max
+		{"30%", "45%", "30%"},  // valid
+		{"90%", "45%", "90%"},  // valid edge
+	}
+	for _, c := range cases {
+		if got := validatePanePct(c.in, c.def); got != c.want {
+			t.Fatalf("validatePanePct(%q,%q) = %q, want %q", c.in, c.def, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/ui/ -run 'TestDecidePreviewAction|TestValidatePanePct' -v`
+Expected: FAIL (undefined: previewAction, decidePreviewAction, validatePanePct).
+
+- [ ] **Step 3: Implement the pure pieces**
+
+Create `internal/ui/executor_pane.go` with the imports and the pure functions:
+
+```go
+package ui
+
+import (
+	"context"
+	"os"
+	osExec "os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/executor"
+)
+
+// previewAction is what the list-view executor preview should do for the
+// current selection. Decided purely (no I/O) by decidePreviewAction.
+type previewAction int
+
+const (
+	previewNoop previewAction = iota
+	previewCollapse
+	previewSwap
+)
+
+// decidePreviewAction decides the preview pane action from the current state.
+//   selectedID:  task selected in the list (0 if none)
+//   selHasExec:  whether the selected task has a live executor window to show
+//   joinedID:    task whose executor pane is currently joined (0 if none)
+//   visible:     whether the preview is enabled (toggled with `p`)
+func decidePreviewAction(selectedID int64, selHasExec bool, joinedID int64, visible bool) previewAction {
+	if !visible || selectedID == 0 || !selHasExec {
+		if joinedID != 0 {
+			return previewCollapse
+		}
+		return previewNoop
+	}
+	if joinedID == selectedID {
+		return previewNoop
+	}
+	return previewSwap
+}
+
+// validatePanePct returns v if it is a "NN%" string within [10,90], else def.
+func validatePanePct(v, def string) string {
+	if strings.HasSuffix(v, "%") {
+		if p, err := strconv.Atoi(strings.TrimSuffix(v, "%")); err == nil && p >= 10 && p <= 90 {
+			return v
+		}
+	}
+	return def
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/ui/ -run 'TestDecidePreviewAction|TestValidatePanePct' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ui/executor_pane.go internal/ui/executor_pane_test.go
+git commit -m "list view: pure decision + width validator for executor preview"
+```
+
+---
+
+## Task 3: Shared tmux helpers (find window target, kill pane, find/create daemon window)
+
+**Files:**
+- Modify: `internal/ui/executor_pane.go`
+
+These mirror detail.go's `findTaskWindow`, `killPaneWithProcess`, and `findOrCreateTaskWindow` but as package functions taking explicit params (no DetailModel). Not unit-tested (pure tmux I/O); exercised by QA in Task 8.
+
+- [ ] **Step 1: Add the helpers**
+
+Append to `internal/ui/executor_pane.go`:
+
+```go
+// findTaskWindowTarget returns the "session:windowID" of the daemon window
+// running task taskID's executor, or "" if none exists. Updates the stored
+// window ID in the DB when found.
+func findTaskWindowTarget(ctx context.Context, database *db.DB, task *db.Task) string {
+	if task == nil {
+		return ""
+	}
+	windowName := executor.TmuxWindowName(task.ID)
+	out, err := osExec.CommandContext(ctx, "tmux", "list-windows", "-a",
+		"-F", "#{session_name}:#{window_id}:#{window_name}").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		sessionName, windowID, name := parts[0], parts[1], parts[2]
+		if !strings.HasPrefix(sessionName, "task-daemon-") {
+			continue
+		}
+		if name == windowName {
+			if database != nil && windowID != "" {
+				database.UpdateTaskWindowID(task.ID, windowID)
+				task.TmuxWindowID = windowID
+			}
+			return sessionName + ":" + windowID
+		}
+	}
+	return ""
+}
+
+// killTmuxPaneWithProcess kills a pane and the process inside it (SIGKILL,
+// since Claude ignores SIGTERM). Shared shape with detail.go's method.
+func killTmuxPaneWithProcess(ctx context.Context, paneID string) {
+	if paneID == "" {
+		return
+	}
+	if pidOut, err := osExec.CommandContext(ctx, "tmux", "display-message", "-t", paneID, "-p", "#{pane_pid}").Output(); err == nil {
+		if pid := strings.TrimSpace(string(pidOut)); pid != "" {
+			osExec.CommandContext(ctx, "kill", "-9", pid).Run()
+		}
+	}
+	osExec.CommandContext(ctx, "tmux", "kill-pane", "-t", paneID).Run()
+}
+
+// findOrCreateDaemonWindow returns the window ID for task's executor in
+// daemonSession, creating a placeholder window if none exists. Mirrors
+// detail.go's findOrCreateTaskWindow.
+func findOrCreateDaemonWindow(ctx context.Context, database *db.DB, task *db.Task, daemonSession, workdir string) string {
+	windowName := executor.TmuxWindowName(task.ID)
+	// Priority 1: stored window ID if still valid.
+	if task.TmuxWindowID != "" {
+		out, err := osExec.CommandContext(ctx, "tmux", "display-message", "-t", task.TmuxWindowID, "-p", "#{window_id}").Output()
+		if err == nil && strings.TrimSpace(string(out)) == task.TmuxWindowID {
+			return task.TmuxWindowID
+		}
+		if database != nil {
+			database.UpdateTaskWindowID(task.ID, "")
+		}
+	}
+	// Priority 2: search by name.
+	if out, err := osExec.CommandContext(ctx, "tmux", "list-windows", "-t", daemonSession, "-F", "#{window_id}:#{window_name}").Output(); err == nil {
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 && parts[1] == windowName {
+				if database != nil {
+					database.UpdateTaskWindowID(task.ID, parts[0])
+				}
+				return parts[0]
+			}
+		}
+	}
+	// Priority 3: create placeholder.
+	if err := osExec.CommandContext(ctx, "tmux", "new-window", "-d", "-t", daemonSession+":", "-n", windowName, "-c", workdir, "tail", "-f", "/dev/null").Run(); err != nil {
+		return ""
+	}
+	if out, err := osExec.CommandContext(ctx, "tmux", "list-windows", "-t", daemonSession, "-F", "#{window_id}:#{window_name}").Output(); err == nil {
+		var id string
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 && parts[1] == windowName {
+				id = parts[0]
+			}
+		}
+		if id != "" {
+			if database != nil {
+				database.UpdateTaskWindowID(task.ID, id)
+			}
+			return id
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `go build ./...`
+Expected: clean (functions are unused for now — Go allows unused package-level funcs).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/ui/executor_pane.go
+git commit -m "list view: shared tmux helpers for executor preview"
+```
+
+---
+
+## Task 4: The `listExecutorPane` controller (join right / break back / width persistence)
+
+**Files:**
+- Modify: `internal/ui/executor_pane.go`
+
+- [ ] **Step 1: Add the controller and its state/result types**
+
+Append to `internal/ui/executor_pane.go`:
+
+```go
+// joinedState is the volatile state of the currently-joined preview pane.
+// Owned by AppModel; passed into controller ops and returned back so the tea
+// goroutine never mutates AppModel directly.
+type joinedState struct {
+	taskID        int64
+	paneID        string
+	daemonSession string
+	initialWidth  int // executor pane width % captured right after join
+}
+
+// previewResult is returned from controller ops and applied in AppModel.Update.
+type previewResult struct {
+	gen   int // generation that requested this op (for staleness checks)
+	state joinedState
+	err   error
+}
+
+// listExecutorPane joins/breaks a single task's executor pane to the right of
+// the TUI pane in the UI session. Identity/config only; volatile joined state
+// is threaded through method args/returns.
+type listExecutorPane struct {
+	database      *db.DB
+	uiSessionName string
+	tuiPaneID     string
+}
+
+func newListExecutorPane(database *db.DB) *listExecutorPane {
+	return &listExecutorPane{database: database}
+}
+
+// ensureIdentity caches the UI session name and TUI pane id. Call from the
+// main loop (not a goroutine); the active pane is the TUI pane because we
+// always select-pane back to it after every op.
+func (p *listExecutorPane) ensureIdentity() bool {
+	if os.Getenv("TMUX") == "" {
+		return false
+	}
+	if p.uiSessionName == "" {
+		if out, err := osExec.Command("tmux", "display-message", "-p", "#{session_name}").Output(); err == nil {
+			p.uiSessionName = strings.TrimSpace(string(out))
+		}
+	}
+	if p.tuiPaneID == "" {
+		if out, err := osExec.Command("tmux", "display-message", "-p", "#{pane_id}").Output(); err == nil {
+			p.tuiPaneID = strings.TrimSpace(string(out))
+		}
+	}
+	return p.uiSessionName != "" && p.tuiPaneID != ""
+}
+
+func (p *listExecutorPane) widthPref() string {
+	def := "45%"
+	if p.database == nil {
+		return def
+	}
+	v, err := p.database.GetSetting(config.SettingListExecutorPaneWidth)
+	if err != nil || v == "" {
+		return def
+	}
+	return validatePanePct(v, def)
+}
+
+// currentWidthPct returns the joined executor pane's current width as a % of
+// (executor + tui) widths, or 0 on error.
+func (p *listExecutorPane) currentWidthPct(execPaneID string) int {
+	if execPaneID == "" || p.tuiPaneID == "" {
+		return 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ew := tmuxPaneWidth(ctx, execPaneID)
+	tw := tmuxPaneWidth(ctx, p.tuiPaneID)
+	if ew <= 0 || tw <= 0 {
+		return 0
+	}
+	return (ew*100 + (ew+tw)/2) / (ew + tw)
+}
+
+func tmuxPaneWidth(ctx context.Context, paneID string) int {
+	out, err := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "-t", paneID, "#{pane_width}").Output()
+	if err != nil {
+		return 0
+	}
+	w, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0
+	}
+	return w
+}
+
+// saveWidthIfResized persists the executor pane width if the user dragged it
+// (>2% off the captured initial), mirroring detail.go's resize-detection.
+func (p *listExecutorPane) saveWidthIfResized(prev joinedState) {
+	if prev.paneID == "" || prev.initialWidth <= 0 {
+		return
+	}
+	cur := p.currentWidthPct(prev.paneID)
+	if cur <= 0 {
+		return
+	}
+	if cur < prev.initialWidth-2 || cur > prev.initialWidth+2 {
+		if p.database != nil && cur >= 10 && cur <= 90 {
+			p.database.SetSetting(config.SettingListExecutorPaneWidth, strconv.Itoa(cur)+"%")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Add `breakBack` (process-preserving)**
+
+Append:
+
+```go
+// breakBack returns the joined executor pane to its daemon window (creating the
+// window if tmux destroyed it when the pane was joined out), preserving the
+// executor process, and resizes the TUI pane back to full width. Persists the
+// width first if `save` or the user dragged it. Returns a zeroed joinedState.
+func (p *listExecutorPane) breakBack(prev joinedState, save bool) joinedState {
+	if prev.paneID == "" {
+		p.resizeTuiFull()
+		return joinedState{}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if save {
+		// Explicit teardown always records the current width.
+		if cur := p.currentWidthPct(prev.paneID); cur >= 10 && cur <= 90 && p.database != nil {
+			p.database.SetSetting(config.SettingListExecutorPaneWidth, strconv.Itoa(cur)+"%")
+		}
+	} else {
+		p.saveWidthIfResized(prev)
+	}
+
+	daemon := prev.daemonSession
+	if daemon == "" {
+		daemon = executor.TmuxDaemonSession
+	}
+	task := &db.Task{ID: prev.taskID}
+	if p.database != nil {
+		if full, err := p.database.GetTask(prev.taskID); err == nil && full != nil {
+			task = full
+		}
+	}
+	windowID := findOrCreateDaemonWindow(ctx, p.database, task, daemon, p.workdir(task))
+	if windowID == "" {
+		// Could not re-home — DO NOT kill the executor; leave the pane in place.
+		p.resizeTuiFull()
+		return joinedState{}
+	}
+	// Detect a placeholder-only window so we can remove it after joining.
+	paneCountOut, _ := osExec.CommandContext(ctx, "tmux", "display-message", "-t", windowID, "-p", "#{window_panes}").Output()
+	hadPlaceholder := strings.TrimSpace(string(paneCountOut)) == "1"
+
+	err := osExec.CommandContext(ctx, "tmux", "join-pane", "-d", "-s", prev.paneID, "-t", windowID).Run()
+	if err != nil {
+		// Fallback: break to a fresh window rather than kill the process.
+		osExec.CommandContext(ctx, "tmux", "break-pane", "-d", "-s", prev.paneID, "-t", daemon+":", "-n", executor.TmuxWindowName(prev.taskID)).Run()
+		p.resizeTuiFull()
+		return joinedState{}
+	}
+	if hadPlaceholder {
+		osExec.CommandContext(ctx, "tmux", "kill-pane", "-t", windowID+".0").Run()
+	}
+	p.resizeTuiFull()
+	return joinedState{}
+}
+
+func (p *listExecutorPane) workdir(task *db.Task) string {
+	if task != nil && task.WorktreePath != "" {
+		return task.WorktreePath
+	}
+	return os.Getenv("HOME")
+}
+
+func (p *listExecutorPane) resizeTuiFull() {
+	if p.tuiPaneID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	osExec.CommandContext(ctx, "tmux", "resize-pane", "-t", p.tuiPaneID, "-x", "100%").Run()
+}
+```
+
+- [ ] **Step 3: Add `joinRight`**
+
+Append:
+
+```go
+// joinRight joins task's executor pane to the right of the TUI pane at the
+// preferred width, then returns focus to the TUI. Returns the new joinedState,
+// or a zeroed state (no error) if the task has no live executor window.
+func (p *listExecutorPane) joinRight(task *db.Task) (joinedState, error) {
+	if task == nil {
+		return joinedState{}, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	target := findTaskWindowTarget(ctx, p.database, task) // "session:windowID" or ""
+	if target == "" {
+		return joinedState{}, nil
+	}
+	daemonSession := target
+	if i := strings.Index(target, ":"); i >= 0 {
+		daemonSession = target[:i]
+	}
+
+	// Choose the source pane: stored Claude pane if still in the window, else first.
+	panesOut, err := osExec.CommandContext(ctx, "tmux", "list-panes", "-t", target, "-F", "#{pane_id}").Output()
+	if err != nil {
+		return joinedState{}, nil
+	}
+	paneIDs := strings.Split(strings.TrimSpace(string(panesOut)), "\n")
+	if len(paneIDs) == 0 || paneIDs[0] == "" {
+		return joinedState{}, nil
+	}
+	src := paneIDs[0]
+	if task.ClaudePaneID != "" {
+		for _, id := range paneIDs {
+			if id == task.ClaudePaneID {
+				src = task.ClaudePaneID
+				break
+			}
+		}
+	}
+
+	// Join to the right of the TUI pane at the preferred width.
+	if err := osExec.CommandContext(ctx, "tmux", "join-pane", "-h", "-l", p.widthPref(), "-s", src, "-t", p.tuiPaneID).Run(); err != nil {
+		return joinedState{}, err
+	}
+	// The joined pane is now active; capture its id.
+	joinedID := src
+	if out, err := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}").Output(); err == nil {
+		joinedID = strings.TrimSpace(string(out))
+	}
+	osExec.CommandContext(ctx, "tmux", "select-pane", "-t", joinedID, "-T", "Executor #"+strconv.FormatInt(task.ID, 10)).Run()
+
+	// Visual affordance + draggable borders, and Shift-arrow focus switching.
+	p.styleAndBind()
+
+	// Return focus to the TUI so list keys keep driving Bubble Tea.
+	osExec.CommandContext(ctx, "tmux", "select-pane", "-t", p.tuiPaneID).Run()
+
+	st := joinedState{taskID: task.ID, paneID: joinedID, daemonSession: daemonSession}
+	st.initialWidth = p.currentWidthPct(joinedID)
+	return st, nil
+}
+
+// styleAndBind sets draggable heavy borders + Shift-Left/Right pane focus
+// switching (mirrors detail.go). Unbound again on breakBack via unbindKeys.
+func (p *listExecutorPane) styleAndBind() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	s := p.uiSessionName
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-lines", "heavy").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-indicators", "arrows").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-active-border-style", "fg=#61AFEF").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "status-right", " drag border to resize · shift+→ focus executor ").Run()
+	osExec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "S-Right", "select-pane", "-t", ":.+").Run()
+	osExec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "S-Left", "select-pane", "-t", ":.-").Run()
+}
+
+func (p *listExecutorPane) unbindStyleAndBind() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	s := p.uiSessionName
+	osExec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "S-Right").Run()
+	osExec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "S-Left").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "status-right", " ").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-lines", "single").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-indicators", "off").Run()
+}
+```
+
+Then call `p.unbindStyleAndBind()` at the top of `breakBack` when `prev.paneID != ""` (before the join-back), so styling/bindings are reset. Add that one line.
+
+- [ ] **Step 4: Build**
+
+Run: `go build ./...`
+Expected: clean. (Requires `db.DB.GetTask`, `UpdateTaskWindowID`, `GetSetting`, `SetSetting` — all exist.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ui/executor_pane.go
+git commit -m "list view: executor pane controller (join right / break back / width)"
+```
+
+---
+
+## Task 5: AppModel state + async swap on navigation (debounced, serialized)
+
+**Files:**
+- Modify: `internal/ui/app.go`
+
+- [ ] **Step 1: Add state fields to AppModel**
+
+In the `AppModel` struct (near the other dashboard fields ~line 530), add:
+
+```go
+	// List-view live executor preview
+	listPreview        *listExecutorPane
+	previewVisible     bool        // p toggle; true = show pane for selected task
+	previewLoading     bool        // a join/break op is in flight
+	previewDirty       bool        // a newer request arrived mid-flight
+	previewGen         int         // debounce generation; stale ticks ignored
+	previewJoined      joinedState // currently-joined pane state
+```
+
+In the AppModel constructor (where other fields init, ~line 671), add:
+
+```go
+	m.listPreview = newListExecutorPane(database)
+	m.previewVisible = true
+```
+
+(Use the actual db variable name in that constructor; it is the same `database`/`db` passed to other views.)
+
+- [ ] **Step 2: Add the message types**
+
+Near the other msg types in app.go:
+
+```go
+// listPreviewTickMsg fires after the selection-change debounce; gen guards staleness.
+type listPreviewTickMsg struct{ gen int }
+
+// listPreviewUpdatedMsg carries the result of an async preview join/break.
+type listPreviewUpdatedMsg struct{ result previewResult }
+```
+
+- [ ] **Step 3: Add arm + helpers**
+
+Add methods on AppModel:
+
+```go
+// armPreview schedules a debounced preview refresh for the current selection.
+// Returns a Cmd to be batched into the caller's return. No-op outside tmux.
+func (m *AppModel) armPreview() tea.Cmd {
+	if m.listPreview == nil || os.Getenv("TMUX") == "" {
+		return nil
+	}
+	m.previewGen++
+	gen := m.previewGen
+	return tea.Tick(300*time.Millisecond, func(time.Time) tea.Msg {
+		return listPreviewTickMsg{gen: gen}
+	})
+}
+
+// selectedHasExecutor reports whether task t has a live executor window to show.
+func (m *AppModel) selectedHasExecutor(t *db.Task) bool {
+	if t == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return findTaskWindowTarget(ctx, nil, t) != ""
+}
+
+// runPreviewAction dispatches the decided action as an async Cmd (serialized by
+// previewLoading). Call only from Update.
+func (m *AppModel) runPreviewAction(gen int) tea.Cmd {
+	if !m.listPreview.ensureIdentity() {
+		return nil
+	}
+	sel := m.listView.SelectedTask()
+	var selID int64
+	if sel != nil {
+		selID = sel.ID
+	}
+	action := decidePreviewAction(selID, m.selectedHasExecutor(sel), m.previewJoined.taskID, m.previewVisible)
+	if action == previewNoop {
+		return nil
+	}
+	if m.previewLoading {
+		m.previewDirty = true
+		return nil
+	}
+	m.previewLoading = true
+	prev := m.previewJoined
+	p := m.listPreview
+	switch action {
+	case previewCollapse:
+		return func() tea.Msg {
+			st := p.breakBack(prev, false)
+			return listPreviewUpdatedMsg{result: previewResult{gen: gen, state: st}}
+		}
+	default: // previewSwap
+		return func() tea.Msg {
+			p.breakBack(prev, false) // return the old pane first
+			st, err := p.joinRight(sel)
+			return listPreviewUpdatedMsg{result: previewResult{gen: gen, state: st, err: err}}
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Handle the two messages in Update**
+
+In `AppModel.Update`'s type switch, add cases:
+
+```go
+	case listPreviewTickMsg:
+		if msg.gen != m.previewGen {
+			return m, nil // stale debounce tick
+		}
+		return m, m.runPreviewAction(msg.gen)
+
+	case listPreviewUpdatedMsg:
+		m.previewLoading = false
+		m.previewJoined = msg.result.state
+		if m.previewDirty {
+			m.previewDirty = false
+			return m, m.runPreviewAction(m.previewGen)
+		}
+		return m, nil
+```
+
+- [ ] **Step 5: Arm on list navigation**
+
+In `updateListNav` (app.go ~765), after each branch that changes the selection (`MoveUp`, `MoveDown`, `SelectVisibleRow`, and the click handler path in Update ~1024), batch in `m.armPreview()`. Concretely, change the navigation returns from `return true, nil` to `return true, m.armPreview()` for the Up/Down cases, and for `SelectVisibleRow`/click return `tea.Batch(m.loadTask(...), ...)` only where it opens detail (those don't arm; see Task 6). For pure selection moves:
+
+```go
+	case key.Matches(msg, m.keys.Up):
+		m.listView.MoveUp()
+		return true, m.armPreview()
+	case key.Matches(msg, m.keys.Down):
+		m.listView.MoveDown()
+		return true, m.armPreview()
+```
+
+- [ ] **Step 6: Build + run existing tests**
+
+Run: `go build ./... && go test ./internal/ui/`
+Expected: clean build, tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ui/app.go
+git commit -m "list view: debounced async executor preview on navigation"
+```
+
+---
+
+## Task 6: Synchronous teardown on explicit transitions (Enter, v, p, quit)
+
+**Files:**
+- Modify: `internal/ui/app.go`
+
+The executor pane must be broken back synchronously before detail's `joinTmuxPanes` (which kills non-TUI panes), before switching to board, on hide, and on quit.
+
+- [ ] **Step 1: Add a synchronous teardown helper**
+
+```go
+// teardownPreviewSync breaks the joined executor pane back to its daemon window
+// synchronously (so the executor is re-homed before detail view or quit). Safe
+// to call when nothing is joined.
+func (m *AppModel) teardownPreviewSync(save bool) {
+	if m.listPreview == nil || m.previewJoined.paneID == "" {
+		return
+	}
+	m.listPreview.ensureIdentity()
+	m.listPreview.breakBack(m.previewJoined, save)
+	m.previewJoined = joinedState{}
+	m.previewLoading = false
+	m.previewDirty = false
+	m.previewGen++ // invalidate any in-flight debounce tick
+}
+```
+
+- [ ] **Step 2: Tear down before opening detail**
+
+In every list-view path that calls `m.loadTask(...)` to open detail (Enter handler ~2304, numeric `SelectVisibleRow` ~ in updateListNav, click handler ~1024), call `m.teardownPreviewSync(true)` immediately before `m.loadTask`. Example for the Enter case:
+
+```go
+	case key.Matches(msg, m.keys.Enter):
+		if task := m.dashboardSelectedTask(); task != nil {
+			m.teardownPreviewSync(true)
+			return m, m.loadTask(task.ID)
+		}
+```
+
+- [ ] **Step 3: Tear down / re-arm on view toggle**
+
+In `toggleViewMode` (~749): when switching to board, tear down; when switching to list, arm. Return any arm Cmd. Since `toggleViewMode` currently returns nothing, have its caller (the `ToggleView` case in `updateDashboard` ~2187) capture and return the cmd:
+
+```go
+	if key.Matches(msg, m.keys.ToggleView) {
+		cmd := m.toggleViewMode()
+		return m, cmd
+	}
+```
+
+And change `toggleViewMode` to:
+
+```go
+func (m *AppModel) toggleViewMode() tea.Cmd {
+	if m.viewMode == ViewModeList {
+		m.teardownPreviewSync(true)
+		m.viewMode = ViewModeBoard
+		// ... existing selection-sync code ...
+		return nil
+	}
+	m.viewMode = ViewModeList
+	// ... existing selection-sync code ...
+	return m.armPreview()
+}
+```
+
+(Preserve the existing selection-preservation logic already in `toggleViewMode`.)
+
+- [ ] **Step 4: `p` toggles preview visibility**
+
+In `updateListNav`, add a branch (before the default) for the `p` key. NOTE: `p`/`ctrl+p` is currently "go to task" (palette) per the help bar — verify the existing binding in `updateListNav`/keys and pick a free key if `p` is taken (fallback: `e` is "edit"; use `P` (shift) for preview toggle if `p` conflicts). Assuming `P`:
+
+```go
+	if msg.String() == "P" {
+		m.previewVisible = !m.previewVisible
+		if m.previewVisible {
+			return true, m.armPreview()
+		}
+		m.teardownPreviewSync(true)
+		return true, nil
+	}
+```
+
+- [ ] **Step 5: Tear down on quit**
+
+Find the quit path (search `tea.Quit` in app.go). Before returning `tea.Quit` from the dashboard/list, call `m.teardownPreviewSync(true)`. If there is a central place where the app already cleans up the detail view on quit, add the preview teardown alongside it.
+
+- [ ] **Step 6: Build + tests**
+
+Run: `go build ./... && go test ./internal/ui/`
+Expected: clean, pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ui/app.go
+git commit -m "list view: synchronous executor-pane teardown on enter/toggle/hide/quit"
+```
+
+---
+
+## Task 7: Debug state + hidden-affordance (small)
+
+**Files:**
+- Modify: `internal/ui/debug.go`
+- Modify: `internal/ui/list_view.go`
+
+- [ ] **Step 1: Expose preview state for QA**
+
+In `debug.go`'s `DebugList` (or the dashboard debug section), add fields and populate them where the app builds debug state:
+
+```go
+	PreviewVisible      bool  `json:"preview_visible"`
+	PreviewJoinedTaskID int64 `json:"preview_joined_task_id"`
+```
+
+Populate from `m.previewVisible` and `m.previewJoined.taskID` in the function that assembles the debug snapshot (search `debugState`/`DebugState` in app.go/debug.go).
+
+- [ ] **Step 2: Hidden affordance in the summary**
+
+In `list_view.go` `renderFilterChips`, the `ListView` cannot see AppModel's `previewVisible`. Add a settable field `previewHidden bool` on `ListView` and a setter `SetPreviewHidden(bool)`; call it from AppModel whenever `previewVisible` changes. When true, append a dim ` · pane hidden (P)` to the summary; when false and in tmux, optionally nothing. Keep it tiny.
+
+```go
+// in ListView struct:
+	previewHidden bool
+// setter:
+func (l *ListView) SetPreviewHidden(v bool) { if l != nil { l.previewHidden = v } }
+// in renderFilterChips, after building summary:
+	if l.previewHidden {
+		summary += sep + muted.Render("pane hidden (P)")
+	}
+```
+
+- [ ] **Step 3: Build + tests**
+
+Run: `go build ./... && go test ./internal/ui/`
+Expected: clean, pass. (Update `TestListViewSummaryShowsActiveFiltersOnly` only if it asserts exact summary; it uses Contains, so unaffected.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/ui/debug.go internal/ui/list_view.go internal/ui/app.go
+git commit -m "list view: expose preview state in debug + hidden affordance"
+```
+
+---
+
+## Task 8: Manual QA with the harness + screenshots
+
+**Files:** none (verification). Uses `scripts/qa/` + the seeded `/tmp/ty-qa` instance and the `live panes without daemon` tier (`scripts/qa/ty-qa-agent.sh`).
+
+- [ ] **Step 1: Rebuild the isolated instance and stand up a live executor for a task**
+
+```bash
+scripts/qa/ty-qa-up.sh offerlab
+# seed tasks (see session notes) then:
+scripts/qa/ty-qa-agent.sh 1     # stand up a real executor window+pane for task #1 and point its DB row at it
+scripts/qa/ty-qa-tui.sh
+```
+
+- [ ] **Step 2: Drive and assert split appears for a running task**
+
+```bash
+scripts/qa/ty-qa-key.sh v          # list view
+scripts/qa/ty-qa-key.sh Up Up      # land on task #1 (running)
+sleep 1                            # debounce
+scripts/qa/ty-qa-state.sh '.dashboard.list.preview_joined_task_id'   # expect 1
+scripts/qa/ty-qa-capture.sh        # eyeball: list left, executor right
+```
+Expected: `preview_joined_task_id == 1`; two panes visible.
+
+- [ ] **Step 3: Assert collapse on a no-executor task; no thrash on rapid nav**
+
+```bash
+scripts/qa/ty-qa-key.sh Down Down Down   # move to a backlog/done task quickly
+sleep 1
+scripts/qa/ty-qa-state.sh '.dashboard.list.preview_joined_task_id'   # expect 0 (collapsed, full-width)
+```
+
+- [ ] **Step 4: Assert executor SURVIVES teardown (the critical correctness check)**
+
+```bash
+# Note the executor window before:
+tmux list-windows -a -F '#{session_name}:#{window_name}' | grep task_1
+scripts/qa/ty-qa-key.sh Up Up      # back to #1 (re-joins)
+sleep 1
+scripts/qa/ty-qa-key.sh v          # toggle to board -> synchronous break-back
+tmux list-windows -a -F '#{session_name}:#{window_name}' | grep task_1   # window MUST still exist
+```
+Expected: the `task_1` daemon window still exists after toggling away (executor not killed).
+
+- [ ] **Step 5: Enter detail from the preview, confirm clean handoff**
+
+```bash
+scripts/qa/ty-qa-key.sh v Up Up    # list, select #1
+sleep 1
+scripts/qa/ty-qa-key.sh Enter      # open detail; preview must break back first, detail joins
+scripts/qa/ty-qa-state.sh '.view'  # "detail"
+scripts/qa/ty-qa-state.sh '.detail.has_panes'  # true
+scripts/qa/ty-qa-key.sh Escape
+```
+
+- [ ] **Step 6: Drag-resize persistence**
+
+Attach (`tmux attach -t task-ui-qa`), drag the border, detach; toggle board/list; confirm the executor pane reappears at the dragged width. Check `ty settings get list_executor_pane_width` reflects it.
+
+- [ ] **Step 7: PNG screenshots via VHS**
+
+Render split state, collapsed/full-width state, and focused-executor state to PNGs (custom tape against `/tmp/ty-qa/tasks.db`, no DB wipe; press `v`, navigate, `Sleep`). Attach to the PR.
+
+- [ ] **Step 8: Tear down**
+
+```bash
+scripts/qa/ty-qa-down.sh --purge
+```
+
+---
+
+## Task 9: Final integration + PR
+
+- [ ] **Step 1: Full build + test**
+
+Run: `go build ./... && go test ./internal/ui/ ./internal/config/ ./internal/db/`
+Expected: pass (pre-existing `internal/ai`/`internal/autocomplete` failures unrelated).
+
+- [ ] **Step 2: Run the repo lint (before pushing)**
+
+Use the project lint workflow (gofmt/vet); fix any issues.
+
+- [ ] **Step 3: Update the PR**
+
+Push; update PR #564 description with the executor-pane feature, the debounce/teardown model, the drag-resize setting, and the QA screenshots.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** layout/states (Tasks 4–6), debounce+serialization+pure decision (Tasks 2,5), draggable resize + persisted `list_executor_pane_width` (Tasks 1,4), focus keys Shift-←/→ (Task 4 `styleAndBind`), teardown on all exits incl. quit and the detail-view kill-panes hazard (Task 6), tests (Task 2) + QA/screenshots (Task 8). All covered.
+- **Type consistency:** `previewAction`, `joinedState`, `previewResult`, `listExecutorPane`, `decidePreviewAction`, `validatePanePct`, `armPreview`, `runPreviewAction`, `teardownPreviewSync`, `listPreviewTickMsg`, `listPreviewUpdatedMsg` used consistently across tasks.
+- **Open risk to verify during execution:** the `p` key may already be bound ("go to task") — Task 6 Step 4 picks `P` if so; confirm against the keymap. The exact quit path (Task 6 Step 5) must be located in app.go. `db.DB.GetTask` signature to be confirmed at use.

--- a/docs/superpowers/specs/2026-06-07-list-view-executor-pane-design.md
+++ b/docs/superpowers/specs/2026-06-07-list-view-executor-pane-design.md
@@ -1,0 +1,129 @@
+# List view: live executor pane
+
+**Date:** 2026-06-07
+**Status:** Approved (design)
+**Branch:** `task/4196-list-view-status-should-have-active-whic`
+
+## Summary
+
+When the dashboard list view has a row selected, show that task's **live, interactive executor tmux pane** on the right of the screen — Bubble Tea list on the left, the real executor pane joined on the right. This turns the list into a master/detail triage surface: scan tasks on the left, watch (and optionally interact with) the selected task's executor on the right, and press `Enter` to drop into the full detail workspace.
+
+This builds on the existing tmux integration: `ty` already runs inside a tmux UI session, and the detail view already joins a task's executor pane out of the daemon session into the UI session. The list-view pane reuses that machinery for a different *layout* (left/right split instead of the detail view's top/bottom-split).
+
+## Goals
+
+- In list view, the selected task's executor pane appears live on the right.
+- Navigating the list updates which executor is shown, without thrashing tmux.
+- The right pane is **draggable to resize**, like the detail view's panes, and the chosen width persists.
+- Leaving list view (any exit path) never kills a running executor.
+
+## Non-goals
+
+- Showing more than one executor pane at a time (only the selected task's).
+- A shell pane in list view (that remains a detail-view feature).
+- Read-only/captured previews (we join the real pane; rejected in favor of live).
+- Reworking the detail view's layout.
+
+## Background / current architecture
+
+(Verified against current code on the task branch.)
+
+- **`ty` runs inside tmux and requires it.** `cmd/task/main.go` re-execs into a tmux UI session named `task-ui-<sessionID>` if `$TMUX` is unset; the Bubble Tea TUI is pane `:.0`. Mouse is enabled via `tea.WithMouseCellMotion()` (`cmd/task/main.go:3594`), so tmux pane borders are drag-resizable.
+- **Executors live in a daemon session.** Each task's executor runs in a window of `task-daemon-<sessionID>` (`internal/executor`, `TmuxSessionName(taskID)`, `new-window`). `executor.IsExecutorSessionRunning(taskID)` reports whether it's live; `executor.CapturePaneContent(target, n)` can read pane text.
+- **Detail view joins panes.** `internal/ui/detail.go` `joinTmuxPanes()` does `join-pane -v` to bring the executor below the (shrunk) TUI pane, then `join-pane -h` / `split-window -h` for the shell. It tracks `claudePaneID`, `workdirPaneID`, `tuiPaneID`, `cachedWindowTarget`, `daemonSessionID`, and guards async work with `paneLoading`.
+- **Drag-resize persistence pattern (to mirror).** Detail view captures `initialDetailHeight` / `initialShellWidth` right after join, then on tick/teardown compares the current tmux pane size (`display-message -p '#{pane_width}'`) against the initial; if it changed by >2% it treats it as a user drag and persists via `saveShellPaneWidth()` → setting `shell_pane_width` (`internal/config/config.go`). Next join reads it back with `getShellPaneWidth()`.
+- **List view today.** `internal/ui/list_view.go` is a pure Bubble Tea table (selection, sort, filters). Selection moves via `MoveUp/MoveDown`; `Enter`/click/`1-9` call `m.loadTask(id)` which opens the detail view. The list view does no tmux work today.
+- **Race lessons (memory `tmux-pane-join-architecture`).** Once a pane is joined into the UI session it has *moved* out of the daemon window — operate on it by **pane ID**, not the daemon window target, and serialize pane operations behind a loading flag to avoid concurrent join/break races killing panes.
+
+## Design
+
+### Visible states
+
+The right pane's presence is derived from the selected task and a visibility toggle:
+
+| Condition | Layout |
+|---|---|
+| Preview visible **and** selected task has a live executor | **Split**: list left (~55%), executor right (~45%, or persisted width) |
+| Preview visible **and** selected task has no live executor | **Full-width**: pane broken back to daemon, window unsplit, list reflows full width |
+| Preview hidden (`p`) | Always full-width list; no joining regardless of selection |
+
+Preview is **on by default** when entering list view.
+
+### Selection → pane swap (debounce + serialization)
+
+Moving the cursor must not touch tmux on every keystroke.
+
+1. **Debounce.** On selection change, arm a ~300 ms timer using `tea.Tick` carrying a monotonically increasing **generation counter**. A tick whose generation ≠ the current generation is stale and ignored. Rapid arrowing just moves the highlight; tmux acts only once the selection settles.
+
+2. **Pure decision function.** When a live (non-stale) tick fires, compute the desired action from pure inputs and return one of:
+   - `none` — selected task already joined, or nothing to do.
+   - `collapse` — preview visible but selected task has no live executor (or preview hidden) and a pane is currently joined → break it back, unsplit.
+   - `swap(taskID)` — preview visible, selected task has a live executor different from the joined one → break current (if any), join the new one.
+
+   ```
+   decidePreviewAction(sel, joined, visible, executorRunning(sel), loading) -> Action
+   ```
+   This function has no I/O and is **unit-tested** across the combinations (hidden, no-executor, same task, different task, mid-load).
+
+3. **Serialized execution.** A single `previewLoading` flag gates execution; never run two join/break operations concurrently. A request arriving mid-flight sets a `previewDirty` marker; on completion we re-run the decision against the *latest* selection so we always converge. All async results flow back as a `previewUpdatedMsg` (mirroring detail view's `panesJoinedMsg`) — no shared-state mutation from goroutines.
+
+4. **Swap mechanics** (all targeting by **pane ID**):
+   - Break the currently-joined preview pane back to its daemon window (`break-pane`/`join-pane` reverse) if one is joined.
+   - `join-pane -h` the selected task's executor pane into the right slot at the persisted/default width.
+   - `select-pane` back to the **list (TUI) pane** so keystrokes keep driving Bubble Tea.
+
+### Draggable resize + persistence
+
+- The executor pane border is drag-resizable for free (tmux mouse mode is already on).
+- Mirror the detail view's persistence: capture `initialListExecutorWidth` right after join; on a periodic tick / on teardown, compare current `#{pane_width}` to initial and, if changed >2%, persist via a new setting **`list_executor_pane_width`** (`internal/config/config.go`).
+- New join reads it back (`getListExecutorPaneWidth()`), defaulting to **45%** when unset. Getter/saver mirror `getShellPaneWidth` / `saveShellPaneWidth`.
+
+### Focus & keybindings (list view)
+
+- `↑/↓`, sort/filter keys, `v`, `p` — drive the Bubble Tea list as today.
+- `Shift-Right` → move tmux focus into the executor pane to interact; `Shift-Left` → focus back to the list. Reuses the detail view's existing root-level `select-pane` bindings.
+- `Enter` (and click / `1-9`) → open the **full detail view** (detail top + executor + shell bottom), unchanged. The inline pane is for triage/peek; detail is the full workspace.
+- `p` → toggle the executor pane off/on.
+
+### Lifecycle / teardown (correctness-critical)
+
+The executor must **never** be killed by leaving the list view. Always break the preview pane back to its daemon window before tearing down, on every exit path:
+
+- Toggle to board (`v`) → break back, unsplit, restore full-width TUI.
+- `Enter` into detail → break back + unsplit first, then the detail view joins as today (minor flicker acceptable; guarantees a single owner of the executor pane).
+- `p` hide → break back, unsplit.
+- App quit → break back before the UI session/window closes.
+- Window resize (`WindowSizeMsg`) → re-apply the split proportion to the persisted/default width.
+
+### Code shape
+
+- **Shared helper.** Extract the pane primitives the detail view already has — join/break/capture by pane ID, the `loading` guard, current-size read, drag-detect/save — into a small reusable unit (e.g. `internal/ui/executor_pane.go`) used by both detail and list. This avoids duplicating the racy logic and trims `detail.go`. Scope the extraction to what list view needs; do not refactor unrelated detail-view behavior.
+- **List view owns layout + decision only.** `ListView` (or `AppModel`) gains: `previewVisible bool`, `previewLoading bool`, `previewJoinedTaskID int64`, `previewDirty bool`, `previewGen int`, `initialListExecutorWidth int`. The pure `decidePreviewAction` lives next to the list view and is tested.
+- New config constant `SettingListExecutorPaneWidth = "list_executor_pane_width"`.
+
+## Testing
+
+**Unit (Go):**
+- `decidePreviewAction` truth table: hidden; no executor; same task already joined; different task with executor; request while loading (→ dirty); preview toggled off while joined (→ collapse).
+- Debounce generation logic: a stale-generation tick is a no-op; only the latest generation triggers an action.
+- Existing list-view tests continue to pass.
+
+**Manual / QA (isolated `ty` TUI harness + screenshots):**
+- Split appears for a running task; collapses for a backlog/done task; reappears on returning to a running task.
+- Rapid arrow navigation does not thrash (only settles after ~300 ms).
+- `Shift-Right`/`Shift-Left` focus in/out; typing reaches the executor.
+- Drag the border → width changes and **persists** across hide/show and across leaving/re-entering list view.
+- `Enter` opens the full detail view with the executor intact.
+- Teardown: toggle to board, hide with `p`, and **quit** all leave the executor running in the daemon (verify the daemon window still exists; no orphaned/killed pane).
+- Capture screenshots of: split state, full-width (no-executor) state, focused-executor state, and post-resize state. Attach to the PR.
+
+## Risks & mitigations
+
+- **Join/break races** (documented in memory) → serialize behind `previewLoading`, target by pane ID, drop stale generations.
+- **Accidentally killing an executor on teardown** → always break back before unsplit/exit; QA explicitly verifies the daemon window survives.
+- **Layout churn on mixed lists** (collapse/expand as you cross running/non-running tasks) → accepted per design decision; debounce smooths it.
+- **Handoff to detail view** → break back + unsplit before detail joins, so there is never contention over the same executor pane.
+
+## Open questions
+
+None blocking. Default width (45%) and debounce (300 ms) are tunable during QA.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ const (
 	SettingTheme                 = "theme"
 	SettingDetailPaneHeight      = "detail_pane_height"
 	SettingShellPaneWidth        = "shell_pane_width"
+	SettingListExecutorPaneWidth = "list_executor_pane_width"
 	SettingShellPaneHidden       = "shell_pane_hidden"
 	SettingIdleSuspendTimeout    = "idle_suspend_timeout"
 	SettingServerURL             = "server_url"

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2038,7 +2038,7 @@ func (m *AppModel) renderFilterBar() string {
 			parts = append(parts, helpStyle.Render(fmt.Sprintf("  (backspace: clear, Enter: done, %s: navigate, [: project)", navHelp)))
 		}
 	} else if m.filterText != "" {
-		parts = append(parts, helpStyle.Render("  (/: edit, Esc: clear)"))
+		parts = append(parts, helpStyle.Render("  (esc to clear)"))
 	}
 
 	filterContent := lipgloss.JoinHorizontal(lipgloss.Center, parts...)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -536,6 +536,14 @@ type AppModel struct {
 	filterAutocomplete *FilterAutocompleteModel
 	showFilterDropdown bool // Whether to show the project autocomplete dropdown
 
+	// List-view live executor preview
+	listPreview    *listExecutorPane
+	previewVisible bool        // P toggle; true = show executor pane for selected task
+	previewLoading bool        // a join/break op is in flight
+	previewDirty   bool        // a newer request arrived mid-flight
+	previewGen     int         // debounce generation; stale ticks ignored
+	previewJoined  joinedState // currently-joined pane state
+
 	// Available executors (cached on startup)
 	availableExecutors []string
 
@@ -656,6 +664,8 @@ func NewAppModel(database *db.DB, exec *executor.Executor, workingDir string, ve
 		currentView:        ViewDashboard,
 		kanban:             kanban,
 		listView:           listView,
+		listPreview:        newListExecutorPane(database),
+		previewVisible:     true,
 		loading:            true,
 		prevStatuses:       make(map[int64]string),
 		tasksNeedingInput:  make(map[int64]bool),
@@ -746,18 +756,22 @@ func (m *AppModel) dashboardMoveDown() {
 
 // toggleViewMode switches between the kanban board and the list view, carrying
 // the current selection across so the same task stays focused.
-func (m *AppModel) toggleViewMode() {
+func (m *AppModel) toggleViewMode() tea.Cmd {
 	if m.viewMode == ViewModeBoard {
 		m.viewMode = ViewModeList
 		if t := m.kanban.SelectedTask(); t != nil {
 			m.listView.SelectTask(t.ID)
 		}
-	} else {
-		m.viewMode = ViewModeBoard
-		if t := m.listView.SelectedTask(); t != nil {
-			m.kanban.SelectTask(t.ID)
-		}
+		// Entering list view: show the executor pane for the selection.
+		return m.armPreview()
 	}
+	// Leaving list view: re-home any joined executor pane before showing the board.
+	m.teardownPreviewSync(true)
+	m.viewMode = ViewModeBoard
+	if t := m.listView.SelectedTask(); t != nil {
+		m.kanban.SelectTask(t.ID)
+	}
+	return nil
 }
 
 // updateListNav handles navigation, sorting, and filtering keys that are specific
@@ -766,48 +780,59 @@ func (m *AppModel) updateListNav(msg tea.KeyMsg) (bool, tea.Cmd) {
 	switch {
 	case key.Matches(msg, m.keys.Up):
 		m.listView.MoveUp()
-		return true, nil
+		return true, m.armPreview()
 	case key.Matches(msg, m.keys.Down):
 		m.listView.MoveDown()
-		return true, nil
+		return true, m.armPreview()
 	case key.Matches(msg, m.keys.Left):
 		m.listView.PrevSortColumn()
-		return true, nil
+		return true, m.armPreview()
 	case key.Matches(msg, m.keys.Right):
 		m.listView.NextSortColumn()
-		return true, nil
+		return true, m.armPreview()
 	}
 
 	switch msg.String() {
 	case " ":
 		m.listView.ToggleSortDirection()
-		return true, nil
+		return true, m.armPreview()
 	// [ ] cycle the project filter, matching the kanban "/[project]" convention
 	// where square brackets already mean "project".
 	case "[":
 		m.listView.CycleProjectFilter(-1)
-		return true, nil
+		return true, m.armPreview()
 	case "]":
 		m.listView.CycleProjectFilter(1)
-		return true, nil
+		return true, m.armPreview()
 	// { } cycle the status filter.
 	case "{":
 		m.listView.CycleStatusFilter(-1)
-		return true, nil
+		return true, m.armPreview()
 	case "}":
 		m.listView.CycleStatusFilter(1)
-		return true, nil
+		return true, m.armPreview()
 	case "<":
 		m.listView.CycleDateFilter(-1)
-		return true, nil
+		return true, m.armPreview()
 	case ">":
 		m.listView.CycleDateFilter(1)
+		return true, m.armPreview()
+	// P toggles the live executor preview pane (list view only; on the board P
+	// focuses the In Progress column, which is handled after this).
+	case "P":
+		m.previewVisible = !m.previewVisible
+		m.listView.SetPreviewHidden(!m.previewVisible)
+		if m.previewVisible {
+			return true, m.armPreview()
+		}
+		m.teardownPreviewSync(true)
 		return true, nil
 	}
 
 	// Numeric shortcuts select and open the Nth visible row.
 	if s := msg.String(); len(s) == 1 && s >= "1" && s <= "9" {
 		if task := m.listView.SelectVisibleRow(int(s[0] - '0')); task != nil {
+			m.teardownPreviewSync(true) // re-home preview before detail joins
 			return true, m.loadTask(task.ID)
 		}
 		return true, nil
@@ -961,6 +986,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.executor.UnsubscribeTaskEvents(m.eventCh)
 			}
 			m.stopDatabaseWatcher()
+			m.teardownPreviewSync(true) // re-home executor pane so quitting never strands it
 			return m, tea.Quit
 		}
 
@@ -1023,6 +1049,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Check if clicking on a task card / row
 			if m.viewMode == ViewModeList {
 				if task := m.listView.HandleClick(msg.X, msg.Y); task != nil {
+					m.teardownPreviewSync(true) // re-home preview before detail joins
 					return m, m.loadTask(task.ID)
 				}
 			} else if task := m.kanban.HandleClick(msg.X, msg.Y); task != nil {
@@ -1033,6 +1060,21 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.currentView == ViewDetail {
 			return m.updateDetail(msg)
 		}
+
+	case listPreviewTickMsg:
+		if msg.gen != m.previewGen {
+			return m, nil // stale debounce tick
+		}
+		return m, m.runPreviewAction(msg.gen)
+
+	case listPreviewUpdatedMsg:
+		m.previewLoading = false
+		m.previewJoined = msg.result.state
+		if m.previewDirty {
+			m.previewDirty = false
+			return m, m.runPreviewAction(m.previewGen)
+		}
+		return m, nil
 
 	case tasksLoadedMsg:
 		m.loading = false
@@ -2185,8 +2227,7 @@ func stripAnsiCodes(s string) string {
 func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Toggling between board and list works in either mode.
 	if key.Matches(msg, m.keys.ToggleView) {
-		m.toggleViewMode()
-		return m, nil
+		return m, m.toggleViewMode()
 	}
 
 	// In list mode, intercept navigation/sort/filter keys before the board
@@ -2296,6 +2337,7 @@ func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// Clear notification after jumping
 			m.notification = ""
 			m.notifyTaskID = 0
+			m.teardownPreviewSync(true) // re-home preview before detail joins
 			// Use loadTaskWithFocus to automatically focus the executor pane
 			return m, m.loadTaskWithFocus(taskID)
 		}
@@ -2303,6 +2345,7 @@ func (m *AppModel) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keys.Enter):
 		if task := m.dashboardSelectedTask(); task != nil {
+			m.teardownPreviewSync(true) // re-home preview before detail joins
 			return m, m.loadTask(task.ID)
 		}
 
@@ -2627,6 +2670,7 @@ func (m *AppModel) updateFilterMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.executor.UnsubscribeTaskEvents(m.eventCh)
 		}
 		m.stopDatabaseWatcher()
+		m.teardownPreviewSync(true) // re-home executor pane so quitting never strands it
 		return m, tea.Quit
 	}
 
@@ -3754,6 +3798,7 @@ func (m *AppModel) updateQuitConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.executor.UnsubscribeTaskEvents(m.eventCh)
 			}
 			m.stopDatabaseWatcher()
+			m.teardownPreviewSync(true) // re-home executor pane so quitting never strands it
 			return m, tea.Quit
 		}
 	}
@@ -3772,6 +3817,7 @@ func (m *AppModel) updateQuitConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.executor.UnsubscribeTaskEvents(m.eventCh)
 			}
 			m.stopDatabaseWatcher()
+			m.teardownPreviewSync(true) // re-home executor pane so quitting never strands it
 			return m, tea.Quit
 		}
 		// Cancelled

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2923,6 +2923,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.detailView.Cleanup()
 			m.detailView = nil
 		}
+		// Returning to the list: re-show the executor preview for the selection.
+		if m.viewMode == ViewModeList {
+			return m, m.armPreview()
+		}
 		return m, nil
 	}
 

--- a/internal/ui/debug.go
+++ b/internal/ui/debug.go
@@ -40,6 +40,9 @@ type DebugList struct {
 	ProjectFilter string      `json:"project_filter"`
 	DateFilter    string      `json:"date_filter"`
 	Rows          []DebugTask `json:"rows"`
+
+	PreviewVisible      bool  `json:"preview_visible"`        // executor preview pane enabled (P)
+	PreviewJoinedTaskID int64 `json:"preview_joined_task_id"` // task whose executor pane is joined (0 = none)
 }
 
 type DebugColumn struct {
@@ -109,6 +112,8 @@ func (m *AppModel) GenerateDebugState() DebugState {
 		if m.viewMode == ViewModeList && m.listView != nil {
 			dash.ViewMode = "list"
 			dash.List = m.listView.debugState()
+			dash.List.PreviewVisible = m.previewVisible
+			dash.List.PreviewJoinedTaskID = m.previewJoined.taskID
 			if task := m.listView.SelectedTask(); task != nil {
 				dash.SelectedTask = task.ID
 			}

--- a/internal/ui/executor_pane.go
+++ b/internal/ui/executor_pane.go
@@ -1,0 +1,394 @@
+package ui
+
+import (
+	"context"
+	"os"
+	osExec "os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/executor"
+)
+
+// previewAction is what the list-view executor preview should do for the
+// current selection. Decided purely (no I/O) by decidePreviewAction.
+type previewAction int
+
+const (
+	previewNoop previewAction = iota
+	previewCollapse
+	previewSwap
+)
+
+// decidePreviewAction decides the preview pane action from the current state.
+//
+//	selectedID: task selected in the list (0 if none)
+//	selHasExec: whether the selected task has a live executor window to show
+//	joinedID:   task whose executor pane is currently joined (0 if none)
+//	visible:    whether the preview is enabled (toggled with `P`)
+func decidePreviewAction(selectedID int64, selHasExec bool, joinedID int64, visible bool) previewAction {
+	if !visible || selectedID == 0 || !selHasExec {
+		if joinedID != 0 {
+			return previewCollapse
+		}
+		return previewNoop
+	}
+	if joinedID == selectedID {
+		return previewNoop
+	}
+	return previewSwap
+}
+
+// validatePanePct returns v if it is a "NN%" string within [10,90], else def.
+func validatePanePct(v, def string) string {
+	if strings.HasSuffix(v, "%") {
+		if p, err := strconv.Atoi(strings.TrimSuffix(v, "%")); err == nil && p >= 10 && p <= 90 {
+			return v
+		}
+	}
+	return def
+}
+
+// --- shared tmux helpers (package-level; also usable by detail view later) ---
+
+// findTaskWindowTarget returns the "session:windowID" of the daemon window
+// running task's executor, or "" if none exists. Updates the stored window ID
+// in the DB when found (only when database is non-nil).
+func findTaskWindowTarget(ctx context.Context, database *db.DB, task *db.Task) string {
+	if task == nil {
+		return ""
+	}
+	windowName := executor.TmuxWindowName(task.ID)
+	out, err := osExec.CommandContext(ctx, "tmux", "list-windows", "-a",
+		"-F", "#{session_name}:#{window_id}:#{window_name}").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		sessionName, windowID, name := parts[0], parts[1], parts[2]
+		if !strings.HasPrefix(sessionName, "task-daemon-") {
+			continue
+		}
+		if name == windowName {
+			if database != nil && windowID != "" {
+				database.UpdateTaskWindowID(task.ID, windowID)
+				task.TmuxWindowID = windowID
+			}
+			return sessionName + ":" + windowID
+		}
+	}
+	return ""
+}
+
+// findOrCreateDaemonWindow returns the window ID for task's executor in
+// daemonSession, creating a placeholder window if none exists. Mirrors
+// detail.go's findOrCreateTaskWindow.
+func findOrCreateDaemonWindow(ctx context.Context, database *db.DB, task *db.Task, daemonSession, workdir string) string {
+	windowName := executor.TmuxWindowName(task.ID)
+	// Priority 1: stored window ID if still valid.
+	if task.TmuxWindowID != "" {
+		out, err := osExec.CommandContext(ctx, "tmux", "display-message", "-t", task.TmuxWindowID, "-p", "#{window_id}").Output()
+		if err == nil && strings.TrimSpace(string(out)) == task.TmuxWindowID {
+			return task.TmuxWindowID
+		}
+		if database != nil {
+			database.UpdateTaskWindowID(task.ID, "")
+		}
+	}
+	// Priority 2: search by name.
+	if out, err := osExec.CommandContext(ctx, "tmux", "list-windows", "-t", daemonSession, "-F", "#{window_id}:#{window_name}").Output(); err == nil {
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 && parts[1] == windowName {
+				if database != nil {
+					database.UpdateTaskWindowID(task.ID, parts[0])
+				}
+				return parts[0]
+			}
+		}
+	}
+	// Priority 3: create placeholder.
+	if err := osExec.CommandContext(ctx, "tmux", "new-window", "-d", "-t", daemonSession+":", "-n", windowName, "-c", workdir, "tail", "-f", "/dev/null").Run(); err != nil {
+		return ""
+	}
+	if out, err := osExec.CommandContext(ctx, "tmux", "list-windows", "-t", daemonSession, "-F", "#{window_id}:#{window_name}").Output(); err == nil {
+		var id string
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 && parts[1] == windowName {
+				id = parts[0]
+			}
+		}
+		if id != "" {
+			if database != nil {
+				database.UpdateTaskWindowID(task.ID, id)
+			}
+			return id
+		}
+	}
+	return ""
+}
+
+// --- controller ---
+
+// joinedState is the volatile state of the currently-joined preview pane.
+// Owned by AppModel; passed into controller ops and returned back so the tea
+// goroutine never mutates AppModel directly.
+type joinedState struct {
+	taskID        int64
+	paneID        string
+	daemonSession string
+	initialWidth  int // executor pane width % captured right after join
+}
+
+// previewResult is returned from controller ops and applied in AppModel.Update.
+type previewResult struct {
+	gen   int // generation that requested this op (for staleness checks)
+	state joinedState
+	err   error
+}
+
+// listExecutorPane joins/breaks a single task's executor pane to the right of
+// the TUI pane in the UI session. Identity/config only; volatile joined state
+// is threaded through method args/returns.
+type listExecutorPane struct {
+	database      *db.DB
+	uiSessionName string
+	tuiPaneID     string
+}
+
+func newListExecutorPane(database *db.DB) *listExecutorPane {
+	return &listExecutorPane{database: database}
+}
+
+// ensureIdentity caches the UI session name and TUI pane id. Call from the main
+// loop (not a goroutine); the active pane is the TUI pane because we always
+// select-pane back to it after every op.
+func (p *listExecutorPane) ensureIdentity() bool {
+	if os.Getenv("TMUX") == "" {
+		return false
+	}
+	if p.uiSessionName == "" {
+		if out, err := osExec.Command("tmux", "display-message", "-p", "#{session_name}").Output(); err == nil {
+			p.uiSessionName = strings.TrimSpace(string(out))
+		}
+	}
+	if p.tuiPaneID == "" {
+		if out, err := osExec.Command("tmux", "display-message", "-p", "#{pane_id}").Output(); err == nil {
+			p.tuiPaneID = strings.TrimSpace(string(out))
+		}
+	}
+	return p.uiSessionName != "" && p.tuiPaneID != ""
+}
+
+func (p *listExecutorPane) widthPref() string {
+	def := "45%"
+	if p.database == nil {
+		return def
+	}
+	v, err := p.database.GetSetting(config.SettingListExecutorPaneWidth)
+	if err != nil || v == "" {
+		return def
+	}
+	return validatePanePct(v, def)
+}
+
+// currentWidthPct returns the joined executor pane's current width as a % of
+// (executor + tui) widths, or 0 on error.
+func (p *listExecutorPane) currentWidthPct(execPaneID string) int {
+	if execPaneID == "" || p.tuiPaneID == "" {
+		return 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ew := tmuxPaneWidth(ctx, execPaneID)
+	tw := tmuxPaneWidth(ctx, p.tuiPaneID)
+	if ew <= 0 || tw <= 0 {
+		return 0
+	}
+	return (ew*100 + (ew+tw)/2) / (ew + tw)
+}
+
+func tmuxPaneWidth(ctx context.Context, paneID string) int {
+	out, err := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "-t", paneID, "#{pane_width}").Output()
+	if err != nil {
+		return 0
+	}
+	w, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0
+	}
+	return w
+}
+
+// saveWidth persists the executor pane width to settings if within [10,90].
+func (p *listExecutorPane) saveWidth(pct int) {
+	if p.database != nil && pct >= 10 && pct <= 90 {
+		p.database.SetSetting(config.SettingListExecutorPaneWidth, strconv.Itoa(pct)+"%")
+	}
+}
+
+// joinRight joins task's executor pane to the right of the TUI pane at the
+// preferred width, then returns focus to the TUI. Returns the new joinedState,
+// or a zeroed state (no error) if the task has no live executor window.
+func (p *listExecutorPane) joinRight(task *db.Task) (joinedState, error) {
+	if task == nil {
+		return joinedState{}, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	target := findTaskWindowTarget(ctx, p.database, task) // "session:windowID" or ""
+	if target == "" {
+		return joinedState{}, nil
+	}
+	daemonSession := target
+	if i := strings.Index(target, ":"); i >= 0 {
+		daemonSession = target[:i]
+	}
+
+	// Choose the source pane: stored Claude pane if still in the window, else first.
+	panesOut, err := osExec.CommandContext(ctx, "tmux", "list-panes", "-t", target, "-F", "#{pane_id}").Output()
+	if err != nil {
+		return joinedState{}, nil
+	}
+	paneIDs := strings.Split(strings.TrimSpace(string(panesOut)), "\n")
+	if len(paneIDs) == 0 || paneIDs[0] == "" {
+		return joinedState{}, nil
+	}
+	src := paneIDs[0]
+	if task.ClaudePaneID != "" {
+		for _, id := range paneIDs {
+			if id == task.ClaudePaneID {
+				src = task.ClaudePaneID
+				break
+			}
+		}
+	}
+
+	// Join to the right of the TUI pane at the preferred width.
+	if err := osExec.CommandContext(ctx, "tmux", "join-pane", "-h", "-l", p.widthPref(), "-s", src, "-t", p.tuiPaneID).Run(); err != nil {
+		return joinedState{}, err
+	}
+	// The joined pane is now active; capture its id.
+	joinedID := src
+	if out, err := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}").Output(); err == nil {
+		joinedID = strings.TrimSpace(string(out))
+	}
+	osExec.CommandContext(ctx, "tmux", "select-pane", "-t", joinedID, "-T", "Executor #"+strconv.FormatInt(task.ID, 10)).Run()
+
+	// Visual affordance + draggable borders, and Shift-arrow focus switching.
+	p.styleAndBind()
+
+	// Return focus to the TUI so list keys keep driving Bubble Tea.
+	osExec.CommandContext(ctx, "tmux", "select-pane", "-t", p.tuiPaneID).Run()
+
+	st := joinedState{taskID: task.ID, paneID: joinedID, daemonSession: daemonSession}
+	st.initialWidth = p.currentWidthPct(joinedID)
+	return st, nil
+}
+
+// breakBack returns the joined executor pane to its daemon window (creating the
+// window if tmux destroyed it when the pane was joined out), preserving the
+// executor process, and resizes the TUI pane back to full width. Persists the
+// width if `save` or the user dragged it. Returns a zeroed joinedState.
+func (p *listExecutorPane) breakBack(prev joinedState, save bool) joinedState {
+	if prev.paneID == "" {
+		p.resizeTuiFull()
+		return joinedState{}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Persist width: always on explicit teardown, otherwise only if dragged.
+	if cur := p.currentWidthPct(prev.paneID); cur > 0 {
+		if save {
+			p.saveWidth(cur)
+		} else if prev.initialWidth > 0 && (cur < prev.initialWidth-2 || cur > prev.initialWidth+2) {
+			p.saveWidth(cur)
+		}
+	}
+
+	// Reset styling/bindings applied at join.
+	p.unbindStyleAndBind()
+
+	daemon := prev.daemonSession
+	if daemon == "" {
+		daemon = executor.TmuxDaemonSession
+	}
+	task := &db.Task{ID: prev.taskID}
+	if p.database != nil {
+		if full, err := p.database.GetTask(prev.taskID); err == nil && full != nil {
+			task = full
+		}
+	}
+	windowID := findOrCreateDaemonWindow(ctx, p.database, task, daemon, p.workdir(task))
+	if windowID == "" {
+		// Could not re-home — DO NOT kill the executor; leave the pane in place.
+		p.resizeTuiFull()
+		return joinedState{}
+	}
+	// Detect a placeholder-only window so we can remove it after joining.
+	paneCountOut, _ := osExec.CommandContext(ctx, "tmux", "display-message", "-t", windowID, "-p", "#{window_panes}").Output()
+	hadPlaceholder := strings.TrimSpace(string(paneCountOut)) == "1"
+
+	if err := osExec.CommandContext(ctx, "tmux", "join-pane", "-d", "-s", prev.paneID, "-t", windowID).Run(); err != nil {
+		// Fallback: break to a fresh window rather than kill the process.
+		osExec.CommandContext(ctx, "tmux", "break-pane", "-d", "-s", prev.paneID, "-t", daemon+":", "-n", executor.TmuxWindowName(prev.taskID)).Run()
+		p.resizeTuiFull()
+		return joinedState{}
+	}
+	if hadPlaceholder {
+		osExec.CommandContext(ctx, "tmux", "kill-pane", "-t", windowID+".0").Run()
+	}
+	p.resizeTuiFull()
+	return joinedState{}
+}
+
+func (p *listExecutorPane) workdir(task *db.Task) string {
+	if task != nil && task.WorktreePath != "" {
+		return task.WorktreePath
+	}
+	return os.Getenv("HOME")
+}
+
+func (p *listExecutorPane) resizeTuiFull() {
+	if p.tuiPaneID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	osExec.CommandContext(ctx, "tmux", "resize-pane", "-t", p.tuiPaneID, "-x", "100%").Run()
+}
+
+// styleAndBind sets draggable heavy borders + Shift-Left/Right pane focus
+// switching (mirrors detail.go). Reset again on breakBack via unbindStyleAndBind.
+func (p *listExecutorPane) styleAndBind() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	s := p.uiSessionName
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-lines", "heavy").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-indicators", "arrows").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-active-border-style", "fg=#61AFEF").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "status-right", " drag border to resize · shift+→ focus executor ").Run()
+	osExec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "S-Right", "select-pane", "-t", ":.+").Run()
+	osExec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "S-Left", "select-pane", "-t", ":.-").Run()
+}
+
+func (p *listExecutorPane) unbindStyleAndBind() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	s := p.uiSessionName
+	osExec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "S-Right").Run()
+	osExec.CommandContext(ctx, "tmux", "unbind-key", "-T", "root", "S-Left").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "status-right", " ").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-lines", "single").Run()
+	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-indicators", "off").Run()
+}

--- a/internal/ui/executor_pane.go
+++ b/internal/ui/executor_pane.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/bborn/workflow/internal/config"
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/executor"
@@ -391,4 +393,87 @@ func (p *listExecutorPane) unbindStyleAndBind() {
 	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "status-right", " ").Run()
 	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-lines", "single").Run()
 	osExec.CommandContext(ctx, "tmux", "set-option", "-t", s, "pane-border-indicators", "off").Run()
+}
+
+// --- AppModel wiring for the list-view executor preview ---
+
+// listPreviewTickMsg fires after the selection-change debounce; gen guards staleness.
+type listPreviewTickMsg struct{ gen int }
+
+// listPreviewUpdatedMsg carries the result of an async preview join/break.
+type listPreviewUpdatedMsg struct{ result previewResult }
+
+// armPreview schedules a debounced preview refresh for the current selection.
+// Returns a Cmd to be batched into the caller's return. No-op outside tmux.
+func (m *AppModel) armPreview() tea.Cmd {
+	if m.listPreview == nil || os.Getenv("TMUX") == "" {
+		return nil
+	}
+	m.previewGen++
+	gen := m.previewGen
+	return tea.Tick(300*time.Millisecond, func(time.Time) tea.Msg {
+		return listPreviewTickMsg{gen: gen}
+	})
+}
+
+// selectedHasExecutor reports whether task t has a live executor window to show.
+func (m *AppModel) selectedHasExecutor(t *db.Task) bool {
+	if t == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return findTaskWindowTarget(ctx, nil, t) != ""
+}
+
+// runPreviewAction dispatches the decided action as an async Cmd (serialized by
+// previewLoading). Call only from Update.
+func (m *AppModel) runPreviewAction(gen int) tea.Cmd {
+	if m.listPreview == nil || !m.listPreview.ensureIdentity() {
+		return nil
+	}
+	sel := m.listView.SelectedTask()
+	var selID int64
+	if sel != nil {
+		selID = sel.ID
+	}
+	action := decidePreviewAction(selID, m.selectedHasExecutor(sel), m.previewJoined.taskID, m.previewVisible)
+	if action == previewNoop {
+		return nil
+	}
+	if m.previewLoading {
+		m.previewDirty = true
+		return nil
+	}
+	m.previewLoading = true
+	prev := m.previewJoined
+	p := m.listPreview
+	switch action {
+	case previewCollapse:
+		return func() tea.Msg {
+			st := p.breakBack(prev, false)
+			return listPreviewUpdatedMsg{result: previewResult{gen: gen, state: st}}
+		}
+	default: // previewSwap
+		return func() tea.Msg {
+			p.breakBack(prev, false) // return the old pane first
+			st, err := p.joinRight(sel)
+			return listPreviewUpdatedMsg{result: previewResult{gen: gen, state: st, err: err}}
+		}
+	}
+}
+
+// teardownPreviewSync breaks the joined executor pane back to its daemon window
+// synchronously (so the executor is re-homed before detail view, board, or
+// quit). Safe to call when nothing is joined.
+func (m *AppModel) teardownPreviewSync(save bool) {
+	if m.listPreview == nil || m.previewJoined.paneID == "" {
+		return
+	}
+	m.listPreview.ensureIdentity()
+	m.listPreview.breakBack(m.previewJoined, save)
+	m.previewJoined = joinedState{}
+	m.previewLoading = false
+	m.previewDirty = false
+	m.previewGen++ // invalidate any in-flight debounce tick
 }

--- a/internal/ui/executor_pane_test.go
+++ b/internal/ui/executor_pane_test.go
@@ -1,0 +1,50 @@
+package ui
+
+import "testing"
+
+func TestDecidePreviewAction(t *testing.T) {
+	cases := []struct {
+		name       string
+		selectedID int64
+		selHasExec bool
+		joinedID   int64
+		visible    bool
+		want       previewAction
+	}{
+		{"hidden, nothing joined", 5, true, 0, false, previewNoop},
+		{"hidden, something joined", 5, true, 5, false, previewCollapse},
+		{"visible, no selection", 0, false, 0, true, previewNoop},
+		{"visible, selected has no executor, none joined", 7, false, 0, true, previewNoop},
+		{"visible, selected has no executor, stale joined", 7, false, 9, true, previewCollapse},
+		{"visible, selected has executor, none joined", 5, true, 0, true, previewSwap},
+		{"visible, selected has executor, different joined", 5, true, 9, true, previewSwap},
+		{"visible, selected has executor, already joined", 5, true, 5, true, previewNoop},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := decidePreviewAction(c.selectedID, c.selHasExec, c.joinedID, c.visible)
+			if got != c.want {
+				t.Fatalf("decidePreviewAction(%d,%v,%d,%v) = %v, want %v",
+					c.selectedID, c.selHasExec, c.joinedID, c.visible, got, c.want)
+			}
+		})
+	}
+}
+
+func TestValidatePanePct(t *testing.T) {
+	cases := []struct{ in, def, want string }{
+		{"", "45%", "45%"},
+		{"garbage", "45%", "45%"},
+		{"45", "45%", "45%"},  // missing %
+		{"5%", "45%", "45%"},  // below min
+		{"95%", "45%", "45%"}, // above max
+		{"30%", "45%", "30%"}, // valid
+		{"90%", "45%", "90%"}, // valid edge
+		{"10%", "45%", "10%"}, // valid edge
+	}
+	for _, c := range cases {
+		if got := validatePanePct(c.in, c.def); got != c.want {
+			t.Fatalf("validatePanePct(%q,%q) = %q, want %q", c.in, c.def, got, c.want)
+		}
+	}
+}

--- a/internal/ui/list_view.go
+++ b/internal/ui/list_view.go
@@ -595,45 +595,47 @@ func (l *ListView) View() string {
 	return lipgloss.NewStyle().Width(l.width).Render(content)
 }
 
-// renderFilterChips renders the sort + filter status bar at the top of the list.
+// renderFilterChips renders a compact summary + hint bar at the top of the list.
+// The summary shows the visible/total count and only the filters that are actually
+// narrowing the list — default ("All"/"Any time") filters and the active sort are
+// omitted as noise, since the column header already shows the sort column + arrow.
 func (l *ListView) renderFilterChips() string {
-	chip := func(label, value string, active bool) string {
-		labelStyle := lipgloss.NewStyle().Foreground(ColorMuted)
-		valStyle := lipgloss.NewStyle().Bold(true)
-		if active {
-			valStyle = valStyle.Foreground(ColorPrimary)
-		} else {
-			valStyle = valStyle.Foreground(ColorSecondary)
-		}
-		return labelStyle.Render(label+": ") + valStyle.Render(value)
+	muted := lipgloss.NewStyle().Foreground(ColorMuted)
+	sep := muted.Render("  ·  ")
+
+	// Count: "N tasks" normally, "M of N" when a filter is hiding rows.
+	total := len(l.allTasks)
+	shown := len(l.rows)
+	countText := fmt.Sprintf("%d tasks", total)
+	if shown != total {
+		countText = fmt.Sprintf("%d of %d", shown, total)
 	}
 
-	arrow := IconArrowUp()
-	if l.sortDesc {
-		arrow = IconArrowDown()
+	// Collect only the filters that differ from their default.
+	var active []string
+	if l.statusIdx != 0 {
+		active = append(active, statusFilterOptions[l.statusIdx].Label)
 	}
-	sortVal := sortColumns[l.sortColIdx].label() + " " + arrow
-
-	projectName := "All"
 	projects := l.projects()
-	if l.projectIdx < len(projects) {
-		projectName = projects[l.projectIdx]
+	if l.projectIdx > 0 && l.projectIdx < len(projects) {
+		active = append(active, projects[l.projectIdx])
+	}
+	if l.dateIdx != 0 {
+		active = append(active, dateFilterOptions[l.dateIdx].Label)
 	}
 
-	chips := []string{
-		chip("Sort", sortVal, true),
-		chip("Status", statusFilterOptions[l.statusIdx].Label, l.statusIdx != 0),
-		chip("Project", projectName, l.projectIdx != 0),
-		chip("Updated", dateFilterOptions[l.dateIdx].Label, l.dateIdx != 0),
-		lipgloss.NewStyle().Foreground(ColorMuted).Render(fmt.Sprintf("(%d)", len(l.rows))),
+	segs := []string{lipgloss.NewStyle().Bold(true).Foreground(ColorSecondary).Render(countText)}
+	activeStyle := lipgloss.NewStyle().Foreground(ColorPrimary)
+	for _, a := range active {
+		segs = append(segs, activeStyle.Render(a))
 	}
-	chipLine := strings.Join(chips, lipgloss.NewStyle().Foreground(ColorMuted).Render("  •  "))
+	summary := strings.Join(segs, sep)
 
-	hint := lipgloss.NewStyle().Foreground(ColorMuted).Italic(true).Render(
+	hint := muted.Italic(true).Render(
 		"←→ sort  ⎵ reverse  [ ] project  { } status  < > date  v board")
 
 	barStyle := lipgloss.NewStyle().Width(l.width).Padding(0, listHPadding)
-	return barStyle.Render(lipgloss.JoinVertical(lipgloss.Left, chipLine, hint))
+	return barStyle.Render(lipgloss.JoinVertical(lipgloss.Left, summary, hint))
 }
 
 // renderColumnHeader renders the underlined column header row, highlighting the

--- a/internal/ui/list_view.go
+++ b/internal/ui/list_view.go
@@ -137,6 +137,16 @@ type ListView struct {
 	runningProcesses  map[int64]bool
 	tasksNeedingInput map[int64]bool
 	blockedByDeps     map[int64]int
+
+	previewHidden bool // true when the live executor preview pane is toggled off
+}
+
+// SetPreviewHidden records whether the live executor preview pane is hidden, so
+// the summary can surface the toggle affordance.
+func (l *ListView) SetPreviewHidden(v bool) {
+	if l != nil {
+		l.previewHidden = v
+	}
 }
 
 // NewListView creates a new list view.
@@ -630,6 +640,9 @@ func (l *ListView) renderFilterChips() string {
 		segs = append(segs, activeStyle.Render(a))
 	}
 	summary := strings.Join(segs, sep)
+	if l.previewHidden {
+		summary += sep + muted.Render("pane hidden (P)")
+	}
 
 	hint := muted.Italic(true).Render(
 		"←→ sort  ⎵ reverse  [ ] project  { } status  < > date  v board")

--- a/internal/ui/list_view.go
+++ b/internal/ui/list_view.go
@@ -95,6 +95,7 @@ type statusFilterOption struct {
 
 var statusFilterOptions = []statusFilterOption{
 	{Label: "All"},
+	{Label: "Active", Statuses: []string{db.StatusQueued, db.StatusProcessing, db.StatusBlocked}},
 	{Label: "Backlog", Statuses: []string{db.StatusBacklog}},
 	{Label: "In Progress", Statuses: []string{db.StatusQueued, db.StatusProcessing}},
 	{Label: "Blocked", Statuses: []string{db.StatusBlocked}},

--- a/internal/ui/list_view_test.go
+++ b/internal/ui/list_view_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -137,6 +138,32 @@ func TestListViewActiveStatusFilter(t *testing.T) {
 		if !want[id] {
 			t.Fatalf("active filter unexpectedly included task %d (rows %v)", id, got)
 		}
+	}
+}
+
+func TestListViewSummaryShowsActiveFiltersOnly(t *testing.T) {
+	l := NewListView(120, 30)
+	l.SetTasks(makeListTasks())
+
+	// At defaults the summary is just the count — no "All"/"Any time" noise.
+	out := l.View()
+	if !strings.Contains(out, "4 tasks") {
+		t.Fatalf("expected '4 tasks' summary at defaults, got:\n%s", out)
+	}
+	if strings.Contains(out, "All") {
+		t.Fatalf("default filters should be hidden, but 'All' appeared:\n%s", out)
+	}
+
+	// Once a filter is active it appears, and the count switches to "M of N".
+	for statusFilterOptions[l.statusIdx].Label != "Active" {
+		l.CycleStatusFilter(1)
+	}
+	out = l.View()
+	if !strings.Contains(out, "Active") {
+		t.Fatalf("expected 'Active' filter in summary, got:\n%s", out)
+	}
+	if !strings.Contains(out, "of 4") {
+		t.Fatalf("expected 'of 4' count when filtered, got:\n%s", out)
 	}
 }
 

--- a/internal/ui/list_view_test.go
+++ b/internal/ui/list_view_test.go
@@ -81,6 +81,20 @@ func TestListViewStatusFilter(t *testing.T) {
 	l := NewListView(120, 30)
 	l.SetTasks(makeListTasks())
 
+	// Cycle status filter forward to "Active" (queued/processing/blocked).
+	l.CycleStatusFilter(1)
+	if statusFilterOptions[l.statusIdx].Label != "Active" {
+		t.Fatalf("expected Active filter, got %q", statusFilterOptions[l.statusIdx].Label)
+	}
+	if got := rowIDs(l); len(got) != 2 {
+		t.Fatalf("active filter rows = %v, want 2 rows (blocked + processing)", got)
+	}
+	for _, id := range rowIDs(l) {
+		if id != 3 && id != 4 { // Charlie (blocked), Delta (processing)
+			t.Fatalf("active filter unexpectedly included task %d", id)
+		}
+	}
+
 	// Cycle status filter forward to "Backlog".
 	l.CycleStatusFilter(1)
 	if statusFilterOptions[l.statusIdx].Label != "Backlog" {
@@ -97,6 +111,32 @@ func TestListViewStatusFilter(t *testing.T) {
 	}
 	if got := rowIDs(l); len(got) != 1 || got[0] != 4 {
 		t.Fatalf("in-progress filter rows = %v, want [4]", got)
+	}
+}
+
+func TestListViewActiveStatusFilter(t *testing.T) {
+	l := NewListView(120, 30)
+	// Add a queued task so Active covers all three of its statuses.
+	tasks := makeListTasks()
+	now := time.Now()
+	tasks = append(tasks, &db.Task{ID: 5, Title: "Echo", Status: db.StatusQueued, Project: "proj-a", CreatedAt: lt(now.Add(-4 * time.Hour)), UpdatedAt: lt(now.Add(-4 * time.Hour))})
+	l.SetTasks(tasks)
+
+	// Select the Active filter directly.
+	for statusFilterOptions[l.statusIdx].Label != "Active" {
+		l.CycleStatusFilter(1)
+	}
+
+	// Active = queued (5) + processing (4) + blocked (3); excludes backlog (1) and done (2).
+	got := rowIDs(l)
+	if len(got) != 3 {
+		t.Fatalf("active filter rows = %v, want 3 rows", got)
+	}
+	want := map[int64]bool{3: true, 4: true, 5: true}
+	for _, id := range got {
+		if !want[id] {
+			t.Fatalf("active filter unexpectedly included task %d (rows %v)", id, got)
+		}
 	}
 }
 

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -19,10 +19,22 @@ Everything is namespaced off two env vars (set automatically by `lib.sh`):
 | | live instance | this harness |
 |---|---|---|
 | DB (`WORKTREE_DB_PATH`) | `~/.local/share/task/tasks.db` | `/tmp/ty-qa/tasks.db` |
-| tmux (`WORKTREE_SESSION_ID`) | pid-based | `task-{ui,daemon}-qa` |
+| tmux **server** | default socket | dedicated socket `tmux -L taskyou-qa-qa` |
+| tmux sessions (`WORKTREE_SESSION_ID`) | pid-based | `task-{ui,daemon}-qa` |
 | projects (`projects_dir`) | `~/Projects` | `/tmp/ty-qa/projects` |
 
 Override location/id with `TY_QA_ROOT` and `TY_QA_SID`.
+
+> **Isolation is critical — the harness runs on its own tmux server.** ty issues
+> raw `tmux` commands (join-pane, break-pane, and the **server-global**
+> `bind-key -T root`). If the harness shared the default tmux server with your
+> live ty daemon, a QA run could clobber the live instance's panes and root
+> key-bindings. So the harness uses a dedicated socket (`qtmux()` in `lib.sh` =
+> `tmux -L "$TY_QA_TMUX_SOCKET"`), and launches ty via `qtmux` so ty inherits
+> `$TMUX` and routes *its own* tmux calls to the same isolated server. Always use
+> `qtmux`, never bare `tmux`, in the harness. (`ty-qa-shoot.sh` is also safe: it
+> sets `TMUX=vhs`, a non-existent socket, so ty's tmux calls error out harmlessly
+> instead of reaching any real server.)
 
 ## Quickstart
 
@@ -36,7 +48,8 @@ scripts/qa/ty-qa-capture.sh            # or eyeball the rendered screen
 scripts/qa/ty-qa-down.sh               # stop (add --purge to delete the DB)
 ```
 
-To watch live while scripting: `tmux attach -t task-ui-qa`.
+To watch live while scripting: `tmux -L taskyou-qa-qa attach -t task-ui-qa`
+(the harness runs on its own tmux socket — bare `tmux attach` won't find it).
 
 ## Asserting state
 

--- a/scripts/qa/lib.sh
+++ b/scripts/qa/lib.sh
@@ -21,6 +21,16 @@ TY_UI_SESSION="task-ui-$TY_QA_SID"
 TY_DAEMON_SESSION="task-daemon-$TY_QA_SID"
 TY_UI_PANE="$TY_UI_SESSION:tui"
 
+# CRITICAL ISOLATION: the harness runs on its OWN tmux server (a dedicated
+# socket), never the default server the live ty instance/daemon use. ty launched
+# via qtmux inherits $TMUX pointing at this socket, so even ty's own bare `tmux`
+# calls — join-pane, break-pane, and especially the server-global `bind-key -T
+# root` — land on THIS server only. Using the default server here would let QA
+# clobber the live instance's panes and root key-bindings. Always use `qtmux`
+# (never bare `tmux`) in the harness, and launch ty via `qtmux`.
+export TY_QA_TMUX_SOCKET="${TY_QA_TMUX_SOCKET:-taskyou-qa-$TY_QA_SID}"
+qtmux() { tmux -L "$TY_QA_TMUX_SOCKET" "$@"; }
+
 # Run the isolated binary with the instance env.
 ty() { "$TY_BIN" "$@"; }
 

--- a/scripts/qa/ty-qa-agent.sh
+++ b/scripts/qa/ty-qa-agent.sh
@@ -24,24 +24,24 @@ git -C "$PROJECT_PATH" worktree remove --force "$WT" 2>/dev/null || true
 git -C "$PROJECT_PATH" worktree add -q "$WT" -b "qa-$TASK_ID" 2>/dev/null \
   || git -C "$PROJECT_PATH" worktree add -q "$WT"
 
-tmux has-session -t "$TY_DAEMON_SESSION" 2>/dev/null \
-  || tmux new-session -d -s "$TY_DAEMON_SESSION" -n _placeholder "tail -f /dev/null"
-tmux kill-window -t "$WIN" 2>/dev/null || true
+qtmux has-session -t "$TY_DAEMON_SESSION" 2>/dev/null \
+  || qtmux new-session -d -s "$TY_DAEMON_SESSION" -n _placeholder "tail -f /dev/null"
+qtmux kill-window -t "$WIN" 2>/dev/null || true
 
 runner="$TY_QA_ROOT/agent-$TASK_ID.sh"
 printf '#!/usr/bin/env bash\ncd %q\nexec %s\n' "$WT" "$AGENT_CMD" > "$runner"
 chmod +x "$runner"
 
-tmux new-window -d -t "$TY_DAEMON_SESSION" -n "task-$TASK_ID" -c "$WT" "bash $runner"
+qtmux new-window -d -t "$TY_DAEMON_SESSION" -n "task-$TASK_ID" -c "$WT" "bash $runner"
 sleep 6
-tmux send-keys -t "$WIN.0" Enter   # accept Claude folder-trust prompt if shown
+qtmux send-keys -t "$WIN.0" Enter   # accept Claude folder-trust prompt if shown
 sleep 6
-tmux split-window -h -t "$WIN.0" -c "$WT" "${SHELL:-/bin/zsh}"
+qtmux split-window -h -t "$WIN.0" -c "$WT" "${SHELL:-/bin/zsh}"
 sleep 1
 
-CLAUDE_PANE=$(tmux display-message -t "$WIN.0" -p '#{pane_id}')
-SHELL_PANE=$(tmux display-message -t "$WIN.1" -p '#{pane_id}')
-WIN_ID=$(tmux display-message -t "$WIN" -p '#{window_id}')
+CLAUDE_PANE=$(qtmux display-message -t "$WIN.0" -p '#{pane_id}')
+SHELL_PANE=$(qtmux display-message -t "$WIN.1" -p '#{pane_id}')
+WIN_ID=$(qtmux display-message -t "$WIN" -p '#{window_id}')
 
 sqlite3 "$WORKTREE_DB_PATH" "UPDATE tasks SET \
   status='processing', worktree_path='$WT', daemon_session='$TY_DAEMON_SESSION', \

--- a/scripts/qa/ty-qa-capture.sh
+++ b/scripts/qa/ty-qa-capture.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 if [[ -n "${1:-}" ]]; then
-  tmux capture-pane -t "$TY_UI_PANE" -p -S "-$1" | sed 's/[[:space:]]*$//'
+  qtmux capture-pane -t "$TY_UI_PANE" -p -S "-$1" | sed 's/[[:space:]]*$//'
 else
-  tmux capture-pane -t "$TY_UI_PANE" -p | sed 's/[[:space:]]*$//'
+  qtmux capture-pane -t "$TY_UI_PANE" -p | sed 's/[[:space:]]*$//'
 fi

--- a/scripts/qa/ty-qa-down.sh
+++ b/scripts/qa/ty-qa-down.sh
@@ -6,8 +6,10 @@
 set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
-tmux kill-session -t "$TY_UI_SESSION" 2>/dev/null || true
-tmux kill-session -t "$TY_DAEMON_SESSION" 2>/dev/null || true
+qtmux kill-session -t "$TY_UI_SESSION" 2>/dev/null || true
+qtmux kill-session -t "$TY_DAEMON_SESSION" 2>/dev/null || true
+# Kill the whole isolated tmux server (it only ever hosts this qa instance).
+qtmux kill-server 2>/dev/null || true
 
 if [[ -d "$TY_QA_PROJECTS" ]]; then
   for p in "$TY_QA_PROJECTS"/*/; do

--- a/scripts/qa/ty-qa-firstrun.sh
+++ b/scripts/qa/ty-qa-firstrun.sh
@@ -9,7 +9,7 @@
 # card runs a real `claude -p` inference (needs claude on PATH), so allow ~15s.
 #
 # Usage: scripts/qa/ty-qa-firstrun.sh
-#        tmux attach -t task-ui-<sid>   # to watch / drive manually
+#        tmux -L "$TY_QA_TMUX_SOCKET" attach -t task-ui-<sid>   # watch / drive manually
 #        scripts/qa/ty-qa-down.sh       # tear down
 set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
@@ -36,13 +36,13 @@ printf '{"name":"marker-pkg"}\n' > "$MARKER/package.json"
 # C) PLAIN stays empty -> not a candidate -> Welcome fork
 
 launch() { # $1 = cwd
-  tmux kill-session -t "$SID" 2>/dev/null || true
+  qtmux kill-session -t "$SID" 2>/dev/null || true
   rm -f "$WORKTREE_DB_PATH" "$TY_QA_STATE"   # fresh DB => true first run
-  tmux new-session -d -s "$SID" -x "${TY_QA_COLS:-220}" -y "${TY_QA_ROWS:-50}" -n tui -c "$1" \
+  qtmux new-session -d -s "$SID" -x "${TY_QA_COLS:-220}" -y "${TY_QA_ROWS:-50}" -n tui -c "$1" \
     "WORKTREE_DB_PATH='$WORKTREE_DB_PATH' WORKTREE_SESSION_ID='$WORKTREE_SESSION_ID' '$TY_BIN' --debug-state-file '$TY_QA_STATE'"
 }
 
-cap() { tmux capture-pane -t "${SID}:tui" -p | sed 's/[[:space:]]*$//' | grep -v '^[[:space:]]*$'; }
+cap() { qtmux capture-pane -t "${SID}:tui" -p | sed 's/[[:space:]]*$//' | grep -v '^[[:space:]]*$'; }
 
 echo; echo "### Scenario A: git repo -> enriched suggestion card (inference, ~15s)"
 launch "$GITPROJ"; sleep 16; cap | head -22
@@ -56,7 +56,7 @@ launch "$PLAIN"; sleep 6; cap | head -18
 cat <<EOF
 
 ==> Drive manually from here:
-    tmux attach -t $SID
+    tmux -L $TY_QA_TMUX_SOCKET attach -t $SID
     Welcome fork:  enter = Set up a project (-> fuzzy folder picker), →/enter = Just start a task
     Folder picker: type to fuzzy-filter, ↑↓ select, → descend, enter pick, esc back
     Suggestion card: y = Create Project, n = Not Now

--- a/scripts/qa/ty-qa-key.sh
+++ b/scripts/qa/ty-qa-key.sh
@@ -15,5 +15,5 @@ if [[ $# -eq 0 ]]; then
   exit 1
 fi
 
-tmux send-keys -t "$TY_UI_PANE" "$@"
+qtmux send-keys -t "$TY_UI_PANE" "$@"
 sleep "${TY_QA_KEY_DELAY:-0.4}"

--- a/scripts/qa/ty-qa-shoot.sh
+++ b/scripts/qa/ty-qa-shoot.sh
@@ -6,6 +6,9 @@
 # captures. VHS runs the TUI in its own correctly-sized headless terminal, so
 # the screenshot matches what real users see. ty renders in-pane (runLocal)
 # whenever $TMUX is set, so we set a dummy TMUX and don't need a real tmux here.
+# Isolation note: TMUX="vhs" points at a non-existent socket, so any tmux call ty
+# makes (join-pane, bind-key -T root, …) errors out harmlessly — it can NEVER
+# reach the live default tmux server.
 #
 # Usage:
 #   ty-qa-shoot.sh <cwd> <out.png> [<vhs-line> ...]

--- a/scripts/qa/ty-qa-tui.sh
+++ b/scripts/qa/ty-qa-tui.sh
@@ -10,16 +10,18 @@ ty_qa_require_built
 COLS="${TY_QA_COLS:-230}"
 ROWS="${TY_QA_ROWS:-55}"
 
-tmux kill-session -t "$TY_UI_SESSION" 2>/dev/null || true
+qtmux kill-session -t "$TY_UI_SESSION" 2>/dev/null || true
 
-# Inside tmux, TMUX is set automatically, so ty runs the bubbletea TUI in-pane (runLocal).
+# Launch on the isolated qa tmux server (qtmux). Inside tmux, TMUX is set
+# automatically, so ty runs the bubbletea TUI in-pane (runLocal) AND inherits
+# this socket for all its own tmux calls — fully isolated from the live server.
 # --debug-state-file dumps UI state as JSON on every update for assertions.
-tmux new-session -d -s "$TY_UI_SESSION" -x "$COLS" -y "$ROWS" -n tui \
+qtmux new-session -d -s "$TY_UI_SESSION" -x "$COLS" -y "$ROWS" -n tui \
   "WORKTREE_DB_PATH='$WORKTREE_DB_PATH' WORKTREE_SESSION_ID='$WORKTREE_SESSION_ID' '$TY_BIN' --debug-state-file '$TY_QA_STATE'"
 
 sleep 4
-echo "==> TUI running: session '$TY_UI_SESSION', pane '$TY_UI_PANE'"
-echo "    attach : tmux attach -t $TY_UI_SESSION"
+echo "==> TUI running: session '$TY_UI_SESSION', pane '$TY_UI_PANE' (tmux -L $TY_QA_TMUX_SOCKET)"
+echo "    attach : tmux -L $TY_QA_TMUX_SOCKET attach -t $TY_UI_SESSION"
 echo "    drive  : scripts/qa/ty-qa-key.sh <keys>"
 echo "    state  : scripts/qa/ty-qa-state.sh"
 echo "    view   : scripts/qa/ty-qa-capture.sh"


### PR DESCRIPTION
This branch grows the dashboard **list view** (task #4196) across three changes, smallest to largest.

## 1. `Active` status filter
The Status filter chip gains an **Active** option = `queued` + `processing` + `blocked` (in‑progress *plus* blocked) — everything in flight or needing attention, minus backlog/done. Order: `All → Active → Backlog → In Progress → Blocked → Done`. The existing granular filters are unchanged.

## 2. Decluttered header
The old header stacked a busy chips line (`Sort … • Status: All • Project: All • Updated: 30 days • (42)`) above a hint line. It's now a single compact summary showing **only what's meaningful** — the count (`N tasks`, or `M of N` when filtered) plus the filters actually narrowing the list. The active sort is dropped from the summary (the column header already shows it via the `↓`/`↑` arrow). Filter‑bar hint shortened to `(esc to clear)`.

## 3. Live executor pane
With a row selected in the list, that task's **live, interactive executor tmux pane** is shown on the right — list on the left, the real executor on the right.

- **Debounced + serialized:** moving the selection arms a 300 ms debounce (generation‑guarded); the join/break runs async behind a single in‑flight flag, re‑queued if a newer request arrives. Rapid arrowing doesn't thrash tmux.
- **Adaptive:** tasks with no live executor collapse the pane to a full‑width list; `P` toggles the pane off (`pane hidden (P)` affordance in the summary).
- **Draggable + persisted:** drag the border to resize; the width is saved to a new `list_executor_pane_width` setting (default 45%), mirroring the detail view's pattern.
- **Never kills the executor:** explicit transitions (Enter→detail, `v`→board, `P` hide, quit) break the pane **back to its daemon window synchronously** before anything else touches the UI session — important because the detail view kills non‑TUI panes on entry. Verified the executor process survives every teardown path.
- Bubble Tea doesn't render the executor — tmux owns that pane; the list simply re‑renders at the narrower width.

Focus stays on the list after a join (keys keep driving Bubble Tea); `Shift‑→` focuses the executor to interact, `Shift‑←` returns.

### Design & plan
- Spec: `docs/superpowers/specs/2026-06-07-list-view-executor-pane-design.md`
- Plan: `docs/superpowers/plans/2026-06-07-list-view-executor-pane.md`

## QA (isolated `ty` TUI harness, real tmux)
- Join on a running task; collapse on a no‑executor task; swap between tasks — all correct (`preview_joined_task_id` asserts).
- **Executor survives** toggle‑to‑board, Enter→detail handoff, and `P` hide (process alive, re‑homed to the daemon window).
- No spurious join for no‑executor selections; no thrash on rapid navigation.

**List view + live executor pane (selected task running):**
![exec-split](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-06-07/564-exec-split.png)

**Selected task has no executor → full‑width list:**
![exec-collapsed](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-06-07/564-exec-collapsed.png)

## Tests
`go build ./...`, `go vet`, `go test ./internal/ui/ ./internal/config/ ./internal/db/` all green. New unit tests: `decidePreviewAction` truth table, `validatePanePct`, Active‑filter coverage, and the decluttered‑summary regression test. (Pre‑existing `internal/ai`/`internal/autocomplete` failures and the repo's `govulncheck` CI job are unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
