### PR TITLE
fix(cli): make `ty input` submit by default

### DIFF
--- a/cmd/task/cli_test.go
+++ b/cmd/task/cli_test.go
@@ -1804,3 +1804,32 @@ func TestFormatPermissionDetail(t *testing.T) {
 		})
 	}
 }
+
+// TestShouldSubmitInput verifies the submit decision used by `task input`:
+// by default a non-empty message is submitted (Enter pressed), --no-submit
+// leaves it in the field, and --enter always submits.
+func TestShouldSubmitInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   string
+		justEnter bool
+		noSubmit  bool
+		want      bool
+	}{
+		{name: "message submits by default", message: "yes", want: true},
+		{name: "message with --no-submit stays in field", message: "yes", noSubmit: true, want: false},
+		{name: "--enter alone submits", justEnter: true, want: true},
+		{name: "--enter wins over --no-submit", justEnter: true, noSubmit: true, want: true},
+		{name: "empty message does not submit", message: "", want: false},
+		{name: "empty message with --no-submit does not submit", message: "", noSubmit: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSubmitInput(tt.message, tt.justEnter, tt.noSubmit); got != tt.want {
+				t.Errorf("shouldSubmitInput(%q, %v, %v) = %v, want %v",
+					tt.message, tt.justEnter, tt.noSubmit, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -1838,13 +1838,18 @@ Examples:
 This allows you to interact with a blocked or running task without going through
 the retry mechanism. The input is sent directly to the executor's tmux pane.
 
+By default the message is submitted (Enter is pressed after the text), so the
+agent actually receives it. Pass --no-submit to only drop the text in the input
+field without submitting it.
+
 If no message is provided, reads from stdin (useful for piping).
 Use --enter to just send Enter (for confirming TUI prompts).
 Use --key to send special keys like "Up", "Down", "Tab", "Escape".
 
 Examples:
-  task input 42 "yes"
+  task input 42 "yes"                # Type "yes" and submit
   task input 42 "Try a different approach"
+  task input 42 "draft text" --no-submit   # Fill the field, don't submit
   task input 42 --enter              # Just press Enter
   task input 42 --key Down --enter   # Press Down then Enter
   echo "continue" | task input 42`,
@@ -1858,6 +1863,7 @@ Examples:
 
 			justEnter, _ := cmd.Flags().GetBool("enter")
 			specialKey, _ := cmd.Flags().GetString("key")
+			noSubmit, _ := cmd.Flags().GetBool("no-submit")
 
 			var message string
 			if len(args) > 1 {
@@ -1915,14 +1921,26 @@ Examples:
 				}
 			}
 
-			// Send message if provided, or just Enter if --enter flag
+			// Send the message text (literally, so a message that looks like a tmux
+			// key name such as "Enter" or "Up" isn't interpreted as a keypress).
 			if message != "" {
-				sendCmd := osexec.Command("tmux", "send-keys", "-t", paneID, message, "Enter")
+				sendCmd := osexec.Command("tmux", "send-keys", "-t", paneID, "-l", message)
 				if err := sendCmd.Run(); err != nil {
 					fmt.Fprintln(os.Stderr, errorStyle.Render(fmt.Sprintf("Error sending input to pane %s (task may have finished): %v", paneID, err)))
 					os.Exit(1)
 				}
-			} else if justEnter {
+			}
+
+			// Submit by pressing Enter unless --no-submit was passed. Enter is sent
+			// as a SEPARATE keypress after the text: agentic TUIs (Claude Code, etc.)
+			// use bracketed-paste / input debouncing, so an Enter bundled into the
+			// same send-keys call as the text gets absorbed as a newline instead of
+			// submitting. The brief pause lets the TUI register the text first.
+			submit := shouldSubmitInput(message, justEnter, noSubmit)
+			if submit {
+				if message != "" {
+					time.Sleep(100 * time.Millisecond)
+				}
 				sendCmd := osexec.Command("tmux", "send-keys", "-t", paneID, "Enter")
 				if err := sendCmd.Run(); err != nil {
 					fmt.Fprintln(os.Stderr, errorStyle.Render(fmt.Sprintf("Error sending Enter to pane %s (task may have finished): %v", paneID, err)))
@@ -1930,11 +1948,16 @@ Examples:
 				}
 			}
 
-			fmt.Println(successStyle.Render(fmt.Sprintf("Sent input to task #%d", taskID)))
+			if message != "" && !submit {
+				fmt.Println(successStyle.Render(fmt.Sprintf("Sent input to task #%d (not submitted)", taskID)))
+			} else {
+				fmt.Println(successStyle.Render(fmt.Sprintf("Sent input to task #%d", taskID)))
+			}
 		},
 	}
 	inputCmd.Flags().Bool("enter", false, "Just send Enter key (for confirming prompts)")
 	inputCmd.Flags().String("key", "", "Send a special key (e.g., Up, Down, Tab, Escape)")
+	inputCmd.Flags().Bool("no-submit", false, "Type the text but don't press Enter (leave it in the input field)")
 	rootCmd.AddCommand(inputCmd)
 
 	// Pi Wrapper subcommand - internal use for RPC mode
@@ -4226,6 +4249,17 @@ func formatToolLogMessage(input *ClaudeHookInput) string {
 
 	// Default: just the tool name
 	return toolName
+}
+
+// shouldSubmitInput decides whether `task input` should press Enter after the
+// text. By default a message is submitted so the agent actually receives it;
+// --no-submit leaves the text in the input field without submitting. The
+// --enter flag (justEnter) always submits, since pressing Enter is its purpose.
+func shouldSubmitInput(message string, justEnter, noSubmit bool) bool {
+	if justEnter {
+		return true
+	}
+	return message != "" && !noSubmit
 }
 
 // formatPermissionDetail extracts a short detail string from the tool input


### PR DESCRIPTION
## Problem

`ty input <task-id> "message"` appeared to "just drop the text in the field" without submitting it — agent CLI users would type input and then forget to press submit, so the running agent never actually received the message.

The root cause: the command crammed the message text and `Enter` into a **single** `tmux send-keys` call:

```go
osexec.Command("tmux", "send-keys", "-t", paneID, message, "Enter")
```

Agentic TUIs like Claude Code (and Codex) use bracketed-paste / input debouncing. When the `Enter` arrives in the same terminal write as the pasted text, the TUI absorbs it as a *newline inside the textarea* rather than a submit. The text sits in the input box and nothing happens.

## Fix

Send the input in the same robust way the existing `executor.SendLiteralTextToPane` helper does:

1. Send the message text first, with the `-l` (literal) flag — so a message that happens to look like a tmux key name (`"Enter"`, `"Up"`, `"Space"`) is typed as text instead of interpreted as a keypress.
2. Pause briefly (100ms) so the TUI registers the pasted text.
3. Send `Enter` as a **separate** keypress to actually submit.

So `ty input 42 "yes"` now types **and submits** by default — which is what users expect.

### New `--no-submit` flag

For the cases where you genuinely want to stage text in the field without submitting (e.g. pre-filling a draft), pass `--no-submit`:

```
ty input 42 "draft text" --no-submit   # fills the field, does not press Enter
```

The success message reflects this: `Sent input to task #42 (not submitted)`.

## Notes
- The submit decision is extracted into a pure `shouldSubmitInput` helper and unit-tested.
- `--enter` still always submits (pressing Enter is its whole purpose); `--key` behavior is unchanged.

## Testing
- `go build ./...` ✅
- `go test ./cmd/task/ -run TestShouldSubmitInput` ✅ (6 cases: default-submit, `--no-submit`, `--enter`, precedence, empty message)
- Verified `ty input --help` shows the new flag and updated examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)