### PR TITLE
perf(ui): make the executor/detail pane open instantly + cache its renders

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -34,6 +34,36 @@ func shouldSkipAutoExecutor(task *db.Task) bool {
 	}
 }
 
+// paneAction describes what the detail view should do for a task that has no
+// existing tmux window when it is opened.
+type paneAction int
+
+const (
+	// paneActionStartExecutor: start a fresh executor session, then join its panes.
+	paneActionStartExecutor paneAction = iota
+	// paneActionSkip: don't start anything (backlog/done/archived tasks).
+	paneActionSkip
+	// paneActionWaitForExecutor: a freshly queued task with no worktree yet — the
+	// daemon's executor will create the window shortly; keep polling for it.
+	paneActionWaitForExecutor
+)
+
+// pendingPaneAction decides what to do when a task has no existing tmux window.
+// Extracted as a pure function (no tmux I/O) so the open-path decision tree can
+// be unit-tested without a running tmux server.
+func pendingPaneAction(task *db.Task) paneAction {
+	if shouldSkipAutoExecutor(task) {
+		return paneActionSkip
+	}
+	// Queued tasks without a worktree are handled by the daemon's executor, which
+	// creates the window. Starting panes here would race it (project dir vs worktree
+	// dir), so we wait and let ensureTmuxPanesJoined pick the panes up.
+	if task.Status == db.StatusQueued && task.WorktreePath == "" {
+		return paneActionWaitForExecutor
+	}
+	return paneActionStartExecutor
+}
+
 // DetailModel represents the task detail view.
 type DetailModel struct {
 	task     *db.Task
@@ -85,12 +115,34 @@ type DetailModel struct {
 	lastRenderedFocused bool
 	cachedContent       string
 
+	// View render cache. View() runs on every Bubble Tea update while the detail
+	// view is open (focus ticks, polls, pane events), but its pixels only change
+	// when an input does. Each call renders the cheap header/help, folds them and
+	// the viewport/scroll/theme state into a signature, and reuses the previously
+	// rendered string when the signature is unchanged — skipping the expensive
+	// viewport.View() + bordered box.Render() (~2ms, ~2.7MB) on idle frames.
+	cachedView    string
+	cachedViewSig uint64
+	cachedViewOK  bool
+
+	// viewportContentVersion bumps whenever the viewport content is (re)set, so the
+	// View render cache knows the body changed even though the viewport value itself
+	// is opaque. Mutated only through setViewportContent.
+	viewportContentVersion uint64
+
 	// Log count tracking for smarter refreshes
 	lastLogCount int
 	logsLoading  bool // true while async log loading is in progress
 
 	// Memory check throttling (don't check every refresh)
 	lastMemoryCheck time.Time
+
+	// Shell process indicator, refreshed on a throttle in Refresh() rather than
+	// queried on every render. HasRunningShellProcess() shells out to tmux, so
+	// calling it from renderHeader() (every frame) meant a synchronous subprocess
+	// on the UI thread per paint. We cache the result and refresh it periodically.
+	hasRunningShellProc  bool
+	lastShellProcessPoll time.Time
 
 	// Pane join check throttling
 	lastPaneCheck time.Time
@@ -133,6 +185,12 @@ type panesJoinedMsg struct {
 	userMessage     string
 	err             error
 }
+
+// paneWaitForExecutorMsg is returned by setupPanesAsync when a freshly queued
+// task has no worktree (and thus no window) yet. It tells the detail view to keep
+// showing the loading spinner and let ensureTmuxPanesJoined poll the executor's
+// panes in once the daemon creates them.
+type paneWaitForExecutorMsg struct{}
 
 // logsLoadedMsg is sent when async log loading completes.
 type logsLoadedMsg struct {
@@ -242,7 +300,7 @@ func (m *DetailModel) UpdateTask(t *db.Task) tea.Cmd {
 
 	m.task = t
 	if m.ready {
-		m.viewport.SetContent(m.renderContent())
+		m.setViewportContent()
 	}
 
 	// Detect executor change — trigger switch if we have an active window
@@ -343,7 +401,7 @@ func (m *DetailModel) SetPosition(position, total int) {
 func (m *DetailModel) SetPRInfo(prInfo *github.PRInfo) {
 	m.prInfo = prInfo
 	if m.ready {
-		m.viewport.SetContent(m.renderContent())
+		m.setViewportContent()
 	}
 }
 
@@ -370,7 +428,7 @@ func (m *DetailModel) Refresh() tea.Cmd {
 			prevTask.Project != m.task.Project ||
 			prevTask.Type != m.task.Type ||
 			prevTask.Title != m.task.Title {
-			m.viewport.SetContent(m.renderContent())
+			m.setViewportContent()
 		}
 	}
 
@@ -413,6 +471,14 @@ func (m *DetailModel) Refresh() tea.Cmd {
 		m.lastServerCheck = time.Now()
 	}
 
+	// Throttle the shell-process indicator check to every 2 seconds. This shells
+	// out to tmux, so we cache the result here instead of querying it from
+	// renderHeader() on every frame.
+	if time.Since(m.lastShellProcessPoll) >= 2*time.Second {
+		m.hasRunningShellProc = m.HasRunningShellProcess()
+		m.lastShellProcessPoll = time.Now()
+	}
+
 	// Throttle pane join checks (runs tmux commands)
 	// Poll faster (1s) while loading to reduce latency for "create and execute" flow,
 	// slower (5s) once panes are established for normal health checks
@@ -439,7 +505,7 @@ func (m *DetailModel) HandleLogsLoaded(msg logsLoadedMsg) {
 		m.logs = msg.logs
 		m.lastLogCount = msg.logCount
 		if m.ready {
-			m.viewport.SetContent(m.renderContent())
+			m.setViewportContent()
 		}
 	}
 }
@@ -495,102 +561,128 @@ func NewDetailModel(t *db.Task, database *db.DB, exec *executor.Executor, width,
 		return m, nil
 	}
 
-	// Get the actual UI session name (avoid prefix-matching wrong session)
-	if out, err := osExec.Command("tmux", "display-message", "-p", "#{session_name}").Output(); err == nil {
-		m.uiSessionName = strings.TrimSpace(string(out))
-	} else {
-		m.uiSessionName = "task-ui" // fallback
-	}
-
-	// Cache the tmux window target once (expensive operation)
-	log.Debug("NewDetailModel: calling findTaskWindow...")
-	m.cachedWindowTarget = m.findTaskWindow()
-	log.Info("NewDetailModel: cachedWindowTarget=%q", m.cachedWindowTarget)
-
-	// Fast path: If task has active session, join it synchronously (already running)
-	if m.cachedWindowTarget != "" {
-		log.Info("NewDetailModel: in tmux with active session, calling joinTmuxPane")
-		m.joinTmuxPane()
-		log.Info("NewDetailModel: after joinTmuxPane, claudePaneID=%q, workdirPaneID=%q",
-			m.claudePaneID, m.workdirPaneID)
-		log.Info("NewDetailModel: completed for task %d", t.ID)
-		return m, nil
-	}
-
-	// Don't auto-start executor for backlog/done/archived tasks
-	// Backlog tasks haven't been queued for execution yet, and done/archived tasks are finished
-	if shouldSkipAutoExecutor(t) {
-		log.Info("NewDetailModel: skipping auto-executor for %s task", t.Status)
-		log.Info("NewDetailModel: completed for task %d", t.ID)
-		return m, nil
-	}
-
-	// Don't start panes for queued tasks without a worktree - let executor handle it
-	// This prevents a race condition where detail view creates panes with project dir,
-	// then executor kills them and creates new panes with worktree dir
-	if t.Status == db.StatusQueued && t.WorktreePath == "" {
-		log.Info("NewDetailModel: task is queued without worktree, waiting for executor")
-		m.paneLoading = true
-		m.waitingForExecutor = true
-		m.paneLoadingStart = time.Now()
-		// Don't start panes, just show loading spinner and let ensureTmuxPanesJoined
-		// pick up the panes once executor creates them
-		return m, m.spinnerTick()
-	}
-
-	// Slow path: No active window - start session asynchronously
-	log.Info("NewDetailModel: no window target, starting async pane setup")
+	// Everything below is tmux I/O: resolving the UI session, searching for the
+	// task's window, and — on the common "executor already running" path — a
+	// ~30-call join/split/select/resize/option dance. Done synchronously here it
+	// froze the Bubble Tea update loop for the entire join, so pressing Enter on
+	// the board stalled before the detail view ever painted. Defer all of it to a
+	// background command: paint the view instantly with a loading spinner, then
+	// drop the panes in when setupPanesAsync reports back via panesJoinedMsg /
+	// paneWaitForExecutorMsg.
 	m.paneLoading = true
 	m.paneError = ""
 	m.paneLoadingStart = time.Now()
-
-	// Return immediately with a command to start panes in background
 	log.Info("NewDetailModel: completed for task %d (async pane setup pending)", t.ID)
-	return m, tea.Batch(m.startPanesAsync(), m.spinnerTick())
+	return m, tea.Batch(m.setupPanesAsync(), m.spinnerTick())
+}
+
+// setupPanesAsync resolves the task's tmux window and joins (or starts) its panes
+// entirely off the UI thread. It mirrors the decision tree that used to run
+// synchronously inside NewDetailModel, but every tmux call now happens in this
+// goroutine so opening the detail view stays instant. Results flow back to the
+// model through panesJoinedMsg / paneWaitForExecutorMsg — matching the existing
+// startPanesAsync contract for goroutine-produced pane state.
+func (m *DetailModel) setupPanesAsync() tea.Cmd {
+	taskID := m.task.ID
+	sessionID := m.task.ClaudeSessionID
+	action := pendingPaneAction(m.task)
+
+	return func() tea.Msg {
+		log := GetLogger()
+		log.Info("setupPanesAsync: starting for task %d", taskID)
+
+		// Resolve the actual UI session name (avoid prefix-matching the wrong session).
+		if out, err := osExec.Command("tmux", "display-message", "-p", "#{session_name}").Output(); err == nil {
+			m.uiSessionName = strings.TrimSpace(string(out))
+		} else {
+			m.uiSessionName = "task-ui" // fallback
+		}
+
+		// Find the task's existing window (one tmux call).
+		m.cachedWindowTarget = m.findTaskWindow()
+		log.Info("setupPanesAsync: cachedWindowTarget=%q", m.cachedWindowTarget)
+
+		// Fast path: an active window exists — join it. This is the heavy ~30-call
+		// path that used to block the UI thread.
+		if m.cachedWindowTarget != "" {
+			m.joinTmuxPane()
+			log.Info("setupPanesAsync: joined existing window, claudePaneID=%q, workdirPaneID=%q",
+				m.claudePaneID, m.workdirPaneID)
+			return panesJoinedMsg{
+				claudePaneID:    m.claudePaneID,
+				workdirPaneID:   m.workdirPaneID,
+				daemonSessionID: m.daemonSessionID,
+				windowTarget:    m.cachedWindowTarget,
+			}
+		}
+
+		// No window — decide based on task status (pure decision, no tmux).
+		switch action {
+		case paneActionSkip:
+			// Backlog/done/archived: don't auto-start an executor. Clear loading,
+			// no panes, no error.
+			log.Info("setupPanesAsync: skipping auto-executor for task %d", taskID)
+			return panesJoinedMsg{}
+		case paneActionWaitForExecutor:
+			// Freshly queued task with no worktree: the daemon's executor will create
+			// the window shortly. Keep the spinner and let ensureTmuxPanesJoined poll
+			// the panes in once they appear.
+			log.Info("setupPanesAsync: task %d queued without worktree, waiting for executor", taskID)
+			return paneWaitForExecutorMsg{}
+		default:
+			// Slow path: no window yet — start the executor session, then join.
+			return m.startAndJoinSession(sessionID)
+		}
+	}
 }
 
 // startPanesAsync returns a command that starts the Claude session and joins panes in the background.
 func (m *DetailModel) startPanesAsync() tea.Cmd {
-	// Capture values needed for the goroutine
-	taskID := m.task.ID
 	sessionID := m.task.ClaudeSessionID
-
 	return func() tea.Msg {
-		log := GetLogger()
-		log.Info("startPanesAsync: starting for task %d", taskID)
+		return m.startAndJoinSession(sessionID)
+	}
+}
 
-		// Start the Claude session (creates tmux window)
-		if err := m.startResumableSession(sessionID); err != nil {
-			userMsg := m.executorFailureMessage(err.Error())
-			m.logExecutorFailure(userMsg)
-			return panesJoinedMsg{err: err, userMessage: userMsg}
-		}
+// startAndJoinSession starts the task's executor session, locates its window, and
+// joins the panes, returning the resulting panesJoinedMsg. It is the shared body
+// of the async "no active window" path used by both startPanesAsync and
+// setupPanesAsync. Runs in a goroutine — never call it on the UI thread.
+func (m *DetailModel) startAndJoinSession(sessionID string) tea.Msg {
+	log := GetLogger()
+	log.Info("startAndJoinSession: starting for task %d", m.task.ID)
 
-		// Find the window target
-		windowTarget := m.findTaskWindow()
-		log.Info("startPanesAsync: after startResumableSession, windowTarget=%q", windowTarget)
+	// Start the Claude session (creates tmux window)
+	if err := m.startResumableSession(sessionID); err != nil {
+		userMsg := m.executorFailureMessage(err.Error())
+		m.logExecutorFailure(userMsg)
+		return panesJoinedMsg{err: err, userMessage: userMsg}
+	}
 
-		if windowTarget == "" {
-			log.Error("startPanesAsync: failed to find window after starting session")
-			err := fmt.Errorf("%s session window not found", m.executorDisplayName())
-			userMsg := m.executorFailureMessage("the executor exited before panes could be created")
-			m.logExecutorFailure(userMsg)
-			return panesJoinedMsg{err: err, userMessage: userMsg}
-		}
+	// Find the window target
+	windowTarget := m.findTaskWindow()
+	log.Info("startAndJoinSession: after startResumableSession, windowTarget=%q", windowTarget)
 
-		// Join the panes
-		m.cachedWindowTarget = windowTarget
-		m.joinTmuxPane()
+	if windowTarget == "" {
+		log.Error("startAndJoinSession: failed to find window after starting session")
+		err := fmt.Errorf("%s session window not found", m.executorDisplayName())
+		userMsg := m.executorFailureMessage("the executor exited before panes could be created")
+		m.logExecutorFailure(userMsg)
+		return panesJoinedMsg{err: err, userMessage: userMsg}
+	}
 
-		log.Info("startPanesAsync: completed, claudePaneID=%q, workdirPaneID=%q",
-			m.claudePaneID, m.workdirPaneID)
+	// Join the panes
+	m.cachedWindowTarget = windowTarget
+	m.joinTmuxPane()
 
-		return panesJoinedMsg{
-			claudePaneID:    m.claudePaneID,
-			workdirPaneID:   m.workdirPaneID,
-			daemonSessionID: m.daemonSessionID,
-			windowTarget:    windowTarget,
-		}
+	log.Info("startAndJoinSession: completed, claudePaneID=%q, workdirPaneID=%q",
+		m.claudePaneID, m.workdirPaneID)
+
+	return panesJoinedMsg{
+		claudePaneID:    m.claudePaneID,
+		workdirPaneID:   m.workdirPaneID,
+		daemonSessionID: m.daemonSessionID,
+		windowTarget:    windowTarget,
 	}
 }
 
@@ -633,7 +725,7 @@ func (m *DetailModel) initViewport() {
 	}
 
 	m.viewport = viewport.New(m.width-4, vpHeight)
-	m.viewport.SetContent(m.renderContent())
+	m.setViewportContent()
 	m.ready = true
 }
 
@@ -646,7 +738,7 @@ func (m *DetailModel) SetSize(width, height int) {
 		footerHeight := 2
 		m.viewport.Width = width - 4
 		m.viewport.Height = height - headerHeight - footerHeight
-		m.viewport.SetContent(m.renderContent())
+		m.setViewportContent()
 	}
 }
 
@@ -676,8 +768,17 @@ func (m *DetailModel) Update(msg tea.Msg) (*DetailModel, tea.Cmd) {
 				m.focusExecutorPane()
 			}
 		}
-		m.viewport.SetContent(m.renderContent())
+		m.setViewportContent()
 		return m, nil
+
+	case paneWaitForExecutorMsg:
+		// A freshly queued task with no worktree yet: keep the spinner up and let
+		// the Refresh() poll join the executor's panes once the daemon creates them.
+		m.paneLoading = true
+		m.waitingForExecutor = true
+		m.paneError = ""
+		m.setViewportContent()
+		return m, m.spinnerTick()
 
 	case logsLoadedMsg:
 		// Async log loading completed
@@ -687,7 +788,7 @@ func (m *DetailModel) Update(msg tea.Msg) (*DetailModel, tea.Cmd) {
 	case spinnerTickMsg:
 		// Update spinner animation while loading
 		if m.paneLoading {
-			m.viewport.SetContent(m.renderContent())
+			m.setViewportContent()
 			return m, m.spinnerTick()
 		}
 		return m, nil
@@ -700,7 +801,7 @@ func (m *DetailModel) Update(msg tea.Msg) (*DetailModel, tea.Cmd) {
 			if msg.err == nil {
 				m.relatedTasks = msg.results
 			}
-			m.viewport.SetContent(m.renderContent())
+			m.setViewportContent()
 		}
 		return m, nil
 
@@ -1606,7 +1707,7 @@ func (m *DetailModel) joinTmuxPanes() {
 		vpHeight := m.height - headerHeight - footerHeight
 		if vpHeight > 0 && m.ready {
 			m.viewport.Height = vpHeight
-			m.viewport.SetContent(m.renderContent())
+			m.setViewportContent()
 		}
 	}
 
@@ -2133,6 +2234,9 @@ func (m *DetailModel) saveDaemonPaneIDs(ctx context.Context, targetWindowID stri
 }
 
 // HasRunningShellProcess returns true if the shell pane has a running process.
+// This shells out to tmux, so it must NOT be called from the per-frame render
+// path. Refresh() polls it on a throttle and caches the result in
+// hasRunningShellProc, which renderHeader() reads instead.
 func (m *DetailModel) HasRunningShellProcess() bool {
 	if m.task == nil {
 		return false
@@ -2251,9 +2355,25 @@ func (m *DetailModel) checkFocusState() {
 }
 
 // View renders the detail view.
+//
+// View runs on every Bubble Tea update while the detail view is open. The header
+// and help are cheap (~12µs) and have many volatile inputs (spinner frame, PR
+// info, badges, theme colours), so we render them every frame and fold their
+// output into the cache signature — that captures every input they read without
+// having to enumerate each one. The expensive parts — viewport.View() and the
+// bordered box.Render(), together ~2ms and ~2.7MB per call — are skipped entirely
+// when the signature is unchanged.
 func (m *DetailModel) View() string {
 	if !m.ready {
 		return "\n  Loading..."
+	}
+
+	header := m.renderHeader()
+	help := m.renderHelp()
+
+	sig := m.viewSignature(header, help)
+	if m.cachedViewOK && m.cachedViewSig == sig {
+		return m.cachedView
 	}
 
 	// Global dangerous mode banner
@@ -2268,7 +2388,6 @@ func (m *DetailModel) View() string {
 		dangerBanner = dangerStyle.Render(IconBlocked() + " DANGEROUS MODE ENABLED")
 	}
 
-	header := m.renderHeader()
 	content := m.viewport.View()
 
 	// Use dimmed border when unfocused
@@ -2300,7 +2419,6 @@ func (m *DetailModel) View() string {
 		scrollIndicator = indicatorStyle.Render(fmt.Sprintf(" %d%% ", scrollPercent))
 	}
 
-	help := m.renderHelp()
 	boxContent := lipgloss.JoinVertical(lipgloss.Left, header, content)
 	if scrollIndicator != "" {
 		boxContent = lipgloss.JoinVertical(lipgloss.Left, header, content, scrollIndicator)
@@ -2336,7 +2454,49 @@ func (m *DetailModel) View() string {
 	}
 	viewParts = append(viewParts, renderedBox, help)
 
-	return lipgloss.JoinVertical(lipgloss.Left, viewParts...)
+	out := lipgloss.JoinVertical(lipgloss.Left, viewParts...)
+
+	m.cachedView = out
+	m.cachedViewSig = sig
+	m.cachedViewOK = true
+	return out
+}
+
+// viewSignature folds every input to View() into an allocation-free FNV-1a
+// signature. The header and help strings are passed in already rendered: hashing
+// their bytes captures all of their inputs (badges, spinner frame, PR info, theme
+// colours) without enumerating each one. The remaining inputs are the View-level
+// state the header/help don't cover: the dangerous-mode banner, the bordered box,
+// and the viewport's content/scroll geometry.
+func (m *DetailModel) viewSignature(header, help string) uint64 {
+	h := newSigHasher()
+	h.u64(StyleGeneration()) // theme / project colour changes
+	h.int(m.width)
+	h.int(m.height)
+	h.boolean(m.focused)
+	h.boolean(IsGlobalDangerousMode())
+	h.boolean(m.shellPaneHidden)
+	h.boolean(os.Getenv("TMUX") != "")
+	// Viewport content + scroll geometry (viewport.View() output is fully
+	// determined by these); the version bumps whenever the body is re-set.
+	h.u64(m.viewportContentVersion)
+	h.int(m.viewport.YOffset)
+	h.int(m.viewport.Width)
+	h.int(m.viewport.Height)
+	h.int(m.viewport.TotalLineCount())
+	h.int(m.viewport.VisibleLineCount())
+	h.str(header)
+	h.str(help)
+	return h.h
+}
+
+// setViewportContent re-renders the task content into the viewport and bumps the
+// content version so the View render cache knows the body changed. All viewport
+// content updates must go through here, or the cache could serve a stale body.
+func (m *DetailModel) setViewportContent() {
+	content := m.renderContent()
+	m.viewport.SetContent(content)
+	m.viewportContentVersion++
 }
 
 func (m *DetailModel) renderHeader() string {
@@ -2532,8 +2692,10 @@ func (m *DetailModel) renderHeader() string {
 		}
 	}
 
-	// Running process indicator
-	if m.HasRunningShellProcess() {
+	// Running process indicator. Reads the cached flag (refreshed on a throttle in
+	// Refresh()) rather than calling HasRunningShellProcess() here — that shells out
+	// to tmux and renderHeader runs on every frame.
+	if m.hasRunningShellProc {
 		meta.WriteString("  ")
 		var processStyle lipgloss.Style
 		if m.focused {

--- a/internal/ui/detail_bench_test.go
+++ b/internal/ui/detail_bench_test.go
@@ -1,0 +1,150 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// benchTaskBody is a realistic, markdown-heavy task body — the kind of content
+// that flows through glamour on the detail-view open path. Headings, lists, code
+// fences and inline emphasis make glamour do real work.
+func benchTaskBody() string {
+	var b strings.Builder
+	b.WriteString("# Implement the executor pane\n\n")
+	b.WriteString("We need to make the executor pane **fast**, _fluid_, and instant-feeling.\n\n")
+	b.WriteString("## Steps\n\n")
+	for i := 1; i <= 8; i++ {
+		b.WriteString(fmt.Sprintf("%d. Do the thing number %d with `some code` and a [link](https://example.com)\n", i, i))
+	}
+	b.WriteString("\n## Details\n\n")
+	b.WriteString("```go\nfunc main() {\n\tfmt.Println(\"hello from the task body\")\n}\n```\n\n")
+	for i := 0; i < 6; i++ {
+		b.WriteString("- A reasonably long bullet point describing one more consideration we must keep in mind while implementing this.\n")
+	}
+	return b.String()
+}
+
+// benchDetail builds a DetailModel with a realistic markdown body + activity
+// summary, sized for a wide terminal, ready to render. database is nil so the
+// benchmarks isolate the render/markdown cost (the dependencies section is
+// skipped when database is nil).
+func benchDetail() *DetailModel {
+	task := &db.Task{
+		ID:      1,
+		Title:   "Perf: executor pane slow to load",
+		Status:  db.StatusProcessing,
+		Project: "taskyou",
+		Type:    "perf",
+		Body:    benchTaskBody(),
+		Summary: "The agent has been profiling the open path and found the synchronous tmux join blocking the UI thread. Work is ongoing.",
+	}
+	m := &DetailModel{
+		task:    task,
+		width:   160,
+		height:  50,
+		focused: true,
+		ready:   true,
+	}
+	m.viewport.Width = m.width - 4
+	m.viewport.Height = m.height - 8
+	return m
+}
+
+// BenchmarkDetailRenderContentCached measures a re-render where nothing changed —
+// the common case while a task sits open (focus ticks, unrelated events). The
+// internal content cache should make this a few cheap string comparisons.
+func BenchmarkDetailRenderContentCached(b *testing.B) {
+	m := benchDetail()
+	_ = m.renderContent() // warm the cache
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink string
+	for i := 0; i < b.N; i++ {
+		sink = m.renderContent()
+	}
+	_ = sink
+}
+
+// BenchmarkDetailRenderContentCold measures rendering the task body + summary
+// through glamour with the content cache cleared but the glamour renderer warm —
+// the per-change cost (e.g. a new log line) once the view is open.
+func BenchmarkDetailRenderContentCold(b *testing.B) {
+	m := benchDetail()
+	_ = m.renderContent() // build + cache the glamour renderer
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink string
+	for i := 0; i < b.N; i++ {
+		m.cachedContent = "" // force a re-render, keep the cached renderer
+		sink = m.renderContent()
+	}
+	_ = sink
+}
+
+// BenchmarkDetailRenderContentColdRenderer measures the worst case on a fresh
+// open: a brand-new DetailModel re-builds the glamour renderer (chroma syntax
+// highlighter, style parsing) before rendering. This is the per-open markdown
+// cost that runs on the detail-view open path.
+func BenchmarkDetailRenderContentColdRenderer(b *testing.B) {
+	m := benchDetail()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink string
+	for i := 0; i < b.N; i++ {
+		m.cachedContent = ""
+		m.glamourRendererFocused = nil
+		m.glamourRendererUnfocused = nil
+		m.glamourWidth = 0
+		sink = m.renderContent()
+	}
+	_ = sink
+}
+
+// BenchmarkDetailRenderHeader measures the per-frame header render (badges, PR
+// info, spinner) — rebuilt on every View() call.
+func BenchmarkDetailRenderHeader(b *testing.B) {
+	m := benchDetail()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink string
+	for i := 0; i < b.N; i++ {
+		sink = m.renderHeader()
+	}
+	_ = sink
+}
+
+// BenchmarkDetailViewIdle measures a re-render where nothing changed — the common
+// case while a task sits open (focus ticks, polls, unrelated events). The View
+// render cache should skip the expensive viewport + bordered box render, leaving
+// only the cheap header/help render used to detect changes.
+func BenchmarkDetailViewIdle(b *testing.B) {
+	m := benchDetail()
+	m.setViewportContent()
+	_ = m.View() // warm the cache
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink string
+	for i := 0; i < b.N; i++ {
+		sink = m.View()
+	}
+	_ = sink
+}
+
+// BenchmarkDetailViewCold measures a full detail View() with the render cache
+// cleared — header + viewport + bordered box. This is the per-change cost (scroll,
+// content update, focus change, resize) and the first paint.
+func BenchmarkDetailViewCold(b *testing.B) {
+	m := benchDetail()
+	m.setViewportContent()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink string
+	for i := 0; i < b.N; i++ {
+		m.cachedViewOK = false
+		sink = m.View()
+	}
+	_ = sink
+}

--- a/internal/ui/detail_cache_test.go
+++ b/internal/ui/detail_cache_test.go
@@ -1,0 +1,170 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/github"
+)
+
+// assertNoStaleDetailView verifies the detail View() render cache returns fresh
+// output after a mutation. It warms the cache with the pre-mutation state, applies
+// the mutation, captures the (cached) render, then forces a cold re-render of the
+// same final state and asserts the two are identical. If the signature failed to
+// notice the mutation, the warm render returns stale bytes that differ from the
+// cold render — failing the test. It also asserts the mutation actually changed
+// the output, so the check can't pass vacuously.
+func assertNoStaleDetailView(t *testing.T, name string, m *DetailModel, mutate func(*DetailModel)) {
+	t.Helper()
+
+	before := m.View() // warm the cache with the pre-mutation state
+
+	mutate(m)
+	cached := m.View() // cache hit iff the signature missed the mutation (stale)
+
+	// Cold render of the identical post-mutation state.
+	m.cachedViewOK = false
+	fresh := m.View()
+
+	if cached != fresh {
+		t.Errorf("%s: detail View cache served stale output after mutation", name)
+	}
+	if before == fresh {
+		t.Errorf("%s: mutation did not change rendered output; test is vacuous", name)
+	}
+}
+
+func TestDetailViewCacheInvalidation(t *testing.T) {
+	forceColor(t)
+
+	cases := []struct {
+		name   string
+		mutate func(*DetailModel)
+	}{
+		{"focus", func(m *DetailModel) { m.focused = false }},
+		{"status", func(m *DetailModel) { m.task.Status = db.StatusDone }},
+		{"pane error", func(m *DetailModel) { m.paneError = "the executor exploded" }},
+		{"pane loading", func(m *DetailModel) { m.paneLoading = true }},
+		{"running shell process", func(m *DetailModel) { m.hasRunningShellProc = true }},
+		{"pr info added", func(m *DetailModel) {
+			m.prInfo = &github.PRInfo{Number: 7, State: github.PRStateOpen, CheckState: github.CheckStatePassing, Additions: 12, Deletions: 3}
+		}},
+		{"resize width", func(m *DetailModel) { m.SetSize(120, m.height) }},
+		{"body content", func(m *DetailModel) {
+			m.task.Body = "A completely different task body that should re-render the viewport."
+			m.setViewportContent()
+		}},
+		{"summary content", func(m *DetailModel) {
+			m.task.Summary = "A brand new activity summary line."
+			m.setViewportContent()
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := benchDetail()
+			m.setViewportContent()
+			assertNoStaleDetailView(t, tc.name, m, tc.mutate)
+		})
+	}
+}
+
+// TestDetailViewCacheShellTab verifies the collapsed-shell indicator (which only
+// appears inside tmux) is part of the View signature.
+func TestDetailViewCacheShellTab(t *testing.T) {
+	forceColor(t)
+	t.Setenv("TMUX", "/tmp/tmux-test/default")
+	m := benchDetail()
+	m.setViewportContent()
+	assertNoStaleDetailView(t, "shell pane hidden", m, func(m *DetailModel) {
+		m.shellPaneHidden = true
+	})
+}
+
+// TestDetailViewCacheScroll verifies the scroll offset is part of the View
+// signature, using a short viewport so the content actually overflows.
+func TestDetailViewCacheScroll(t *testing.T) {
+	forceColor(t)
+	m := benchDetail()
+	m.SetSize(160, 14) // small enough that the body overflows the viewport
+	m.setViewportContent()
+	if m.viewport.TotalLineCount() <= m.viewport.VisibleLineCount() {
+		t.Skip("content did not overflow viewport; cannot exercise scroll")
+	}
+	assertNoStaleDetailView(t, "scroll offset", m, func(m *DetailModel) {
+		m.viewport.SetYOffset(2)
+	})
+}
+
+// TestDetailViewCacheIdleStable verifies repeated renders with no change return
+// the exact same bytes — the cache-hit path is correct, not just fast.
+func TestDetailViewCacheIdleStable(t *testing.T) {
+	forceColor(t)
+	m := benchDetail()
+	m.setViewportContent()
+	first := m.View()
+	for i := 0; i < 5; i++ {
+		if got := m.View(); got != first {
+			t.Fatalf("idle re-render %d differed from first render", i)
+		}
+	}
+}
+
+// TestPendingPaneAction verifies the open-path decision tree for a task with no
+// existing tmux window: which status starts an executor, which skips, and which
+// waits for the daemon.
+func TestPendingPaneAction(t *testing.T) {
+	cases := []struct {
+		name     string
+		task     *db.Task
+		expected paneAction
+	}{
+		{"backlog skips", &db.Task{Status: db.StatusBacklog}, paneActionSkip},
+		{"done skips", &db.Task{Status: db.StatusDone}, paneActionSkip},
+		{"archived skips", &db.Task{Status: db.StatusArchived}, paneActionSkip},
+		{"queued without worktree waits", &db.Task{Status: db.StatusQueued}, paneActionWaitForExecutor},
+		{"queued with worktree starts", &db.Task{Status: db.StatusQueued, WorktreePath: "/tmp/wt"}, paneActionStartExecutor},
+		{"processing starts", &db.Task{Status: db.StatusProcessing}, paneActionStartExecutor},
+		{"blocked starts", &db.Task{Status: db.StatusBlocked}, paneActionStartExecutor},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pendingPaneAction(tc.task); got != tc.expected {
+				t.Errorf("pendingPaneAction(%s) = %v, want %v", tc.task.Status, got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestNewDetailModelOpensAsync verifies that opening a task inside tmux returns
+// immediately with a background command and a loading spinner, instead of
+// blocking the UI thread on the tmux join. This is the core "instant open" fix.
+func TestNewDetailModelOpensAsync(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-test/default")
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	task := &db.Task{ID: 1, Title: "Async open", Status: db.StatusProcessing, Body: "# Body"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	m, cmd := NewDetailModel(task, database, nil, 160, 50, false)
+
+	if cmd == nil {
+		t.Fatal("expected a background command for async pane setup, got nil (open path is blocking)")
+	}
+	if !m.paneLoading {
+		t.Error("expected paneLoading=true so the loading spinner shows while panes set up")
+	}
+	// The view must paint immediately rather than waiting on tmux.
+	if view := m.View(); strings.TrimSpace(view) == "" {
+		t.Error("expected the detail view to render immediately on open")
+	}
+}

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -113,11 +113,26 @@ The board render is cached by a signature of its inputs (see `KanbanBoard.View`)
 so idle re-renders (ticks, mouse motion, unrelated events) are nearly free; the
 profile's render time comes from cache-miss frames (navigation, task changes).
 
+The **detail view** (Enter on a card) is tuned the same way:
+
+- **Opening is instant.** All tmux work — the window search plus the ~30-call
+  join/split/resize that happens when an executor is already running — runs off
+  the Bubble Tea update thread (`setupPanesAsync`), so the view paints
+  immediately with a loading spinner and the panes drop in when ready, instead
+  of freezing the UI for the whole join.
+- **`DetailModel.View()` is render-cached** by a signature of its inputs (same
+  trick as the board): idle frames skip the expensive `viewport.View()` +
+  bordered `box.Render()` (~2ms / ~2.7MB) and cost only the cheap header/help
+  render used to detect changes. See `viewSignature` and `detail_cache_test.go`.
+- The shell-process indicator is polled on a throttle in `Refresh()` instead of
+  shelling out to tmux from `renderHeader()` on every frame.
+
 For reproducible micro-measurements (and CI regression guarding), the Go
 benchmarks are the fastest loop:
 
 ```bash
 go test ./internal/ui/ -run '^$' -bench 'BenchmarkKanbanView' -benchmem
+go test ./internal/ui/ -run '^$' -bench 'BenchmarkDetail'     -benchmem
 # add -cpuprofile=/tmp/c.prof to capture render call stacks from a benchmark
 ```
 


### PR DESCRIPTION
## Problem

Opening a task's detail view (Enter on the board) and getting the agent/executor pane visible felt slow. `NewDetailModel` ran **all of its tmux work synchronously on the Bubble Tea update thread** before the view ever painted. On the common "executor already running" path that meant a window search plus a ~30-call `join-pane`/`split-window`/`select-pane`/`resize-pane`/`set-option`/`bind-key` dance — easily **150–400ms of frozen UI** on Enter — and `renderHeader` shelled out to `tmux` on **every frame** to draw the running-process dot.

Follows the exact pattern of #569 (cache kanban renders): measure → identify → fix the proven bottleneck → verify → guard with benchmarks + tests.

## Measurements (Go benchmarks, Apple M4 Pro)

Added `internal/ui/detail_bench_test.go` (mirrors `render_bench_test.go`).

| Benchmark | before | after |
|---|---|---|
| `DetailView` idle re-render | **2,198,844 ns/op · 2.76 MB · 1435 allocs** | **~40,000 ns/op · 11 KB · 250 allocs** (`BenchmarkDetailViewIdle`) |
| `DetailView` cold / first paint | — | 2,151,502 ns/op · 2.76 MB (`BenchmarkDetailViewCold`) |
| `RenderContent` cached | 3.1 ns/op · 0 allocs | 3.1 ns/op · 0 allocs (already cached) |
| `RenderContent` cold (glamour) | 1.41 ms · 971 KB | unchanged (one-time on open) |
| `RenderHeader` | 5.7 µs | 5.4 µs (no longer execs tmux) |

Diagnostic split of the 2.2ms View(): `viewport.View()` ~830µs/1.07MB + `box.Render()` ~780µs/1.24MB.

**Perceived load time:** opening a task with a running executor used to freeze the board for the full synchronous join (~150–400ms, ~35 tmux subprocesses on the UI thread). Now the detail view paints **immediately** with a loading spinner and the panes drop in a moment later — instant-feeling, matching the slow path that was already async.

## Changes

1. **Async open path.** `NewDetailModel` returns immediately with `paneLoading=true` + a spinner; `setupPanesAsync` runs the whole window-search + join/start decision tree off the UI thread, reporting back via `panesJoinedMsg` / `paneWaitForExecutorMsg`. The no-window decision is a pure, unit-tested function (`pendingPaneAction`). The slow path's body is shared via `startAndJoinSession`.
2. **`DetailModel.View()` render cache** (same trick as `KanbanBoard.View` in #569). Cheap header/help are rendered every frame and their bytes folded into the signature — capturing every input without enumerating it — while the expensive `viewport.View()` + bordered `box.Render()` are skipped on idle frames. All viewport writes go through `setViewportContent` (bumps a content version) so the cache can't go stale.
3. **Throttle the shell-process indicator** out of the per-frame render path: `Refresh()` polls `HasRunningShellProcess()` every 2s into `hasRunningShellProc` (mirrors the existing memory/server throttles); `renderHeader` reads the field instead of exec'ing `tmux` per frame.

## Tests / guards

- `internal/ui/detail_cache_test.go`: proves the View cache never serves stale output across **focus, status, PR info, pane error, loading, running-process, resize, body, summary, scroll, and collapsed-shell** mutations (mirrors `render_cache_test.go`); covers the `pendingPaneAction` decision tree; and verifies opening inside tmux returns a background command and paints immediately.
- `internal/ui/detail_bench_test.go`: kept as CI regression guards.
- Full `go test ./...` green; board render cache + benchmarks unaffected.
- `make lint` clean, **including reproducing with the CI-pinned golangci-lint v2.1.6** (0 issues).

Ignore the pre-existing "Vulnerability Check" CI job (govulncheck needs Go≥1.25 vs CI's 1.24) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
