### PR TITLE
Fix executor pane auto-display after task creation

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -100,6 +100,13 @@ type DetailModel struct {
 	paneLoadingStart time.Time // when loading started (for spinner animation)
 	paneError        string    // user-visible error when panes fail to open
 
+	// waitingForExecutor is true when we're passively waiting for the daemon's
+	// executor to create the tmux window (e.g. a freshly created+queued task with
+	// no worktree yet). In this mode we still show the loading spinner, but unlike
+	// active async setup (startPanesAsync/restartForExecutorSwitch) we want
+	// ensureTmuxPanesJoined to keep polling and join the panes as soon as they exist.
+	waitingForExecutor bool
+
 	// Focus executor pane after joining (e.g., when jumping from kanban)
 	focusExecutorOnJoin bool
 
@@ -524,6 +531,7 @@ func NewDetailModel(t *db.Task, database *db.DB, exec *executor.Executor, width,
 	if t.Status == db.StatusQueued && t.WorktreePath == "" {
 		log.Info("NewDetailModel: task is queued without worktree, waiting for executor")
 		m.paneLoading = true
+		m.waitingForExecutor = true
 		m.paneLoadingStart = time.Now()
 		// Don't start panes, just show loading spinner and let ensureTmuxPanesJoined
 		// pick up the panes once executor creates them
@@ -651,6 +659,7 @@ func (m *DetailModel) Update(msg tea.Msg) (*DetailModel, tea.Cmd) {
 		// Async pane setup completed
 		log := GetLogger()
 		m.paneLoading = false
+		m.waitingForExecutor = false
 		if msg.err != nil {
 			log.Error("panesJoinedMsg: error=%v", msg.err)
 			m.paneError = msg.userMessage
@@ -974,6 +983,20 @@ func (m *DetailModel) refreshTmuxWindowTarget() bool {
 	return m.cachedWindowTarget != ""
 }
 
+// paneJoinBlockedByLoad reports whether ensureTmuxPanesJoined should stay out of
+// the way because another code path is actively setting up the panes.
+//
+// paneLoading is set both during active async setup (startPanesAsync /
+// restartForExecutorSwitch, which start a session in a goroutine and report back
+// via panesJoinedMsg) and while passively waiting for the daemon's executor to
+// create the window (a freshly created+queued task with no worktree yet). In the
+// passive case (waitingForExecutor) we must keep polling so the executor pane
+// shows up automatically — otherwise it only appears after leaving and re-entering
+// the detail view.
+func (m *DetailModel) paneJoinBlockedByLoad() bool {
+	return m.paneLoading && !m.waitingForExecutor
+}
+
 // ensureTmuxPanesJoined checks if tmux panes should be joined and joins them if needed.
 // This handles cases where panes were externally closed or a session was created after opening the view.
 func (m *DetailModel) ensureTmuxPanesJoined() {
@@ -981,8 +1004,12 @@ func (m *DetailModel) ensureTmuxPanesJoined() {
 		return
 	}
 
-	// Don't interfere while an executor switch or async pane setup is in progress
-	if m.paneLoading {
+	// Don't interfere while an executor switch or active async pane setup is in
+	// progress (startPanesAsync/restartForExecutorSwitch start the session in a
+	// goroutine and report back via panesJoinedMsg). When we're merely waiting for
+	// the daemon's executor to create the window, keep polling so we can join the
+	// panes as soon as they appear.
+	if m.paneJoinBlockedByLoad() {
 		return
 	}
 
@@ -1018,6 +1045,7 @@ func (m *DetailModel) ensureTmuxPanesJoined() {
 		// If join succeeded, clear the loading state
 		if m.claudePaneID != "" {
 			m.paneLoading = false
+			m.waitingForExecutor = false
 			m.paneError = ""
 		}
 	}

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -101,6 +101,51 @@ func TestNewDetailModel_ArchivedTaskSkipsAutoExecutor(t *testing.T) {
 	}
 }
 
+// TestPaneJoinBlockedByLoad verifies that ensureTmuxPanesJoined keeps polling for
+// panes while we're passively waiting for the daemon's executor to create the
+// window, but stays out of the way during active async pane setup.
+//
+// Regression: a freshly created + queued task (no worktree yet) entered the detail
+// view with paneLoading=true and relied on ensureTmuxPanesJoined to join the panes
+// once the executor created them — but the loading guard short-circuited, so the
+// executor pane never appeared until the user left and re-entered the view.
+func TestPaneJoinBlockedByLoad(t *testing.T) {
+	tests := []struct {
+		name               string
+		paneLoading        bool
+		waitingForExecutor bool
+		wantBlocked        bool
+	}{
+		{
+			name:        "idle: not blocked",
+			wantBlocked: false,
+		},
+		{
+			name:        "active async setup blocks polling",
+			paneLoading: true,
+			wantBlocked: true,
+		},
+		{
+			name:               "passively waiting for executor keeps polling",
+			paneLoading:        true,
+			waitingForExecutor: true,
+			wantBlocked:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &DetailModel{
+				paneLoading:        tt.paneLoading,
+				waitingForExecutor: tt.waitingForExecutor,
+			}
+			if got := m.paneJoinBlockedByLoad(); got != tt.wantBlocked {
+				t.Errorf("paneJoinBlockedByLoad() = %v, want %v", got, tt.wantBlocked)
+			}
+		})
+	}
+}
+
 // TestPercentageCalculationRounding verifies that percentage calculations
 // use proper rounding to avoid the progressive shrinking bug.
 // Without rounding, integer division truncates: (16 * 100) / 81 = 19 instead of 20


### PR DESCRIPTION
## Problem

After creating a task and executing it, the executor pane did not show up automatically — you had to exit the task detail view and re-enter it before the pane appeared.

## Root cause

When a task is created and queued for execution, opening its detail view hits the "queued without worktree" branch in `NewDetailModel` (the daemon hasn't created the worktree/window yet). That branch sets `paneLoading = true` and returns just a spinner, with a comment promising that `ensureTmuxPanesJoined` will *"pick up the panes once executor creates them."*

But `ensureTmuxPanesJoined` early-returns whenever `paneLoading` is true:

```go
if m.paneLoading {
    return
}
```

So it never actually polls for or joins the panes while in this waiting state. Only when you leave and re-enter does `NewDetailModel` run again, find an active window, and join synchronously.

The real issue is that `paneLoading` is overloaded. It means **two** different things:
1. **Active async setup** (`startPanesAsync` / `restartForExecutorSwitch`) — a goroutine is starting the session and will report results back via `panesJoinedMsg`. Here the poller *must* stay out of the way to avoid races.
2. **Passively waiting** for the daemon's executor to create the window. Here the poller is the *only* thing responsible for joining the panes.

The guard correctly handled case 1 but broke case 2.

## Fix

Introduce a `waitingForExecutor` flag to distinguish the passive-wait case. The join poller now stays out of the way only during active async setup, and keeps polling (and joins the pane as soon as it exists) while passively waiting for the executor:

```go
func (m *DetailModel) paneJoinBlockedByLoad() bool {
    return m.paneLoading && !m.waitingForExecutor
}
```

The spinner still shows during the wait; the flag is cleared once panes join (or async setup completes).

## QA — real TUI, A/B tested

Drove the **real** TUI in an isolated tmux instance (the `scripts/qa` harness) and ran the exact create → execute → open-detail → executor-appears flow against a **before** binary (no fix) and an **after** binary (with fix). Steps: create a task with `--execute` (queued, no worktree), open its detail view, then stand up the executor window (simulating the daemon) and **wait without touching the TUI**.

| | executor window appears | after 6s, no interaction |
|---|---|---|
| **Before (no fix)** | detail shows spinner, `has_panes=false`, 1 pane in `task-ui` | ❌ still 1 pane — pane never displayed |
| **After (fix)** | detail shows spinner, `has_panes=false`, 1 pane in `task-ui` | ✅ 3 panes auto-joined, `has_panes=true` |

Final pane layout in the UI session after the fix (auto-joined, no re-entering the view):

```
pane 0: ty           Task 1: auto pane test (1/1)   <- TUI
pane 1: (executor)   title=Claude                   <- executor pane, auto-displayed
pane 2: zsh          title=Shell                    <- shell pane
```

## Changes

- `internal/ui/detail.go` — add `waitingForExecutor` flag; set it in the queued-without-worktree branch; gate the `ensureTmuxPanesJoined` loading guard behind `paneJoinBlockedByLoad()`; clear the flag when panes join or async setup completes.
- `internal/ui/detail_test.go` — `TestPaneJoinBlockedByLoad` regression test covering idle / active-setup / passive-wait.

`gofmt`, `go vet`, `golangci-lint`, and `go test ./internal/ui/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
