### PR TITLE
fix(ui): stop TUI edit form from silently resetting persisted task fields

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2985,12 +2985,11 @@ func (m *AppModel) updateEditTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if form, ok := model.(*FormModel); ok {
 		m.editTaskForm = form
 		if form.submitted {
-			// Get updated task data from form
-			updatedTask := form.GetDBTask()
-
-			// Check if project has changed - this requires special handling
+			// Moving to another project deletes this task and creates a fresh
+			// one, so build that from form data (moveTaskToProject resets the
+			// runtime fields on purpose).
 			if form.ProjectChanged() {
-				// Store the original task for the confirmation dialog
+				updatedTask := form.GetDBTask()
 				originalTask := m.editingTask
 
 				m.editTaskForm = nil
@@ -2998,14 +2997,13 @@ func (m *AppModel) updateEditTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.showProjectChangeConfirm(updatedTask, originalTask)
 			}
 
-			// Preserve the original task's ID and other fields
-			updatedTask.ID = m.editingTask.ID
-			updatedTask.Status = m.editingTask.Status
-			updatedTask.WorktreePath = m.editingTask.WorktreePath
-			updatedTask.BranchName = m.editingTask.BranchName
-			updatedTask.CreatedAt = m.editingTask.CreatedAt
-			updatedTask.StartedAt = m.editingTask.StartedAt
-			updatedTask.CompletedAt = m.editingTask.CompletedAt
+			// In-place edit: overlay only the fields the form exposes onto a
+			// copy of the original task. Starting from the original preserves
+			// every persisted column the form doesn't show (session IDs, pin
+			// state, permission mode, tags, source branch, PR info, port, ...)
+			// which would otherwise be reset to zero on save. See issue #560.
+			updatedTask := *m.editingTask
+			form.ApplyTo(&updatedTask)
 
 			// Capture old title before clearing editingTask
 			oldTitle := m.editingTask.Title
@@ -3013,7 +3011,7 @@ func (m *AppModel) updateEditTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.editTaskForm = nil
 			m.editingTask = nil
 			m.currentView = m.previousView
-			return m, m.updateTaskWithRename(updatedTask, oldTitle)
+			return m, m.updateTaskWithRename(&updatedTask, oldTitle)
 		}
 		if form.cancelled {
 			m.currentView = m.previousView

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -626,6 +626,112 @@ func TestEditTaskFormEscapeClosesImmediatelyWhenEmpty(t *testing.T) {
 	}
 }
 
+// TestEditTaskFormPreservesRuntimeFields guards against regression of #560:
+// editing a task in the TUI must not reset persisted columns the form does not
+// expose (session IDs, pin state, permission mode, tags, source branch, PR
+// info, port). Previously the save path rebuilt the task from form data and
+// only carried over a handful of fields, silently zeroing the rest.
+func TestEditTaskFormPreservesRuntimeFields(t *testing.T) {
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer database.Close()
+
+	exec := executor.New(database, &config.Config{})
+
+	if err := database.CreateProject(&db.Project{Name: "proj", Path: t.TempDir()}); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Create a task, then persist runtime state the edit form never shows.
+	task := &db.Task{
+		Title:    "Original title",
+		Body:     "Original body",
+		Project:  "proj",
+		Executor: "claude",
+		Status:   db.StatusBacklog,
+	}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	task.ClaudeSessionID = "sess-abc"
+	task.DaemonSession = "ty-session-1"
+	task.Port = 4242
+	task.PRURL = "https://github.com/bborn/taskyou/pull/7"
+	task.PRNumber = 7
+	task.PRInfoJSON = `{"state":"open"}`
+	task.DangerousMode = true
+	task.PermissionMode = "auto"
+	task.RemoteControl = true
+	task.Pinned = true
+	task.Tags = "urgent,backend"
+	task.SourceBranch = "main"
+	if err := database.UpdateTask(task); err != nil {
+		t.Fatalf("UpdateTask (seed): %v", err)
+	}
+
+	// Reload so the form is built from the persisted task, as the TUI does.
+	reloaded, err := database.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+
+	m := &AppModel{
+		width:        100,
+		height:       50,
+		currentView:  ViewEditTask,
+		previousView: ViewDashboard,
+		db:           database,
+		executor:     exec,
+		editTaskForm: NewEditFormModel(database, reloaded, 100, 50, []string{"claude"}),
+		editingTask:  reloaded,
+	}
+
+	// User edits only the title, then submits with ctrl+s.
+	m.editTaskForm.titleInput.SetValue("Edited title")
+	_, cmd := m.updateEditTaskForm(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("expected an update command after submitting the edit form")
+	}
+	cmd() // perform the database update
+
+	got, err := database.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask after save: %v", err)
+	}
+
+	// The edited field is applied.
+	if got.Title != "Edited title" {
+		t.Errorf("Title = %q, want %q", got.Title, "Edited title")
+	}
+
+	// Every persisted runtime field must survive the edit untouched.
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"ClaudeSessionID", got.ClaudeSessionID, "sess-abc"},
+		{"DaemonSession", got.DaemonSession, "ty-session-1"},
+		{"Port", got.Port, 4242},
+		{"PRURL", got.PRURL, "https://github.com/bborn/taskyou/pull/7"},
+		{"PRNumber", got.PRNumber, 7},
+		{"PRInfoJSON", got.PRInfoJSON, `{"state":"open"}`},
+		{"DangerousMode", got.DangerousMode, true},
+		{"PermissionMode", got.PermissionMode, "auto"},
+		{"RemoteControl", got.RemoteControl, true},
+		{"Pinned", got.Pinned, true},
+		{"Tags", got.Tags, "urgent,backend"},
+		{"SourceBranch", got.SourceBranch, "main"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s was reset by edit: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
 func TestAppModelAvailableExecutors(t *testing.T) {
 	// Test that availableExecutors is properly stored
 	m := &AppModel{

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -1886,23 +1886,30 @@ func (m *FormModel) GetDBTask() *db.Task {
 		status = db.StatusQueued
 	}
 
-	task := &db.Task{
-		Title:    m.titleInput.Value(),
-		Body:     m.bodyInput.Value(),
-		Status:   status,
-		Type:     m.taskType,
-		Project:  m.project,
-		Executor: m.executor,
-		PRURL:    m.prURL,
-		PRNumber: m.prNumber,
-	}
+	task := &db.Task{Status: status}
+	m.ApplyTo(task)
+	return task
+}
+
+// ApplyTo overlays the form's editable fields onto task, leaving every other
+// persisted column untouched. Editing a task in place uses this so that saving
+// never resets fields the form doesn't expose (session IDs, pin state,
+// permission mode, tags, source branch, PR info, ...). See issue #560.
+func (m *FormModel) ApplyTo(task *db.Task) {
+	task.Title = m.titleInput.Value()
+	task.Body = m.bodyInput.Value()
+	task.Type = m.taskType
+	task.Project = m.project
+	task.Executor = m.executor
+	task.PRURL = m.prURL
+	task.PRNumber = m.prNumber
 
 	// Effort is a Claude-specific override; only carry it for the Claude executor.
 	if m.executor == db.ExecutorClaude {
 		task.EffortLevel = m.effortLevel
+	} else {
+		task.EffortLevel = ""
 	}
-
-	return task
 }
 
 // SetQueue sets whether to queue the task.

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -905,6 +905,69 @@ func TestGetDBTaskUsesExecutorDirectly(t *testing.T) {
 	}
 }
 
+// TestApplyToOnlyTouchesEditableFields verifies that overlaying the edit form
+// onto an existing task changes only the fields the form exposes and leaves
+// every other persisted column untouched (regression guard for #560).
+func TestApplyToOnlyTouchesEditableFields(t *testing.T) {
+	original := &db.Task{
+		Title:           "Old title",
+		Body:            "Old body",
+		Type:            "code",
+		Project:         "proj",
+		Executor:        "claude",
+		ClaudeSessionID: "sess-abc",
+		DaemonSession:   "ty-1",
+		Port:            4242,
+		PRInfoJSON:      `{"state":"open"}`,
+		DangerousMode:   true,
+		PermissionMode:  "auto",
+		RemoteControl:   true,
+		Pinned:          true,
+		Tags:            "urgent,backend",
+		SourceBranch:    "main",
+		Summary:         "a summary",
+	}
+
+	m := NewEditFormModel(nil, original, 120, 40, []string{"claude"})
+	m.titleInput.SetValue("New title")
+	m.bodyInput.SetValue("New body")
+
+	updated := *original
+	m.ApplyTo(&updated)
+
+	// Edited fields are applied.
+	if updated.Title != "New title" {
+		t.Errorf("Title = %q, want %q", updated.Title, "New title")
+	}
+	if updated.Body != "New body" {
+		t.Errorf("Body = %q, want %q", updated.Body, "New body")
+	}
+
+	// Unexposed persisted fields are preserved.
+	preserved := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"ClaudeSessionID", updated.ClaudeSessionID, "sess-abc"},
+		{"DaemonSession", updated.DaemonSession, "ty-1"},
+		{"Port", updated.Port, 4242},
+		{"PRInfoJSON", updated.PRInfoJSON, `{"state":"open"}`},
+		{"DangerousMode", updated.DangerousMode, true},
+		{"PermissionMode", updated.PermissionMode, "auto"},
+		{"RemoteControl", updated.RemoteControl, true},
+		{"Pinned", updated.Pinned, true},
+		{"Tags", updated.Tags, "urgent,backend"},
+		{"SourceBranch", updated.SourceBranch, "main"},
+		{"Summary", updated.Summary, "a summary"},
+	}
+	for _, c := range preserved {
+		if c.got != c.want {
+			t.Errorf("%s was modified by ApplyTo: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
 func TestFormDefaultsToAvailableExecutor(t *testing.T) {
 	// When claude is available, form should default to claude
 	m := NewFormModel(nil, 100, 50, "", []string{"claude"})


### PR DESCRIPTION
## Problem

Fixes #560. Editing a task via the TUI (`e`) and saving silently wiped persisted columns the edit form never exposes. Even changing only the title would reset:

- `claude_session_id` (breaks conversation resumption)
- `daemon_session` (loses tmux association)
- `port`, `pr_info_json`, `permission_mode`, `dangerous_mode`, `remote_control`
- `pinned` (task gets unpinned)
- `tags`, `source_branch`

### Repro
1. Pin a task, set permission mode to auto/dangerous, let it run so it gets a `claude_session_id`.
2. Select it, press `e`, change only the title, save.
3. Task is now unpinned, back in prompt mode, and resume fails.

## Root cause

The save path rebuilt the task from form data (`GetDBTask()` returns a fresh `db.Task` with only the editable fields) and then hand-picked ~7 fields to copy back from the original. Every other column defaulted to its Go zero value, and `UpdateTask` writes all of those columns — so they were silently overwritten.

## Fix

Invert the logic. Instead of enumerating fields to **preserve** (fragile — it silently breaks every time a column is added), overlay only the fields the form actually **edits** onto a copy of the original task. Anything the form doesn't expose is preserved automatically.

- New `FormModel.ApplyTo(task)` overlays the form's editable fields onto an existing task. `GetDBTask` now delegates to it, so the create/edit field mapping can't drift.
- Edit-save copies `*m.editingTask` and applies the form on top.
- The "move to another project" path is unchanged — it intentionally creates a fresh task via `moveTaskToProject` (which resets runtime fields on purpose).

## Tests

- `TestEditTaskFormPreservesRuntimeFields` — end-to-end through `updateEditTaskForm` + `UpdateTask` against an in-memory DB: seeds a task with session IDs / pin / permission mode / tags / etc., edits the title, and asserts all runtime fields survive. Fails on the old code (10 fields reset), passes now.
- `TestApplyToOnlyTouchesEditableFields` — unit test that `ApplyTo` changes only exposed fields.

`go test ./internal/ui/ ./internal/db/` green; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)