### PR TITLE
Keep a running task's permission mode in sync with the live session

### DIFF
--- a/internal/db/permission_mode_test.go
+++ b/internal/db/permission_mode_test.go
@@ -47,6 +47,90 @@ func TestTaskEffectivePermissionMode(t *testing.T) {
 	}
 }
 
+func TestNextPermissionMode(t *testing.T) {
+	cases := map[string]string{
+		PermissionModeDefault:     PermissionModeAcceptEdits,
+		PermissionModeAcceptEdits: PermissionModeAuto,
+		PermissionModeAuto:        PermissionModeDangerous,
+		PermissionModeDangerous:   PermissionModeDefault, // wraps around
+		"":                        PermissionModeAcceptEdits,
+		"bogus":                   PermissionModeAcceptEdits,
+	}
+	for in, want := range cases {
+		if got := NextPermissionMode(in); got != want {
+			t.Errorf("NextPermissionMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	// Cycling four times returns to the start, covering all modes exactly once.
+	seen := map[string]bool{}
+	mode := PermissionModeDefault
+	for i := 0; i < len(PermissionModeCycle); i++ {
+		seen[mode] = true
+		mode = NextPermissionMode(mode)
+	}
+	if mode != PermissionModeDefault {
+		t.Errorf("cycle did not return to start, ended at %q", mode)
+	}
+	if len(seen) != 4 {
+		t.Errorf("cycle did not visit all 4 modes, saw %d: %v", len(seen), seen)
+	}
+}
+
+func TestPermissionModeLabel(t *testing.T) {
+	cases := map[string]string{
+		PermissionModeDefault:     "Prompt",
+		PermissionModeAcceptEdits: "Accept-edits",
+		PermissionModeAuto:        "Auto",
+		PermissionModeDangerous:   "Dangerous",
+		"":                        "Prompt",
+	}
+	for in, want := range cases {
+		if got := PermissionModeLabel(in); got != want {
+			t.Errorf("PermissionModeLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestUpdateTaskPermissionModeKeepsBoolInSync guards the single-source-of-truth
+// invariant the resume/cycle fix relies on: writing permission_mode must keep the
+// legacy dangerous_mode bool consistent, so the badge and the live session can
+// never disagree (the root cause of tasks "stored dangerous but still prompting").
+func TestUpdateTaskPermissionModeKeepsBoolInSync(t *testing.T) {
+	t.Setenv("TASKYOU_DEFAULT_PERMISSION_MODE", "")
+	database := newPermTestDB(t)
+	if err := database.CreateProject(&Project{Name: "p", Path: t.TempDir()}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	task := &Task{Title: "T", Status: StatusQueued, Type: TypeCode, Project: "p"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	cases := []struct {
+		mode          string
+		wantEffective string
+		wantDangerous bool
+	}{
+		{PermissionModeDangerous, PermissionModeDangerous, true},
+		{PermissionModeAuto, PermissionModeAuto, false}, // dangerous bool must clear
+		{PermissionModeAcceptEdits, PermissionModeAcceptEdits, false},
+		{PermissionModeDefault, PermissionModeDefault, false},
+	}
+	for _, c := range cases {
+		if err := database.UpdateTaskPermissionMode(task.ID, c.mode); err != nil {
+			t.Fatalf("update to %q: %v", c.mode, err)
+		}
+		got, _ := database.GetTask(task.ID)
+		if got.EffectivePermissionMode() != c.wantEffective {
+			t.Errorf("after set %q: EffectivePermissionMode = %q, want %q", c.mode, got.EffectivePermissionMode(), c.wantEffective)
+		}
+		if got.DangerousMode != c.wantDangerous {
+			t.Errorf("after set %q: DangerousMode = %v, want %v", c.mode, got.DangerousMode, c.wantDangerous)
+		}
+	}
+}
+
 func TestGlobalDefaultPermissionMode(t *testing.T) {
 	t.Setenv("TASKYOU_DEFAULT_PERMISSION_MODE", "")
 	if got := GlobalDefaultPermissionMode(); got != PermissionModeAuto {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -115,6 +115,43 @@ func NormalizePermissionMode(mode string) string {
 	return ""
 }
 
+// PermissionModeCycle is the order the UI cycles permission modes, from most to
+// least gated. Cycling keeps the four modes reachable on a running task; each
+// step relaunches the live session so it matches the stored mode.
+var PermissionModeCycle = []string{
+	PermissionModeDefault,
+	PermissionModeAcceptEdits,
+	PermissionModeAuto,
+	PermissionModeDangerous,
+}
+
+// NextPermissionMode returns the next mode after the given one in
+// PermissionModeCycle, wrapping around. Unknown input starts the cycle at
+// accept-edits (one past default), so "advance from wherever you are" is sane.
+func NextPermissionMode(mode string) string {
+	mode = NormalizePermissionMode(mode)
+	for i, m := range PermissionModeCycle {
+		if m == mode {
+			return PermissionModeCycle[(i+1)%len(PermissionModeCycle)]
+		}
+	}
+	return PermissionModeAcceptEdits
+}
+
+// PermissionModeLabel returns a short human-facing label for a permission mode.
+func PermissionModeLabel(mode string) string {
+	switch NormalizePermissionMode(mode) {
+	case PermissionModeAcceptEdits:
+		return "Accept-edits"
+	case PermissionModeAuto:
+		return "Auto"
+	case PermissionModeDangerous:
+		return "Dangerous"
+	default:
+		return "Prompt"
+	}
+}
+
 // GlobalDefaultPermissionMode returns the fallback permission mode used when a
 // project has no explicit default. It can be overridden with the
 // TASKYOU_DEFAULT_PERMISSION_MODE environment variable. Defaults to "auto"

--- a/internal/executor/claude_executor.go
+++ b/internal/executor/claude_executor.go
@@ -32,14 +32,12 @@ type ClaudeExecutor struct {
 	logger   *log.Logger
 }
 
-// claudePermissionFlag returns the Claude CLI permission flag (with a trailing
-// space) for a task's effective permission mode. The WORKTREE_DANGEROUS_MODE
-// environment variable forces dangerous mode for sandboxed environments.
-func claudePermissionFlag(task *db.Task) string {
-	if os.Getenv("WORKTREE_DANGEROUS_MODE") == "1" {
-		return "--dangerously-skip-permissions "
-	}
-	switch task.EffectivePermissionMode() {
+// permissionFlagForMode returns the Claude CLI permission flag (with a trailing
+// space) for an explicit permission mode, or "" for default/prompt mode. This is
+// the single mapping from a stored mode to a CLI flag; every launch and resume
+// path goes through it so the live session always matches the task's mode.
+func permissionFlagForMode(mode string) string {
+	switch mode {
 	case db.PermissionModeDangerous:
 		return "--dangerously-skip-permissions "
 	case db.PermissionModeAuto:
@@ -49,6 +47,27 @@ func claudePermissionFlag(task *db.Task) string {
 	default:
 		return ""
 	}
+}
+
+// safePermissionMode maps a task's mode to the mode a "safe" (non-bypass) resume
+// should use: every non-dangerous mode is preserved (so resuming an auto or
+// accept-edits task keeps that mode instead of dropping to prompt-for-everything),
+// and dangerous degrades to default so "safe" can never mean "bypass all".
+func safePermissionMode(mode string) string {
+	if mode == db.PermissionModeDangerous {
+		return db.PermissionModeDefault
+	}
+	return mode
+}
+
+// claudePermissionFlag returns the Claude CLI permission flag (with a trailing
+// space) for a task's effective permission mode. The WORKTREE_DANGEROUS_MODE
+// environment variable forces dangerous mode for sandboxed environments.
+func claudePermissionFlag(task *db.Task) string {
+	if os.Getenv("WORKTREE_DANGEROUS_MODE") == "1" {
+		return "--dangerously-skip-permissions "
+	}
+	return permissionFlagForMode(task.EffectivePermissionMode())
 }
 
 // effortFlag returns the `--effort <level> ` CLI flag (with a trailing space) for a

--- a/internal/executor/dangerous_mode_test.go
+++ b/internal/executor/dangerous_mode_test.go
@@ -776,58 +776,31 @@ func TestOpenCodeDangerousModeNotSupported(t *testing.T) {
 	})
 }
 
-// TestToggleDangerousModeLogic tests that the toggle logic correctly determines
-// whether to call ResumeSafe or ResumeDangerous based on current task state.
-// This verifies the core toggle decision flow used by the UI's "!" key handler.
-func TestToggleDangerousModeLogic(t *testing.T) {
-	// This test verifies the toggle logic: when DangerousMode is true, we switch to safe;
-	// when DangerousMode is false, we switch to dangerous.
-
+// TestCyclePermissionModeRouting verifies the decision flow behind the UI's "!"
+// key: cycling advances the mode (default -> accept-edits -> auto -> dangerous ->
+// default) and ResumeWithMode routes the dangerous target to ResumeDangerous and
+// every other target to ResumeSafe (which now honors the task's non-dangerous mode).
+func TestCyclePermissionModeRouting(t *testing.T) {
 	tests := []struct {
-		name             string
-		currentMode      bool // current task.DangerousMode value
-		expectSafeCall   bool // should call ResumeSafe
-		expectDangerCall bool // should call ResumeDangerous
+		from             string
+		wantNext         string
+		expectDangerCall bool // ResumeWithMode routes dangerous -> ResumeDangerous, else ResumeSafe
 	}{
-		{
-			name:             "switch from dangerous to safe",
-			currentMode:      true,
-			expectSafeCall:   true,
-			expectDangerCall: false,
-		},
-		{
-			name:             "switch from safe to dangerous",
-			currentMode:      false,
-			expectSafeCall:   false,
-			expectDangerCall: true,
-		},
+		{db.PermissionModeDefault, db.PermissionModeAcceptEdits, false},
+		{db.PermissionModeAcceptEdits, db.PermissionModeAuto, false},
+		{db.PermissionModeAuto, db.PermissionModeDangerous, true},
+		{db.PermissionModeDangerous, db.PermissionModeDefault, false},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Simulate the toggle logic from app.go toggleDangerousMode function:
-			// if task.DangerousMode {
-			//     success = exec.ResumeSafe(id)
-			// } else {
-			//     success = exec.ResumeDangerous(id)
-			// }
-
-			var safeCalled, dangerousCalled bool
-
-			// Simulate the toggle decision
-			if tt.currentMode {
-				// Currently in dangerous mode, switch to safe mode
-				safeCalled = true
-			} else {
-				// Currently in safe mode, switch to dangerous mode
-				dangerousCalled = true
+		t.Run(tt.from, func(t *testing.T) {
+			next := db.NextPermissionMode(tt.from)
+			if next != tt.wantNext {
+				t.Fatalf("NextPermissionMode(%q) = %q, want %q", tt.from, next, tt.wantNext)
 			}
-
-			if safeCalled != tt.expectSafeCall {
-				t.Errorf("ResumeSafe called = %v, want %v", safeCalled, tt.expectSafeCall)
-			}
-			if dangerousCalled != tt.expectDangerCall {
-				t.Errorf("ResumeDangerous called = %v, want %v", dangerousCalled, tt.expectDangerCall)
+			gotDanger := next == db.PermissionModeDangerous
+			if gotDanger != tt.expectDangerCall {
+				t.Errorf("from %q -> %q: routes to ResumeDangerous = %v, want %v", tt.from, next, gotDanger, tt.expectDangerCall)
 			}
 		})
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2759,9 +2759,10 @@ func (e *Executor) resumeClaudeDangerous(task *db.Task, workDir string) bool {
 	// Configure tmux window with helpful status bar
 	e.configureTmuxWindow(windowTarget)
 
-	// Update the task's dangerous mode flag in the database
-	if err := e.db.UpdateTaskDangerousMode(taskID, true); err != nil {
-		e.logger.Warn("could not update task dangerous mode", "error", err)
+	// Persist the mode through permission_mode (the source of truth), which keeps
+	// the legacy dangerous_mode bool in sync — so the badge and the live session agree.
+	if err := e.db.UpdateTaskPermissionMode(taskID, db.PermissionModeDangerous); err != nil {
+		e.logger.Warn("could not update task permission mode", "error", err)
 	}
 
 	e.logLine(taskID, "system", "Claude restarted in dangerous mode (--dangerously-skip-permissions enabled)")
@@ -2818,6 +2819,43 @@ func (e *Executor) ResumeSafe(taskID int64) bool {
 
 	// Delegate to the executor's implementation
 	return exec.ResumeSafe(task, workDir)
+}
+
+// ResumeWithMode persists a new permission mode for a running task and relaunches
+// its agent so the live session matches the stored mode. This is the single entry
+// point for changing a running task's permission mode: it writes permission_mode
+// (the source of truth) first so the resume builds the right CLI flag, then routes
+// to the dangerous or non-dangerous resume path. On failure it rolls the stored
+// mode back so the badge never claims a mode the live session isn't actually in.
+func (e *Executor) ResumeWithMode(taskID int64, mode string) bool {
+	mode = db.NormalizePermissionMode(mode)
+	if mode == "" {
+		mode = db.PermissionModeDefault
+	}
+
+	prev := mode
+	if t, err := e.db.GetTask(taskID); err == nil && t != nil {
+		prev = t.EffectivePermissionMode()
+	}
+
+	if err := e.db.UpdateTaskPermissionMode(taskID, mode); err != nil {
+		e.logger.Error("Failed to set permission mode", "taskID", taskID, "mode", mode, "error", err)
+		return false
+	}
+
+	var ok bool
+	if mode == db.PermissionModeDangerous {
+		ok = e.ResumeDangerous(taskID)
+	} else {
+		ok = e.ResumeSafe(taskID)
+	}
+
+	if !ok && prev != mode {
+		if err := e.db.UpdateTaskPermissionMode(taskID, prev); err != nil {
+			e.logger.Warn("could not roll back permission mode", "taskID", taskID, "error", err)
+		}
+	}
+	return ok
 }
 
 // resumeClaudeSafe is the Claude-specific implementation of safe mode resume.
@@ -2882,10 +2920,13 @@ func (e *Executor) resumeClaudeSafe(task *db.Task, workDir string) bool {
 		taskSessionID = fmt.Sprintf("%d", os.Getpid())
 	}
 
-	// Resume without --dangerously-skip-permissions (safe mode)
+	// Resume honoring the task's configured non-dangerous mode (auto / accept-edits
+	// / default) instead of always dropping to prompt-for-everything. "Safe" must
+	// never mean bypass, so a still-dangerous task degrades to default.
+	safeMode := safePermissionMode(task.EffectivePermissionMode())
 	envPrefix := claudeEnvPrefix(paths.configDir)
-	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude --resume %s`,
-		taskID, taskSessionID, task.Port, task.WorktreePath, envPrefix, claudeSessionID)
+	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s--resume %s`,
+		taskID, taskSessionID, task.Port, task.WorktreePath, envPrefix, permissionFlagForMode(safeMode), claudeSessionID)
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
 	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
@@ -2924,12 +2965,14 @@ func (e *Executor) resumeClaudeSafe(task *db.Task, workDir string) bool {
 	// Configure tmux window with helpful status bar
 	e.configureTmuxWindow(windowTarget)
 
-	// Update the task's dangerous mode flag in the database
-	if err := e.db.UpdateTaskDangerousMode(taskID, false); err != nil {
-		e.logger.Warn("could not update task dangerous mode", "error", err)
+	// Persist the resolved mode through permission_mode (the source of truth),
+	// which keeps the legacy dangerous_mode bool in sync — so the badge and the
+	// live session always agree.
+	if err := e.db.UpdateTaskPermissionMode(taskID, safeMode); err != nil {
+		e.logger.Warn("could not update task permission mode", "error", err)
 	}
 
-	e.logLine(taskID, "system", "Claude restarted in safe mode (permissions enabled)")
+	e.logLine(taskID, "system", fmt.Sprintf("Claude restarted in %s mode", db.PermissionModeLabel(safeMode)))
 
 	// Wait for Claude to be fully ready before sending input
 	time.Sleep(1 * time.Second)

--- a/internal/executor/permission_flag_test.go
+++ b/internal/executor/permission_flag_test.go
@@ -38,3 +38,40 @@ func TestClaudePermissionFlagGlobalDangerousEnv(t *testing.T) {
 		t.Errorf("WORKTREE_DANGEROUS_MODE should force dangerous, got %q", got)
 	}
 }
+
+func TestPermissionFlagForMode(t *testing.T) {
+	cases := map[string]string{
+		db.PermissionModeDefault:     "",
+		db.PermissionModeAcceptEdits: "--permission-mode acceptEdits ",
+		db.PermissionModeAuto:        "--permission-mode auto ",
+		db.PermissionModeDangerous:   "--dangerously-skip-permissions ",
+	}
+	for mode, want := range cases {
+		if got := permissionFlagForMode(mode); got != want {
+			t.Errorf("permissionFlagForMode(%q) = %q, want %q", mode, got, want)
+		}
+	}
+}
+
+// TestSafeResumeFlagPreservesMode is the regression for the bug where the safe
+// side of the permission-mode toggle relaunched with a bare `claude --resume`,
+// silently dropping an auto/accept-edits task into prompt-for-everything. A safe
+// resume must keep the task's non-dangerous mode, and dangerous must degrade to
+// default (never to a bypass flag).
+func TestSafeResumeFlagPreservesMode(t *testing.T) {
+	cases := []struct {
+		mode string
+		want string // flag a "safe" resume should launch with
+	}{
+		{db.PermissionModeAuto, "--permission-mode auto "},               // was bug: came back as ""
+		{db.PermissionModeAcceptEdits, "--permission-mode acceptEdits "}, // was bug: came back as ""
+		{db.PermissionModeDefault, ""},
+		{db.PermissionModeDangerous, ""}, // safe can never mean bypass
+	}
+	for _, c := range cases {
+		got := permissionFlagForMode(safePermissionMode(c.mode))
+		if got != c.want {
+			t.Errorf("safe resume of %q: flag = %q, want %q", c.mode, got, c.want)
+		}
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -206,7 +206,7 @@ func DefaultKeyMap() KeyMap {
 		),
 		ToggleDangerous: key.NewBinding(
 			key.WithKeys("!"),
-			key.WithHelp("!", "dangerous mode"),
+			key.WithHelp("!", "cycle permission mode"),
 		),
 		QueueDangerous: key.NewBinding(
 			key.WithKeys("X"),
@@ -1230,7 +1230,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.handleAICommand(msg.cmd))
 		}
 
-	case taskDangerousModeToggledMsg:
+	case taskPermissionModeCycledMsg:
 		cmds = append(cmds, m.loadTasks())
 		// Refresh the detail view panes since the executor window was recreated
 		if m.detailView != nil && m.selectedTask != nil {
@@ -1242,7 +1242,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.notification = fmt.Sprintf("%s %s", IconBlocked(), msg.err.Error())
 		} else {
-			// Reload the task to get updated dangerous_mode flag
+			// Reload the task to reflect the new permission mode
 			if m.selectedTask != nil {
 				task, _ := m.db.GetTask(m.selectedTask.ID)
 				if task != nil {
@@ -1252,11 +1252,11 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							cmds = append(cmds, cmd)
 						}
 					}
-					if task.DangerousMode {
-						m.notification = IconBlocked() + " Dangerous mode enabled"
-					} else {
-						m.notification = IconDone() + " Safe mode enabled"
+					icon := IconDone()
+					if task.IsDangerous() {
+						icon = IconBlocked()
 					}
+					m.notification = fmt.Sprintf("%s %s mode enabled", icon, db.PermissionModeLabel(msg.mode))
 				}
 			}
 		}
@@ -2788,14 +2788,14 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.toggleTaskPinned(m.selectedTask.ID)
 	}
 	if key.Matches(keyMsg, m.keys.ToggleDangerous) && m.selectedTask != nil {
-		// Only allow toggling dangerous mode if task is processing or blocked
+		// Only allow cycling permission mode if task is processing or blocked
 		if m.selectedTask.Status == db.StatusProcessing || m.selectedTask.Status == db.StatusBlocked {
-			// Break panes back to daemon BEFORE toggling so the executor can kill them.
+			// Break panes back to daemon BEFORE cycling so the executor can kill them.
 			// If panes are joined to task-ui, KillAllWindowsByNameAllSessions won't find them.
 			if m.detailView != nil {
 				m.detailView.Cleanup()
 			}
-			return m, m.toggleDangerousMode(m.selectedTask.ID)
+			return m, m.cyclePermissionMode(m.selectedTask.ID)
 		}
 	}
 	if key.Matches(keyMsg, m.keys.OpenWorktree) && m.selectedTask != nil {
@@ -4176,8 +4176,9 @@ type taskDeletedMsg struct {
 	err error
 }
 
-type taskDangerousModeToggledMsg struct {
-	err error
+type taskPermissionModeCycledMsg struct {
+	mode string
+	err  error
 }
 
 type taskPinnedMsg struct {
@@ -4384,8 +4385,9 @@ func (m *AppModel) queueTaskDangerous(id int64) tea.Cmd {
 	database := m.db
 	exec := m.executor
 	return func() tea.Msg {
-		// Set dangerous mode before queueing
-		if err := database.UpdateTaskDangerousMode(id, true); err != nil {
+		// Set dangerous mode before queueing (writes permission_mode, the source of
+		// truth, keeping the dangerous_mode bool in sync).
+		if err := database.UpdateTaskPermissionMode(id, db.PermissionModeDangerous); err != nil {
 			return taskQueuedMsg{err: err}
 		}
 		err := database.UpdateTaskStatus(id, db.StatusQueued)
@@ -4868,32 +4870,24 @@ func (m *AppModel) moveTaskToProject(newTaskData *db.Task, oldTask *db.Task) tea
 	}
 }
 
-func (m *AppModel) toggleDangerousMode(id int64) tea.Cmd {
+func (m *AppModel) cyclePermissionMode(id int64) tea.Cmd {
 	exec := m.executor
 	database := m.db
 	return func() tea.Msg {
-		// Get the task to check current dangerous mode state
 		task, err := database.GetTask(id)
 		if err != nil || task == nil {
-			return taskDangerousModeToggledMsg{err: fmt.Errorf("failed to get task")}
+			return taskPermissionModeCycledMsg{err: fmt.Errorf("failed to get task")}
 		}
 
-		executorName := taskExecutorDisplayName(task)
-		var success bool
-		if task.DangerousMode {
-			// Currently in dangerous mode, switch to safe mode
-			success = exec.ResumeSafe(id)
-			if !success {
-				return taskDangerousModeToggledMsg{err: fmt.Errorf("failed to restart %s in safe mode", executorName)}
-			}
-		} else {
-			// Currently in safe mode, switch to dangerous mode
-			success = exec.ResumeDangerous(id)
-			if !success {
-				return taskDangerousModeToggledMsg{err: fmt.Errorf("failed to restart %s in dangerous mode", executorName)}
+		// Advance to the next mode in the cycle (default -> accept-edits -> auto ->
+		// dangerous) and relaunch the live session so it actually runs in that mode.
+		next := db.NextPermissionMode(task.EffectivePermissionMode())
+		if !exec.ResumeWithMode(id, next) {
+			return taskPermissionModeCycledMsg{
+				err: fmt.Errorf("failed to restart %s in %s mode", taskExecutorDisplayName(task), db.PermissionModeLabel(next)),
 			}
 		}
-		return taskDangerousModeToggledMsg{err: nil}
+		return taskPermissionModeCycledMsg{mode: next}
 	}
 }
 
@@ -4918,9 +4912,10 @@ func (m *AppModel) retryTaskWithAttachments(id int64, feedback string, attachmen
 	database := m.db
 	exec := m.executor
 	return func() tea.Msg {
-		// Set dangerous mode if requested
+		// Set dangerous mode if requested (writes permission_mode, the source of
+		// truth, keeping the dangerous_mode bool in sync).
 		if dangerous {
-			database.UpdateTaskDangerousMode(id, true)
+			database.UpdateTaskPermissionMode(id, db.PermissionModeDangerous)
 		}
 
 		// Get task to find worktree path


### PR DESCRIPTION
## Problem

Tasks set to **auto** (or **dangerous**) kept stalling at permission prompts and reverting to a prompting mode — even though the board badge still showed the mode the user picked. Concretely, task 4093 was stored `dangerous` yet stopped on a `Waiting for permission: cd …` prompt, which is impossible for a session actually launched with `--dangerously-skip-permissions`.

## Root cause

The mode the **live Claude session** ran in could diverge from the task's stored/displayed mode:

1. **`resumeClaudeSafe` relaunched with a bare `claude --resume`** — no permission flag at all — so the "safe" side of the `!` toggle silently dropped `auto`/`accept-edits` tasks into prompt-for-everything.
2. **Two sources of truth.** The resume/toggle paths wrote only the `dangerous_mode` *bool*, never the `permission_mode` *string* (which `EffectivePermissionMode()` prefers). So the badge and the live session disagreed.

Verified in isolation (throwaway project, dedicated tmux socket — live instance untouched): the Claude CLI **does** honor `--dangerously-skip-permissions` / `--permission-mode` on `--resume` (status bar showed `⏵⏵ bypass permissions on`). So the bug was entirely ours, in the resume/toggle wiring — not the CLI.

## Fix

- `permissionFlagForMode(mode)` / `safePermissionMode(mode)` — a single mode→flag mapping; a "safe" resume now **preserves** the task's non-dangerous mode (`auto`/`accept-edits`/`default`) and degrades `dangerous`→`default` so "safe" can never mean bypass.
- `resumeClaudeSafe`/`resumeClaudeDangerous` build the flag from the task's mode and persist via `UpdateTaskPermissionMode`, keeping the legacy bool in sync.
- New `ResumeWithMode(taskID, mode)` coordinator: set mode → relaunch → **roll back the stored mode if the relaunch fails**, so the badge never claims a mode the session isn't in.
- The **`!` key now cycles all four modes** (prompt → accept-edits → auto → dangerous) instead of a binary dangerous/safe toggle.
- Routed the queue-dangerous and retry-dangerous writes through `UpdateTaskPermissionMode` too.

## Behavior change

`!` on a running task now **cycles** the permission mode and relaunches the agent in that exact mode, rather than flipping dangerous on/off. Pre-existing divergent rows (like 4093) self-heal the next time they're cycled or resumed through the fixed paths.

## Tests

- `TestSafeResumeFlagPreservesMode` — the actual bug: a safe resume of an `auto`/`accept-edits` task now yields the correct `--permission-mode …` flag (was `""`); `dangerous` degrades to default, never a bypass flag.
- `TestNextPermissionMode` / `TestPermissionModeLabel` — cycle order + labels.
- `TestUpdateTaskPermissionModeKeepsBoolInSync` — the `permission_mode`/`dangerous_mode` consistency invariant.
- `TestPermissionFlagForMode`; rewrote the stale binary-toggle test into `TestCyclePermissionModeRouting`.

`go build`, `go vet`, `gofmt`, and the `db`/`executor`/`ui` suites all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)