### PR TITLE
Guard against writes outside the isolated worktree

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -3998,6 +3998,7 @@ type ClaudeHookInput struct {
 	SessionID        string `json:"session_id"`
 	TranscriptPath   string `json:"transcript_path"`
 	Cwd              string `json:"cwd"`
+	PermissionMode   string `json:"permission_mode,omitempty"` // e.g. "default", "acceptEdits", "bypassPermissions"
 	HookEventName    string `json:"hook_event_name"`
 	NotificationType string `json:"notification_type,omitempty"` // For Notification hooks
 	Message          string `json:"message,omitempty"`           // General message field
@@ -4205,7 +4206,53 @@ func handlePreToolUseHook(database *db.DB, taskID int64, input *ClaudeHookInput)
 		database.AppendTaskLog(taskID, "pending_tool", detail)
 	}
 
+	// Worktree write-guard: block/ask on writes that would escape the isolated
+	// worktree. Inert for non-worktree ("shared dir") tasks. Emitting the decision
+	// to stdout is what gives it teeth; an "ask" surfaces as a permission prompt,
+	// which the Notification(permission_prompt) hook turns into a blocked task on
+	// the board, so unattended runs route to needs-input rather than silently
+	// writing to the wrong tree.
+	emitWorktreeGuardDecision(database, taskID, task, input)
+
 	return nil
+}
+
+// emitWorktreeGuardDecision evaluates the worktree write-guard and, when a tool
+// call would write outside the worktree, prints a PreToolUse permission decision
+// (ask/deny) to stdout per Claude Code's hookSpecificOutput contract. It prints
+// nothing when the write is allowed, leaving Claude's normal permission flow intact.
+func emitWorktreeGuardDecision(database *db.DB, taskID int64, task *db.Task, input *ClaudeHookInput) {
+	if task == nil {
+		return
+	}
+	var allow []string
+	if projectDir := executor.ManagedWorktreeProjectDir(task.WorktreePath); projectDir != "" {
+		allow = executor.WorktreeAllowExternalWrites(projectDir)
+	}
+	decision := executor.EvaluateWorktreeWriteGuard(task.WorktreePath, allow, executor.WorktreeGuardInput{
+		ToolName:       input.ToolName,
+		ToolInput:      input.ToolInput,
+		Cwd:            input.Cwd,
+		PermissionMode: input.PermissionMode,
+	})
+	if decision == nil {
+		return
+	}
+
+	if decision.Decision == "deny" {
+		database.AppendTaskLog(taskID, "system", "Worktree guard denied an out-of-worktree write")
+	}
+
+	out := map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":            "PreToolUse",
+			"permissionDecision":       decision.Decision,
+			"permissionDecisionReason": decision.Reason,
+		},
+	}
+	if data, err := json.Marshal(out); err == nil {
+		fmt.Println(string(data))
+	}
 }
 
 // handlePostToolUseHook handles PostToolUse hooks from Claude (after tool execution).

--- a/internal/executor/project_config.go
+++ b/internal/executor/project_config.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -20,6 +21,11 @@ type WorktreeConfig struct {
 	// TeardownScript is the path to a script that runs before worktree deletion.
 	// Can be relative to the project root (e.g., "bin/worktree-teardown").
 	TeardownScript string `yaml:"teardown_script"`
+	// AllowExternalWrites is an allowlist of path prefixes a task may write to even
+	// though they live outside its worktree. Used by the worktree write-guard to
+	// pre-approve known-safe external writes (e.g. a shared scratch dir) so they
+	// don't prompt. Paths may be absolute or start with ~.
+	AllowExternalWrites []string `yaml:"allow_external_writes"`
 }
 
 // ConfigFileNames are the supported configuration file names, in order of precedence.
@@ -58,6 +64,27 @@ func loadConfigFile(path string) (*ProjectConfig, error) {
 	}
 
 	return &config, nil
+}
+
+// ManagedWorktreeProjectDir returns the project root for a managed worktree path
+// (the part before the .task-worktrees/ segment), or "" if the path is not a
+// managed worktree.
+func ManagedWorktreeProjectDir(worktreePath string) string {
+	idx := strings.Index(worktreePath, taskWorktreesSegment)
+	if idx < 0 {
+		return ""
+	}
+	return worktreePath[:idx]
+}
+
+// WorktreeAllowExternalWrites returns the configured allowlist of external write
+// prefixes for a project, or nil if none is configured.
+func WorktreeAllowExternalWrites(projectDir string) []string {
+	config, err := LoadProjectConfig(projectDir)
+	if err != nil || config == nil {
+		return nil
+	}
+	return config.Worktree.AllowExternalWrites
 }
 
 // GetWorktreeInitScript returns the path to the worktree init script for a project.

--- a/internal/executor/worktree_guard.go
+++ b/internal/executor/worktree_guard.go
@@ -1,0 +1,281 @@
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// The worktree write-guard keeps an isolated task from mutating anything outside
+// its own git worktree. TaskYou already tells the agent "the parent repo does not
+// exist for you", but that is a soft instruction the model can drift from — most
+// easily because the worktree is nested inside the main checkout, so an absolute
+// path like /repo/app/x.rb resolves to a real file in main and the write succeeds
+// silently. This guard turns that silent escape into a permission decision.
+//
+// Policy (decided with the user):
+//   - Reads are always allowed — legitimate cross-tree access (reference code in
+//     main, prod over ssh, shared configs) is overwhelmingly reads.
+//   - ANY write whose destination resolves outside the worktree asks the user
+//     (main repo, sibling worktrees, $HOME, /tmp — all the same rule).
+//   - In bypassPermissions mode (--dangerously-skip-permissions) there is no human
+//     to answer, so the guard fails closed and denies instead of asking.
+//   - Only taskyou-managed worktrees are guarded. "Shared dir" projects opted out
+//     of isolation, so there is no boundary to protect and the guard is inert.
+
+// WorktreeGuardInput is the minimal slice of a Claude PreToolUse payload the guard
+// needs. It is decoupled from the hook JSON struct so the guard can be unit-tested
+// without constructing full hook payloads.
+type WorktreeGuardInput struct {
+	ToolName       string
+	ToolInput      json.RawMessage
+	Cwd            string
+	PermissionMode string
+}
+
+// WorktreeGuardDecision maps directly onto Claude Code's
+// hookSpecificOutput.permissionDecision contract.
+type WorktreeGuardDecision struct {
+	Decision string // "ask" or "deny"
+	Reason   string
+}
+
+// bypassPermissionMode is the permission_mode Claude reports when launched with
+// --dangerously-skip-permissions. No interactive prompt exists in that mode, so
+// the guard denies rather than asks.
+const bypassPermissionMode = "bypassPermissions"
+
+// taskWorktreesSegment is the path component every managed worktree lives under
+// (see setupWorktree, which creates <project>/.task-worktrees/<id>-<slug>).
+var taskWorktreesSegment = string(filepath.Separator) + ".task-worktrees" + string(filepath.Separator)
+
+// EvaluateWorktreeWriteGuard returns a decision when the pending tool call would
+// write outside the task's isolated worktree, or nil to let Claude's normal
+// permission flow proceed. worktreePath is the task's worktree root (task.WorktreePath);
+// allowExternal is an optional allowlist of absolute path prefixes that may be
+// written even though they live outside the worktree.
+func EvaluateWorktreeWriteGuard(worktreePath string, allowExternal []string, in WorktreeGuardInput) *WorktreeGuardDecision {
+	root := cleanPath(worktreePath, "")
+	if root == "" || !IsManagedWorktree(root) {
+		return nil // not an isolated worktree task — nothing to protect
+	}
+
+	escapes := externalWriteTargets(in, root, allowExternal)
+	if len(escapes) == 0 {
+		return nil
+	}
+
+	decision := "ask"
+	if in.PermissionMode == bypassPermissionMode {
+		decision = "deny"
+	}
+	return &WorktreeGuardDecision{
+		Decision: decision,
+		Reason: fmt.Sprintf(
+			"%s would write outside your isolated worktree, to: %s. Your worktree is %s — "+
+				"all work must stay inside it; the main checkout and other worktrees are off-limits even "+
+				"though they exist on disk. Use a path under your worktree instead. If this external write "+
+				"is genuinely required, the user must approve it.",
+			toolLabel(in.ToolName), strings.Join(escapes, ", "), root,
+		),
+	}
+}
+
+// IsManagedWorktree reports whether path is inside a taskyou-managed worktree
+// (under a .task-worktrees/ directory). Mirrors the check used elsewhere in the
+// executor for task.WorktreePath.
+func IsManagedWorktree(path string) bool {
+	return strings.Contains(path, taskWorktreesSegment)
+}
+
+// externalWriteTargets returns the resolved write destinations of a tool call that
+// fall outside root and outside the allowlist. Returns nil for reads and in-bounds
+// writes.
+func externalWriteTargets(in WorktreeGuardInput, root string, allowExternal []string) []string {
+	var raw []string
+	switch in.ToolName {
+	case "Edit", "Write", "MultiEdit":
+		raw = stringField(in.ToolInput, "file_path")
+	case "NotebookEdit":
+		raw = stringField(in.ToolInput, "notebook_path")
+	case "Bash":
+		raw = bashWriteTargets(in.ToolInput)
+	default:
+		return nil // Read / Grep / Glob / etc. — reads are always allowed
+	}
+
+	var escapes []string
+	for _, p := range raw {
+		abs := cleanPath(p, in.Cwd)
+		if abs == "" || isIgnorableSink(abs) {
+			continue
+		}
+		if pathWithin(root, abs) || allowlisted(abs, allowExternal) {
+			continue
+		}
+		escapes = append(escapes, abs)
+	}
+	return dedupe(escapes)
+}
+
+// --- Bash command analysis (best-effort) -----------------------------------
+//
+// Shell can't be parsed perfectly, so this targets the high-signal, low-false-
+// positive patterns that escape a worktree. The structured Edit/Write guard above
+// is the reliable backbone; this is the supplement for shell mutations like the
+// `cd /main && git checkout` that caused the incident this guard was built for.
+
+var (
+	reRedirect  = regexp.MustCompile(`(?:^|[\s;&|(])\d*>>?\s*("?)([^\s"';|&)]+)`)
+	reCd        = regexp.MustCompile(`(?:^|[\s;&|(])cd\s+("?)([^\s"';|&)]+)`)
+	reGitC      = regexp.MustCompile(`\bgit\s+-C\s+("?)([^\s"';|&)]+)`)
+	reGitWrite  = regexp.MustCompile(`\bgit\s+(?:-C\s+\S+\s+)?(?:commit|checkout|switch|reset|restore|clean|apply|stash|rm|mv|add|merge|rebase|cherry-pick|push|pull)\b`)
+	reMutator   = regexp.MustCompile(`(?:^|[\s;&|(])(?:rm|mv|cp|tee|touch|mkdir|rmdir|ln|dd|truncate|install|chmod|chown)\b`)
+	reMutTarget = regexp.MustCompile(`(?:^|[\s;&|(])(?:rm|tee|touch|mkdir|truncate)\s+(?:-[^\s]+\s+)*("?)((?:/|~/|\.\./)[^\s"';|&)]+)`)
+)
+
+// bashWriteTargets extracts candidate write destinations from a Bash command.
+func bashWriteTargets(rawInput json.RawMessage) []string {
+	cmds := stringField(rawInput, "command")
+	if len(cmds) == 0 {
+		return nil
+	}
+	command := cmds[0]
+
+	mutates := reGitWrite.MatchString(command) || reMutator.MatchString(command) || reRedirect.MatchString(command)
+
+	var targets []string
+	// 1. Output redirections (`> file`, `2>> file`). /dev/null & friends are filtered later.
+	for _, m := range reRedirect.FindAllStringSubmatch(command, -1) {
+		targets = append(targets, m[2])
+	}
+	// 2. `git -C <dir> <mutating>` — the -C dir is where the mutation lands.
+	if reGitWrite.MatchString(command) {
+		for _, m := range reGitC.FindAllStringSubmatch(command, -1) {
+			targets = append(targets, m[2])
+		}
+	}
+	// 3. `cd <dir>` combined with any mutation in the same command line.
+	if mutates {
+		for _, m := range reCd.FindAllStringSubmatch(command, -1) {
+			targets = append(targets, m[2])
+		}
+	}
+	// 4. Single-target mutators given an absolute/home/parent path (`rm -rf /x`).
+	for _, m := range reMutTarget.FindAllStringSubmatch(command, -1) {
+		targets = append(targets, m[2])
+	}
+	return targets
+}
+
+// --- path helpers ----------------------------------------------------------
+
+// cleanPath resolves p to an absolute, cleaned path. Relative paths resolve against
+// cwd; a leading ~ expands to the home directory. Returns "" when p is empty or a
+// relative path can't be resolved (no cwd) — callers treat "" as in-bounds.
+func cleanPath(p, cwd string) string {
+	p = strings.TrimSpace(p)
+	p = strings.Trim(p, `"'`)
+	if p == "" {
+		return ""
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			if p == "~" {
+				p = home
+			} else {
+				p = filepath.Join(home, p[2:])
+			}
+		}
+	}
+	if !filepath.IsAbs(p) {
+		cwd = strings.TrimSpace(cwd)
+		if cwd == "" {
+			return ""
+		}
+		p = filepath.Join(cwd, p)
+	}
+	return filepath.Clean(p)
+}
+
+// pathWithin reports whether target is at or below root. Both must be absolute.
+func pathWithin(root, target string) bool {
+	if root == "" || target == "" {
+		return false
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// allowlisted reports whether abs is at or below any allowlisted prefix.
+func allowlisted(abs string, allow []string) bool {
+	for _, a := range allow {
+		root := cleanPath(a, "")
+		if root != "" && pathWithin(root, abs) {
+			return true
+		}
+	}
+	return false
+}
+
+// isIgnorableSink reports whether abs is a non-file write sink (e.g. /dev/null)
+// that should never count as escaping the worktree.
+func isIgnorableSink(abs string) bool {
+	switch abs {
+	case "/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty", "/dev/zero":
+		return true
+	}
+	return strings.HasPrefix(abs, "/dev/fd/")
+}
+
+func toolLabel(name string) string {
+	if name == "Bash" {
+		return "This Bash command"
+	}
+	if name == "" {
+		return "This tool call"
+	}
+	return "This " + name
+}
+
+// stringField pulls a single string field out of a tool_input JSON object.
+func stringField(raw json.RawMessage, key string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	v, ok := m[key]
+	if !ok {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil || strings.TrimSpace(s) == "" {
+		return nil
+	}
+	return []string{s}
+}
+
+func dedupe(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	var out []string
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/executor/worktree_guard_test.go
+++ b/internal/executor/worktree_guard_test.go
@@ -1,0 +1,175 @@
+package executor
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// wt is a representative managed-worktree root (contains the .task-worktrees segment).
+const wt = "/home/u/proj/.task-worktrees/4244-speed"
+
+func toolInput(t *testing.T, m map[string]any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal tool input: %v", err)
+	}
+	return b
+}
+
+func TestEvaluateWorktreeWriteGuard(t *testing.T) {
+	cases := []struct {
+		name  string
+		root  string
+		allow []string
+		in    WorktreeGuardInput
+		want  string // "", "ask", or "deny"
+	}{
+		{
+			name: "edit inside worktree (absolute) allowed",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "Edit", Cwd: wt},
+		},
+		{
+			name: "edit inside worktree (relative to cwd) allowed",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "Edit", Cwd: wt},
+		},
+		{
+			name: "edit to main repo absolute path asks (the incident)",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "Edit", Cwd: wt},
+			want: "ask",
+		},
+		{
+			name: "write to home asks",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "Write", Cwd: wt},
+			want: "ask",
+		},
+		{
+			name: "write outside in bypass mode denies",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "Write", Cwd: wt, PermissionMode: "bypassPermissions"},
+			want: "deny",
+		},
+		{
+			name: "notebook edit outside asks",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "NotebookEdit", Cwd: wt},
+			want: "ask",
+		},
+		{
+			name: "read tool anywhere allowed",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "Read", Cwd: wt},
+		},
+		{
+			name: "multiedit outside asks",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "MultiEdit", Cwd: wt},
+			want: "ask",
+		},
+		{
+			name: "shared dir project (no .task-worktrees) is inert",
+			root: "/home/u/proj",
+			in:   WorktreeGuardInput{ToolName: "Edit", Cwd: "/home/u/proj"},
+		},
+		{
+			name:  "allowlisted external path allowed",
+			root:  wt,
+			allow: []string{"/home/u/shared"},
+			in:    WorktreeGuardInput{ToolName: "Write", Cwd: wt},
+		},
+	}
+
+	// Per-case tool inputs (kept out of the struct so we can use the helper).
+	inputs := map[string]map[string]any{
+		"edit inside worktree (absolute) allowed":             {"file_path": wt + "/app/x.rb"},
+		"edit inside worktree (relative to cwd) allowed":      {"file_path": "app/x.rb"},
+		"edit to main repo absolute path asks (the incident)": {"file_path": "/home/u/proj/app/models/event.rb"},
+		"write to home asks":                                  {"file_path": "~/notes.txt"},
+		"write outside in bypass mode denies":                 {"file_path": "/home/u/proj/app/x.rb"},
+		"notebook edit outside asks":                          {"notebook_path": "/home/u/proj/nb.ipynb"},
+		"read tool anywhere allowed":                          {"file_path": "/etc/hosts"},
+		"multiedit outside asks":                              {"file_path": "/home/u/proj/Gemfile"},
+		"shared dir project (no .task-worktrees) is inert":    {"file_path": "/home/u/proj/app/x.rb"},
+		"allowlisted external path allowed":                   {"file_path": "/home/u/shared/cache.db"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := c.in
+			in.ToolInput = toolInput(t, inputs[c.name])
+			got := EvaluateWorktreeWriteGuard(c.root, c.allow, in)
+			gotDecision := ""
+			if got != nil {
+				gotDecision = got.Decision
+			}
+			if gotDecision != c.want {
+				t.Errorf("decision = %q, want %q (reason: %v)", gotDecision, c.want, reasonOf(got))
+			}
+		})
+	}
+}
+
+func TestWorktreeWriteGuardBash(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"read-only grep allowed", "grep -r foo .", ""},
+		{"read-only cat allowed", "cat /etc/hosts", ""},
+		{"redirect to /tmp asks", "echo data > /tmp/scratch", "ask"},
+		{"redirect to /dev/null allowed", "ls -la > /dev/null", ""},
+		{"stderr to /dev/null allowed", "rails test 2>/dev/null", ""},
+		{"redirect inside worktree allowed", "echo hi > out.txt", ""},
+		{"cd to main then git checkout asks", "cd /home/u/proj && git checkout main", "ask"},
+		{"git -C main reset asks", "git -C /home/u/proj reset --hard", "ask"},
+		{"rm absolute outside asks", "rm -rf /home/u/other/build", "ask"},
+		{"cd inside worktree then write allowed", "cd ./sub && echo x > y.txt", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := WorktreeGuardInput{
+				ToolName:  "Bash",
+				Cwd:       wt,
+				ToolInput: toolInput(t, map[string]any{"command": c.command}),
+			}
+			got := EvaluateWorktreeWriteGuard(wt, nil, in)
+			gotDecision := ""
+			if got != nil {
+				gotDecision = got.Decision
+			}
+			if gotDecision != c.want {
+				t.Errorf("command %q: decision = %q, want %q", c.command, gotDecision, c.want)
+			}
+		})
+	}
+}
+
+func TestIsManagedWorktree(t *testing.T) {
+	if !IsManagedWorktree(wt) {
+		t.Errorf("expected %q to be a managed worktree", wt)
+	}
+	if IsManagedWorktree("/home/u/proj") {
+		t.Errorf("expected plain project dir to NOT be a managed worktree")
+	}
+}
+
+func TestManagedWorktreeProjectDir(t *testing.T) {
+	if got := ManagedWorktreeProjectDir(wt); got != "/home/u/proj" {
+		t.Errorf("ManagedWorktreeProjectDir(%q) = %q, want /home/u/proj", wt, got)
+	}
+	if got := ManagedWorktreeProjectDir("/home/u/proj"); got != "" {
+		t.Errorf("expected empty project dir for non-worktree path, got %q", got)
+	}
+}
+
+func reasonOf(d *WorktreeGuardDecision) string {
+	if d == nil {
+		return "<nil>"
+	}
+	return d.Reason
+}


### PR DESCRIPTION
## Why

A worktree-isolated task that writes outside its worktree silently escapes isolation. Because taskyou nests the worktree *inside* the main checkout (`<repo>/.task-worktrees/<id>-<slug>`), an absolute path like `/repo/app/models/event.rb` resolves to a **real file in main** — the write succeeds with no error, so the agent never notices. This actually happened (task #4244 ran edits + a `git checkout` against the main repo).

taskyou already injects a strong "the parent repo does not exist for you" instruction, but it's a *soft* instruction: it's only in the initial prompt, decays/compacts on long or resumed sessions, and is contradicted by projects whose `CLAUDE.md` hardcodes the main absolute path. A correctly-instructed run still escaped. This adds **enforcement**.

## What

Extends the existing worktree-local `PreToolUse` hook (`handlePreToolUseHook`) with a write-guard:

- **Reads anywhere → allowed.** Only writes are gated (legit cross-tree access — reference code in main, prod over ssh, shared configs — is overwhelmingly reads).
- **Any write resolving outside the worktree → `ask`.** Main repo, sibling worktrees, `$HOME`, `/tmp` — one rule.
- **Bypass/dangerous mode → `deny`** (no human to answer; fail closed).
- Gates `Edit`/`Write`/`MultiEdit`/`NotebookEdit` (exact path check) and `Bash` (best-effort: redirects, `cd <outside> && <mutate>`, `git -C <outside> <write>`, `rm/tee/...` to absolute outside paths). `/dev/null` & friends ignored.
- **Inert for non-worktree "shared dir" projects** — gated on the `.task-worktrees` marker in `task.WorktreePath`, equivalent to `taskUsesWorktrees`.
- Optional `.taskyou.yml` `worktree.allow_external_writes:` allowlist for known-safe external writes (e.g. a shared scratch dir).

## How it routes

It rides the hook taskyou already injects — **no new settings files or command-builder changes** — and re-applies on **every run and resume**, so unlike the soft instruction it doesn't decay. An `ask` surfaces as a permission prompt, which the existing `Notification(permission_prompt)` hook turns into a **blocked task on the board** — so unattended auto runs route to needs-input instead of silently writing to the wrong tree.

## Tests

- 24 unit cases in `worktree_guard_test.go` (incl. the exact #4244 case → `ask`, bypass → `deny`, shared-dir → inert, allowlist, Bash patterns).
- End-to-end verified through the real `ty claude-hook --event PreToolUse` command against a throwaway DB.
- `go build ./...`, `go vet`, full `internal/executor` suite all green.

## Limitations

- **Claude executor only** — hooks Claude Code's `PreToolUse`; codex/gemini/opencode would each need their own guard.
- **Bash analysis is best-effort** (shell can't be perfectly parsed); the structured `Edit`/`Write` guard is the exact backbone.
- `/tmp` writes will prompt under the strict rule — add to `allow_external_writes` or use an in-worktree scratch dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)