### PR TITLE
Extend worktree write-guard to codex / gemini / opencode executors

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -395,6 +395,25 @@ Tasks will automatically reconnect to their agent sessions when viewed.`,
 	claudeHookCmd.Flags().String("event", "", "Hook event type (Notification, Stop, etc.)")
 	rootCmd.AddCommand(claudeHookCmd)
 
+	// Worktree write-guard subcommand - the executor-agnostic transport for the
+	// worktree write-guard used by the codex/gemini/opencode pre-tool hooks. Reads a
+	// normalized pre-tool payload on stdin, evaluates EvaluateWorktreeWriteGuard, and
+	// renders the decision in the format the given executor expects (internal use).
+	worktreeGuardCmd := &cobra.Command{
+		Use:    "worktree-guard",
+		Short:  "Evaluate the worktree write-guard for a pre-tool hook",
+		Hidden: true, // Internal use only - invoked by codex/gemini/opencode hooks
+		Run: func(cmd *cobra.Command, args []string) {
+			format, _ := cmd.Flags().GetString("format")
+			// Never block the agent on our own failure: handle errors by allowing.
+			if err := handleWorktreeGuardHook(format); err != nil {
+				os.Exit(0)
+			}
+		},
+	}
+	worktreeGuardCmd.Flags().String("format", "", "Output format: codex | gemini | opencode")
+	rootCmd.AddCommand(worktreeGuardCmd)
+
 	// MCP server subcommand - runs the workflow MCP server for a task (internal use)
 	mcpServerCmd := &cobra.Command{
 		Use:    "mcp-server",
@@ -4251,6 +4270,92 @@ func emitWorktreeGuardDecision(database *db.DB, taskID int64, task *db.Task, inp
 		},
 	}
 	if data, err := json.Marshal(out); err == nil {
+		fmt.Println(string(data))
+	}
+}
+
+// worktreeGuardHookInput is the normalized pre-tool payload the worktree-guard
+// subcommand reads on stdin. Codex (PreToolUse) and Gemini (BeforeTool) emit this
+// snake_case shape natively; the OpenCode plugin assembles it before piping it in.
+type worktreeGuardHookInput struct {
+	ToolName       string          `json:"tool_name"`
+	ToolInput      json.RawMessage `json:"tool_input"`
+	Cwd            string          `json:"cwd"`
+	PermissionMode string          `json:"permission_mode"`
+}
+
+// handleWorktreeGuardHook is the executor-agnostic transport for the worktree
+// write-guard, shared by the codex/gemini/opencode pre-tool hooks. It reads the
+// worktree root from WORKTREE_PATH (set by every executor when launching the CLI),
+// evaluates the single shared policy (EvaluateWorktreeWriteGuard), and renders the
+// decision in the requested executor's wire format. It fails open on any error so a
+// guard malfunction never wedges the agent.
+func handleWorktreeGuardHook(format string) error {
+	worktreePath := strings.TrimSpace(os.Getenv("WORKTREE_PATH"))
+	if worktreePath == "" {
+		return nil // no worktree context — nothing to guard
+	}
+
+	var in worktreeGuardHookInput
+	if err := json.NewDecoder(os.Stdin).Decode(&in); err != nil {
+		return nil // unparseable payload — allow rather than block
+	}
+
+	var allow []string
+	if projectDir := executor.ManagedWorktreeProjectDir(worktreePath); projectDir != "" {
+		allow = executor.WorktreeAllowExternalWrites(projectDir)
+	}
+
+	decision := executor.EvaluateWorktreeWriteGuard(worktreePath, allow, executor.WorktreeGuardInput{
+		ToolName:       in.ToolName,
+		ToolInput:      in.ToolInput,
+		Cwd:            in.Cwd,
+		PermissionMode: in.PermissionMode,
+	})
+
+	renderWorktreeGuardDecision(format, decision)
+	return nil
+}
+
+// renderWorktreeGuardDecision writes a guard decision in the wire format the given
+// executor's hook expects. None of codex/gemini/opencode support an interactive
+// "ask" in their pre-tool hook, so an "ask" is downgraded to a hard deny to fail
+// safe (the escape hatch is worktree.allow_external_writes in .taskyou.yml). When
+// the guard allows the call, nothing is emitted (and exit stays 0) so the CLI's own
+// approval flow proceeds unchanged.
+func renderWorktreeGuardDecision(format string, decision *executor.WorktreeGuardDecision) {
+	if decision == nil {
+		return // allowed
+	}
+
+	switch format {
+	case "codex":
+		// Codex PreToolUse contract: hookSpecificOutput.permissionDecision ∈ {allow,deny}.
+		emitJSONLine(map[string]any{
+			"hookSpecificOutput": map[string]any{
+				"hookEventName":            "PreToolUse",
+				"permissionDecision":       "deny",
+				"permissionDecisionReason": decision.Reason,
+			},
+		})
+	case "gemini":
+		// Gemini BeforeTool contract: {decision: allow|deny, reason, systemMessage}.
+		emitJSONLine(map[string]any{
+			"decision":      "deny",
+			"reason":        decision.Reason,
+			"systemMessage": "Worktree write-guard blocked an out-of-worktree write",
+		})
+	case "opencode":
+		// The OpenCode plugin reads the reason from stdout and treats exit code 1 as
+		// a denial (which it surfaces by throwing, aborting the tool call).
+		fmt.Println(decision.Reason)
+		os.Exit(1)
+	}
+}
+
+// emitJSONLine marshals v and prints it on a single line to stdout for a hook.
+func emitJSONLine(v any) {
+	if data, err := json.Marshal(v); err == nil {
 		fmt.Println(string(data))
 	}
 }

--- a/internal/executor/codex_executor.go
+++ b/internal/executor/codex_executor.go
@@ -105,6 +105,18 @@ func (c *CodexExecutor) runCodex(ctx context.Context, task *db.Task, workDir, pr
 	// Kill ALL existing windows with this name (handles duplicates)
 	KillAllWindowsByNameAllSessions(windowName)
 
+	// Worktree write-guard: install Codex's PreToolUse hook so writes that would
+	// escape the isolated worktree are denied. Cleaned up when the session ends.
+	cleanupGuard, guardErr := c.executor.setupCodexWorktreeGuard(workDir, c.executor.getProjectDir(task.Project))
+	if guardErr != nil {
+		c.logger.Warn("could not set up Codex worktree guard", "error", guardErr)
+	}
+	defer func() {
+		if cleanupGuard != nil {
+			cleanupGuard()
+		}
+	}()
+
 	// Create a temp file for the prompt
 	promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
 	if err != nil {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2195,14 +2195,7 @@ func (e *Executor) setupClaudeHooks(workDir string, taskID int64) (cleanup func(
 	settingsPath := filepath.Join(claudeDir, "settings.local.json")
 
 	// Find the task binary path - use absolute path for hooks
-	taskBin, err := os.Executable()
-	if err != nil {
-		// Fall back to PATH lookup
-		taskBin, _ = exec.LookPath("task")
-		if taskBin == "" {
-			taskBin = "task"
-		}
-	}
+	taskBin := resolveTaskBin()
 
 	// Configure hooks to call our task binary
 	// The WORKTREE_TASK_ID env var is set when launching Claude

--- a/internal/executor/gemini_executor.go
+++ b/internal/executor/gemini_executor.go
@@ -79,6 +79,18 @@ func (g *GeminiExecutor) runGemini(ctx context.Context, task *db.Task, workDir, 
 	// Kill ALL existing windows with this name (handles duplicates)
 	KillAllWindowsByNameAllSessions(windowName)
 
+	// Worktree write-guard: install Gemini's BeforeTool hook so writes that would
+	// escape the isolated worktree are denied. Cleaned up when the session ends.
+	cleanupGuard, guardErr := g.executor.setupGeminiWorktreeGuard(workDir, g.executor.getProjectDir(task.Project))
+	if guardErr != nil {
+		g.logger.Warn("could not set up Gemini worktree guard", "error", guardErr)
+	}
+	defer func() {
+		if cleanupGuard != nil {
+			cleanupGuard()
+		}
+	}()
+
 	promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
 	if err != nil {
 		g.logger.Error("could not create temp file", "error", err)

--- a/internal/executor/opencode_executor.go
+++ b/internal/executor/opencode_executor.go
@@ -90,6 +90,18 @@ func (o *OpenCodeExecutor) runOpenCode(ctx context.Context, task *db.Task, workD
 	// Kill ALL existing windows with this name (handles duplicates)
 	KillAllWindowsByNameAllSessions(windowName)
 
+	// Worktree write-guard: install OpenCode's tool.execute.before plugin so writes
+	// that would escape the isolated worktree are denied. Cleaned up at session end.
+	cleanupGuard, guardErr := o.executor.setupOpenCodeWorktreeGuard(workDir, o.executor.getProjectDir(task.Project))
+	if guardErr != nil {
+		o.logger.Warn("could not set up OpenCode worktree guard", "error", guardErr)
+	}
+	defer func() {
+		if cleanupGuard != nil {
+			cleanupGuard()
+		}
+	}()
+
 	// Build the prompt content
 	promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
 	if err != nil {

--- a/internal/executor/worktree_guard.go
+++ b/internal/executor/worktree_guard.go
@@ -26,9 +26,16 @@ import (
 //   - Only taskyou-managed worktrees are guarded. "Shared dir" projects opted out
 //     of isolation, so there is no boundary to protect and the guard is inert.
 
-// WorktreeGuardInput is the minimal slice of a Claude PreToolUse payload the guard
-// needs. It is decoupled from the hook JSON struct so the guard can be unit-tested
-// without constructing full hook payloads.
+// WorktreeGuardInput is the canonical, executor-agnostic slice of a pre-tool-use
+// payload the guard needs. Every supported agent CLI (Claude, Codex, Gemini,
+// OpenCode) normalizes its native hook payload into this shape before evaluating
+// the guard, so the policy below has a single source of truth. It is also
+// decoupled from any hook JSON struct so the guard can be unit-tested without
+// constructing full hook payloads.
+//
+// ToolName uses each executor's real tool vocabulary (e.g. Claude "Write",
+// Codex "apply_patch", Gemini "write_file"/"run_shell_command"); externalWriteTargets
+// knows how to read the write destinations out of each.
 type WorktreeGuardInput struct {
 	ToolName       string
 	ToolInput      json.RawMessage
@@ -36,8 +43,12 @@ type WorktreeGuardInput struct {
 	PermissionMode string
 }
 
-// WorktreeGuardDecision maps directly onto Claude Code's
-// hookSpecificOutput.permissionDecision contract.
+// WorktreeGuardDecision is the executor-agnostic outcome. The transport layer for
+// each CLI maps it onto that CLI's wire format: Claude/Codex emit
+// hookSpecificOutput.permissionDecision; Gemini emits {decision,reason}; OpenCode
+// throws from its plugin. "ask" is only honored by Claude (whose hook protocol has
+// an interactive permission prompt); executors without one downgrade ask→deny to
+// fail safe.
 type WorktreeGuardDecision struct {
 	Decision string // "ask" or "deny"
 	Reason   string
@@ -97,14 +108,23 @@ func IsManagedWorktree(path string) bool {
 func externalWriteTargets(in WorktreeGuardInput, root string, allowExternal []string) []string {
 	var raw []string
 	switch in.ToolName {
-	case "Edit", "Write", "MultiEdit":
+	// File-edit tools whose target lives in a "file_path" field.
+	//   Claude: Edit / Write / MultiEdit   ·   Gemini: write_file / replace
+	// (The OpenCode plugin normalizes its write/edit tools to "Write" + file_path.)
+	case "Edit", "Write", "MultiEdit", "write_file", "replace":
 		raw = stringField(in.ToolInput, "file_path")
 	case "NotebookEdit":
 		raw = stringField(in.ToolInput, "notebook_path")
-	case "Bash":
+	// Shell tools whose command lives in a "command" field.
+	//   Claude: Bash   ·   Gemini: run_shell_command
+	case "Bash", "run_shell_command":
 		raw = bashWriteTargets(in.ToolInput)
+	// Codex (and the OpenCode plugin) edit files through apply_patch; the write
+	// targets live as marker lines inside the patch envelope carried in "command".
+	case "apply_patch":
+		raw = applyPatchWriteTargets(in.ToolInput)
 	default:
-		return nil // Read / Grep / Glob / etc. — reads are always allowed
+		return nil // Read / Grep / Glob / MCP / etc. — reads are always allowed
 	}
 
 	var escapes []string
@@ -167,6 +187,44 @@ func bashWriteTargets(rawInput json.RawMessage) []string {
 	// 4. Single-target mutators given an absolute/home/parent path (`rm -rf /x`).
 	for _, m := range reMutTarget.FindAllStringSubmatch(command, -1) {
 		targets = append(targets, m[2])
+	}
+	return targets
+}
+
+// --- apply_patch analysis (Codex / OpenCode) -------------------------------
+//
+// Codex performs all file edits through an apply_patch tool whose tool_input.command
+// holds a patch envelope. The mutated files are named by marker lines, e.g.:
+//
+//	*** Begin Patch
+//	*** Add File: path/to/new.go
+//	*** Update File: app/models/event.rb
+//	*** Move to: app/models/renamed.rb
+//	*** Delete File: old/thing.txt
+//	*** End Patch
+//
+// Paths are relative to the session cwd (the worktree) unless absolute. We extract
+// every Add/Update/Delete target plus any Move destination, then the shared path
+// logic decides whether any of them escape the worktree.
+var (
+	reApplyPatchFile = regexp.MustCompile(`(?m)^\s*\*\*\*\s+(?:Add|Update|Delete) File:\s*(.+?)\s*$`)
+	reApplyPatchMove = regexp.MustCompile(`(?m)^\s*\*\*\*\s+Move to:\s*(.+?)\s*$`)
+)
+
+// applyPatchWriteTargets extracts the files an apply_patch envelope would mutate.
+func applyPatchWriteTargets(rawInput json.RawMessage) []string {
+	cmds := stringField(rawInput, "command")
+	if len(cmds) == 0 {
+		return nil
+	}
+	patch := cmds[0]
+
+	var targets []string
+	for _, m := range reApplyPatchFile.FindAllStringSubmatch(patch, -1) {
+		targets = append(targets, strings.Trim(strings.TrimSpace(m[1]), `"'`))
+	}
+	for _, m := range reApplyPatchMove.FindAllStringSubmatch(patch, -1) {
+		targets = append(targets, strings.Trim(strings.TrimSpace(m[1]), `"'`))
 	}
 	return targets
 }

--- a/internal/executor/worktree_guard_hooks.go
+++ b/internal/executor/worktree_guard_hooks.go
@@ -1,0 +1,208 @@
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// This file wires the worktree write-guard (EvaluateWorktreeWriteGuard, the single
+// source of truth in worktree_guard.go) into the *non-Claude* executors by writing
+// each CLI's native pre-tool hook configuration into the task's worktree. Every
+// hook calls back into this binary's hidden `worktree-guard` subcommand, which runs
+// the shared guard and renders the decision in that CLI's wire format.
+//
+// Per-executor mechanism (researched against each CLI's official docs):
+//
+//   - Codex CLI  — PreToolUse lifecycle hook (`<worktree>/.codex/hooks.json`). Codex
+//     emits the same hookSpecificOutput/permissionDecision contract as Claude, but
+//     does NOT support permissionDecision:"ask" (it is "parsed but not supported"),
+//     so the transport downgrades ask→deny to fail safe. Codex covers file edits via
+//     the apply_patch tool and shell via Bash; the guard understands both.
+//
+//   - Gemini CLI — BeforeTool hook (`<worktree>/.gemini/settings.json`). Gemini's
+//     hook protocol is allow/deny only (no interactive "ask"), so ask→deny as well.
+//     Write tools are write_file/replace; shell is run_shell_command.
+//
+//   - OpenCode   — `tool.execute.before` plugin hook (a generated JS plugin in
+//     `<worktree>/.opencode/plugins/`). The plugin normalizes the tool call and
+//     shells back into `worktree-guard`; a non-zero exit makes it throw, which
+//     OpenCode treats as a denial. OpenCode has no human-prompt path here either,
+//     so ask→deny.
+//
+// Known gap / OS-level fallback: none of the three expose an interactive "ask" in
+// their pre-tool hook, so an external write that Claude would prompt on is instead
+// hard-denied (the user's escape hatch is worktree.allow_external_writes in
+// .taskyou.yml). Additionally, in each CLI's fully-bypassed/dangerous mode the
+// hook may not fire; for Codex specifically the default `workspace-write` OS sandbox
+// already confines writes to the worktree, which is the recommended defense-in-depth
+// when running without the guard.
+
+// resolveTaskBin returns the absolute path to the running ty/task binary so hook
+// configs can call back into it. Falls back to a PATH lookup, then the bare name.
+func resolveTaskBin() string {
+	if bin, err := os.Executable(); err == nil && bin != "" {
+		return bin
+	}
+	if bin, _ := exec.LookPath("ty"); bin != "" {
+		return bin
+	}
+	if bin, _ := exec.LookPath("task"); bin != "" {
+		return bin
+	}
+	return "task"
+}
+
+// setupCodexWorktreeGuard writes a Codex PreToolUse hook into the worktree that
+// enforces the write-guard. Returns a cleanup that restores the prior state.
+func (e *Executor) setupCodexWorktreeGuard(workDir, projectDir string) (func(), error) {
+	cmd := fmt.Sprintf("%q worktree-guard --format codex", resolveTaskBin())
+	cleanup, err := writeMergedCommandHook(filepath.Join(workDir, ".codex", "hooks.json"), "PreToolUse", cmd)
+	if err == nil && projectDir != "" {
+		ensureGitExclude(projectDir, ".codex")
+	}
+	return cleanup, err
+}
+
+// setupGeminiWorktreeGuard writes a Gemini BeforeTool hook into the worktree that
+// enforces the write-guard. Returns a cleanup that restores the prior state.
+func (e *Executor) setupGeminiWorktreeGuard(workDir, projectDir string) (func(), error) {
+	cmd := fmt.Sprintf("%q worktree-guard --format gemini", resolveTaskBin())
+	cleanup, err := writeMergedCommandHook(filepath.Join(workDir, ".gemini", "settings.json"), "BeforeTool", cmd)
+	if err == nil && projectDir != "" {
+		ensureGitExclude(projectDir, ".gemini")
+	}
+	return cleanup, err
+}
+
+// writeMergedCommandHook appends a {"type":"command","command":cmd} hook under
+// hooks.<event> in the JSON file at path, preserving any existing configuration,
+// and returns a cleanup that restores the original file (or removes it if it was
+// created here). Codex (hooks.json) and Gemini (settings.json) share this shape.
+func writeMergedCommandHook(path, event, command string) (func(), error) {
+	existingData, existingErr := os.ReadFile(path)
+
+	cfg := map[string]any{}
+	if existingErr == nil {
+		if err := json.Unmarshal(existingData, &cfg); err != nil {
+			cfg = map[string]any{}
+		}
+	}
+
+	hooks, _ := cfg["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	events, _ := hooks[event].([]any)
+	hooks[event] = append(events, map[string]any{
+		"hooks": []any{
+			map[string]any{"type": "command", "command": command},
+		},
+	})
+	cfg["hooks"] = hooks
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return nil, err
+	}
+
+	cleanup := func() {
+		if existingErr == nil {
+			_ = os.WriteFile(path, existingData, 0644)
+		} else {
+			_ = os.Remove(path)
+		}
+	}
+	return cleanup, nil
+}
+
+// setupOpenCodeWorktreeGuard writes a generated OpenCode plugin into the worktree
+// that enforces the write-guard via the tool.execute.before hook. Returns a cleanup
+// that removes the generated plugin file.
+func (e *Executor) setupOpenCodeWorktreeGuard(workDir, projectDir string) (func(), error) {
+	dir := filepath.Join(workDir, ".opencode", "plugins")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, "taskyou-worktree-guard.js")
+
+	binJSON, err := json.Marshal(resolveTaskBin())
+	if err != nil {
+		return nil, err
+	}
+	contents := "// Auto-generated by TaskYou — worktree write-guard for OpenCode.\n" +
+		"// Removed automatically when the task session ends.\n" +
+		"const TY_BIN = " + string(binJSON) + "\n" +
+		openCodeGuardPluginBody
+
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		return nil, err
+	}
+	if projectDir != "" {
+		ensureGitExclude(projectDir, ".opencode")
+	}
+	return func() { _ = os.Remove(path) }, nil
+}
+
+// openCodeGuardPluginBody is the static JS body of the generated OpenCode plugin.
+// TY_BIN is prepended at generation time. The plugin normalizes each tool call into
+// the guard's canonical shape and shells back into `worktree-guard --format opencode`;
+// a clean exit code of 1 means "deny", which it surfaces by throwing (aborting the
+// tool call). Any other outcome fails open so a guard malfunction never wedges the
+// agent.
+const openCodeGuardPluginBody = `import { spawnSync } from "node:child_process"
+
+const WORKTREE_PATH = process.env.WORKTREE_PATH || ""
+
+// Map an OpenCode tool call to the guard's canonical {tool_name, tool_input}.
+// Reads are not mapped (returns null) and therefore always allowed.
+function normalizeToolCall(tool, args) {
+  switch (tool) {
+    case "bash":
+      return { tool_name: "Bash", tool_input: { command: (args && args.command) || "" } }
+    case "write":
+    case "edit":
+      return { tool_name: "Write", tool_input: { file_path: (args && args.filePath) || "" } }
+    case "apply_patch":
+      return { tool_name: "apply_patch", tool_input: { command: (args && args.patchText) || "" } }
+    default:
+      return null
+  }
+}
+
+export const TaskYouWorktreeGuard = async ({ directory }) => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (!WORKTREE_PATH) return
+      const payload = normalizeToolCall(input && input.tool, output && output.args)
+      if (!payload) return
+      payload.cwd = directory || WORKTREE_PATH
+      payload.permission_mode = process.env.WORKTREE_DANGEROUS_MODE === "1" ? "bypassPermissions" : ""
+
+      let res
+      try {
+        res = spawnSync(TY_BIN, ["worktree-guard", "--format", "opencode"], {
+          input: JSON.stringify(payload),
+          encoding: "utf8",
+        })
+      } catch (err) {
+        return // fail open: never block the agent on a guard malfunction
+      }
+      // Only a clean exit code of 1 is a deny; anything else (allow, spawn error,
+      // unexpected code) is treated as allow.
+      if (res && res.status === 1) {
+        const reason = ((res.stdout || "").trim()) || "Write blocked: outside the isolated worktree."
+        throw new Error(reason)
+      }
+    },
+  }
+}
+`

--- a/internal/executor/worktree_guard_hooks_test.go
+++ b/internal/executor/worktree_guard_hooks_test.go
@@ -1,0 +1,162 @@
+package executor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSetupWorktreeGuardHooks verifies that each non-Claude executor's guard setup
+// writes the right pre-tool hook config into the worktree, wired to call back into
+// `worktree-guard` with the executor-appropriate format, and that cleanup removes it.
+func TestSetupWorktreeGuardHooks(t *testing.T) {
+	cases := []struct {
+		name       string
+		setup      func(e *Executor, workDir string) (func(), error)
+		relPath    string // config file written, relative to the worktree
+		wantEvent  string // hooks.<event> key (empty for the opencode plugin)
+		wantFormat string // the --format argument the hook must invoke
+		jsonHook   bool   // true for codex/gemini JSON hook configs
+	}{
+		{
+			name:       "codex",
+			setup:      func(e *Executor, wd string) (func(), error) { return e.setupCodexWorktreeGuard(wd, "") },
+			relPath:    ".codex/hooks.json",
+			wantEvent:  "PreToolUse",
+			wantFormat: "codex",
+			jsonHook:   true,
+		},
+		{
+			name:       "gemini",
+			setup:      func(e *Executor, wd string) (func(), error) { return e.setupGeminiWorktreeGuard(wd, "") },
+			relPath:    ".gemini/settings.json",
+			wantEvent:  "BeforeTool",
+			wantFormat: "gemini",
+			jsonHook:   true,
+		},
+		{
+			name:       "opencode",
+			setup:      func(e *Executor, wd string) (func(), error) { return e.setupOpenCodeWorktreeGuard(wd, "") },
+			relPath:    ".opencode/plugins/taskyou-worktree-guard.js",
+			wantFormat: "opencode",
+			jsonHook:   false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := &Executor{}
+			workDir := t.TempDir()
+
+			cleanup, err := c.setup(e, workDir)
+			if err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+			path := filepath.Join(workDir, c.relPath)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("expected config at %s: %v", c.relPath, err)
+			}
+
+			if !strings.Contains(string(data), "worktree-guard") ||
+				!strings.Contains(string(data), c.wantFormat) {
+				t.Errorf("config does not wire `worktree-guard --format %s`:\n%s", c.wantFormat, data)
+			}
+
+			if c.jsonHook {
+				command := jsonHookCommand(t, data, c.wantEvent)
+				if !strings.Contains(command, "worktree-guard --format "+c.wantFormat) {
+					t.Errorf("hook command = %q, want it to invoke worktree-guard --format %s", command, c.wantFormat)
+				}
+			} else {
+				// OpenCode plugin: must register the tool.execute.before hook.
+				if !strings.Contains(string(data), "tool.execute.before") {
+					t.Errorf("opencode plugin missing tool.execute.before hook:\n%s", data)
+				}
+			}
+
+			cleanup()
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Errorf("cleanup did not remove %s (err=%v)", c.relPath, err)
+			}
+		})
+	}
+}
+
+// TestSetupWorktreeGuardHookMergePreservesExisting verifies that wiring the guard into
+// a worktree that already has a Gemini settings.json preserves the user's existing
+// config, and that cleanup restores the original file byte-for-byte.
+func TestSetupWorktreeGuardHookMergePreservesExisting(t *testing.T) {
+	e := &Executor{}
+	workDir := t.TempDir()
+
+	geminiDir := filepath.Join(workDir, ".gemini")
+	if err := os.MkdirAll(geminiDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	settingsPath := filepath.Join(geminiDir, "settings.json")
+	original := []byte(`{"theme":"dark","hooks":{"BeforeTool":[{"hooks":[{"type":"command","command":"existing"}]}]}}`)
+	if err := os.WriteFile(settingsPath, original, 0644); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	cleanup, err := e.setupGeminiWorktreeGuard(workDir, "")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	merged, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read merged: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(merged, &cfg); err != nil {
+		t.Fatalf("merged settings not valid JSON: %v", err)
+	}
+	if cfg["theme"] != "dark" {
+		t.Errorf("merge dropped existing top-level key: %v", cfg)
+	}
+	hooks := cfg["hooks"].(map[string]any)
+	before := hooks["BeforeTool"].([]any)
+	if len(before) != 2 {
+		t.Errorf("expected existing + guard hook groups (2), got %d: %v", len(before), before)
+	}
+	if !strings.Contains(string(merged), "existing") || !strings.Contains(string(merged), "worktree-guard --format gemini") {
+		t.Errorf("merge must keep existing hook AND add the guard hook:\n%s", merged)
+	}
+
+	cleanup()
+	restored, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	if string(restored) != string(original) {
+		t.Errorf("cleanup did not restore original settings.json\n got: %s\nwant: %s", restored, original)
+	}
+}
+
+// jsonHookCommand digs the first hook command out of a {"hooks":{<event>:[{"hooks":[{"command":...}]}]}} config.
+func jsonHookCommand(t *testing.T, data []byte, event string) string {
+	t.Helper()
+	var cfg struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("hook config not valid JSON: %v\n%s", err, data)
+	}
+	groups := cfg.Hooks[event]
+	if len(groups) == 0 || len(groups[0].Hooks) == 0 {
+		t.Fatalf("no hook registered under %s: %s", event, data)
+	}
+	if groups[0].Hooks[0].Type != "command" {
+		t.Errorf("hook type = %q, want command", groups[0].Hooks[0].Type)
+	}
+	return groups[0].Hooks[0].Command
+}

--- a/internal/executor/worktree_guard_test.go
+++ b/internal/executor/worktree_guard_test.go
@@ -17,6 +17,17 @@ func toolInput(t *testing.T, m map[string]any) json.RawMessage {
 	return b
 }
 
+// applyPatch wraps one or more apply_patch marker lines in a full patch envelope,
+// mirroring what Codex passes as tool_input.command for the apply_patch tool.
+func applyPatch(markers ...string) string {
+	body := "*** Begin Patch\n"
+	for _, m := range markers {
+		body += m + "\n"
+	}
+	body += "*** End Patch\n"
+	return body
+}
+
 func TestEvaluateWorktreeWriteGuard(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -81,6 +92,47 @@ func TestEvaluateWorktreeWriteGuard(t *testing.T) {
 			allow: []string{"/home/u/shared"},
 			in:    WorktreeGuardInput{ToolName: "Write", Cwd: wt},
 		},
+		// --- non-Claude executor tool vocabularies (same policy, one source of truth) ---
+		{
+			name: "gemini write_file outside asks",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "write_file", Cwd: wt},
+			want: "ask",
+		},
+		{
+			name: "gemini write_file inside worktree allowed",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "write_file", Cwd: wt},
+		},
+		{
+			name: "gemini replace outside asks",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "replace", Cwd: wt},
+			want: "ask",
+		},
+		{
+			name: "gemini run_shell_command redirect outside asks",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "run_shell_command", Cwd: wt},
+			want: "ask",
+		},
+		{
+			name: "codex apply_patch update outside asks",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "apply_patch", Cwd: wt},
+			want: "ask",
+		},
+		{
+			name: "codex apply_patch update inside worktree allowed",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "apply_patch", Cwd: wt},
+		},
+		{
+			name: "codex apply_patch outside in bypass mode denies",
+			root: wt,
+			in:   WorktreeGuardInput{ToolName: "apply_patch", Cwd: wt, PermissionMode: "bypassPermissions"},
+			want: "deny",
+		},
 	}
 
 	// Per-case tool inputs (kept out of the struct so we can use the helper).
@@ -95,6 +147,13 @@ func TestEvaluateWorktreeWriteGuard(t *testing.T) {
 		"multiedit outside asks":                              {"file_path": "/home/u/proj/Gemfile"},
 		"shared dir project (no .task-worktrees) is inert":    {"file_path": "/home/u/proj/app/x.rb"},
 		"allowlisted external path allowed":                   {"file_path": "/home/u/shared/cache.db"},
+		"gemini write_file outside asks":                      {"file_path": "/home/u/proj/config.yaml"},
+		"gemini write_file inside worktree allowed":           {"file_path": wt + "/config.yaml"},
+		"gemini replace outside asks":                         {"file_path": "/home/u/proj/app/models/event.rb"},
+		"gemini run_shell_command redirect outside asks":      {"command": "echo data > /home/u/proj/out.txt"},
+		"codex apply_patch update outside asks":               {"command": applyPatch("*** Update File: /home/u/proj/app/models/event.rb")},
+		"codex apply_patch update inside worktree allowed":    {"command": applyPatch("*** Update File: app/models/event.rb")},
+		"codex apply_patch outside in bypass mode denies":     {"command": applyPatch("*** Add File: /home/u/proj/new.rb")},
 	}
 
 	for _, c := range cases {
@@ -144,6 +203,49 @@ func TestWorktreeWriteGuardBash(t *testing.T) {
 			}
 			if gotDecision != c.want {
 				t.Errorf("command %q: decision = %q, want %q", c.command, gotDecision, c.want)
+			}
+		})
+	}
+}
+
+// TestWorktreeWriteGuardApplyPatch covers the Codex/OpenCode apply_patch envelope
+// parser: multi-file patches, Move destinations, and mixed in/out targets.
+func TestWorktreeWriteGuardApplyPatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		markers []string
+		want    string
+	}{
+		{"single update inside allowed", []string{"*** Update File: app/x.rb"}, ""},
+		{"add inside allowed", []string{"*** Add File: pkg/new.go"}, ""},
+		{"update outside asks", []string{"*** Update File: /home/u/proj/app/x.rb"}, "ask"},
+		{"delete outside asks", []string{"*** Delete File: ../sibling/file.txt"}, "ask"},
+		{"move destination outside asks", []string{"*** Update File: app/x.rb", "*** Move to: /home/u/proj/x.rb"}, "ask"},
+		{
+			"multi-file one escapes asks",
+			[]string{"*** Update File: app/a.rb", "*** Add File: /etc/evil.conf", "*** Update File: app/b.rb"},
+			"ask",
+		},
+		{
+			"multi-file all inside allowed",
+			[]string{"*** Update File: app/a.rb", "*** Add File: app/b.rb"},
+			"",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := WorktreeGuardInput{
+				ToolName:  "apply_patch",
+				Cwd:       wt,
+				ToolInput: toolInput(t, map[string]any{"command": applyPatch(c.markers...)}),
+			}
+			got := EvaluateWorktreeWriteGuard(wt, nil, in)
+			gotDecision := ""
+			if got != nil {
+				gotDecision = got.Decision
+			}
+			if gotDecision != c.want {
+				t.Errorf("decision = %q, want %q (reason: %v)", gotDecision, c.want, reasonOf(got))
 			}
 		})
 	}


### PR DESCRIPTION
## What

[PR #573](https://github.com/bborn/taskyou/pull/573) added the worktree write-guard but only **enforced** it for Claude (via Claude Code's `PreToolUse` hook). The pure decision logic — `EvaluateWorktreeWriteGuard` in `internal/executor/worktree_guard.go` — was already executor-agnostic; only the *transport* was Claude-specific.

This PR wires that **same** guard into the other three executors using each CLI's **real** pre-tool mechanism, with **one source of truth** for the policy (no duplicated logic).

## Mechanism per executor (researched against each CLI's official docs)

| Executor | Mechanism wired | Config written into worktree | Decision contract | "ask" support |
|---|---|---|---|---|
| **Codex** | `PreToolUse` lifecycle hook | `.codex/hooks.json` | `hookSpecificOutput.permissionDecision` ∈ {allow, deny} — same shape as Claude | ❌ → `ask`→`deny` |
| **Gemini** | `BeforeTool` hook | `.gemini/settings.json` | `{ "decision": "deny", "reason": ... }` | ❌ → `ask`→`deny` |
| **OpenCode** | `tool.execute.before` **plugin** | `.opencode/plugins/taskyou-worktree-guard.js` | plugin `throw`s to abort the tool call | ❌ → `ask`→`deny` |

All three call back into a **new hidden `worktree-guard` subcommand** (`cmd/task/main.go`) — the analog of `claude-hook`. It reads the worktree root from `WORKTREE_PATH` (already exported by every executor), runs `EvaluateWorktreeWriteGuard`, and renders the decision in the requested CLI's wire format. It **fails open** on any error so a guard malfunction never wedges the agent.

### Single source of truth
The guard's write-target extraction was extended (not duplicated) to understand the non-Claude tool vocabularies, so the policy (resolve path → outside worktree? → allowlist? → bypass→deny) lives in exactly one place:
- **Codex** `apply_patch` → parses the patch envelope (`*** Add/Update/Delete File:`, `*** Move to:`) for every mutated path.
- **Gemini** `write_file` / `replace` (→ `file_path`) and `run_shell_command` (→ `command`, reuses the existing bash analysis).
- **OpenCode** the generated plugin normalizes `bash`/`write`/`edit`/`apply_patch` into the canonical `{tool_name, tool_input}` shape before piping it in.

## Policy preserved (identical to Claude)
Reads anywhere allowed · any write resolving **outside** the worktree → blocked · inert for non-worktree "shared dir" projects (gated on the `.task-worktrees` marker) · `worktree.allow_external_writes` allowlist honored · `/dev/null` & friends ignored.

## Documented gaps / fallbacks
- **No interactive "ask".** None of the three pre-tool hooks have Claude's human-prompt path, so an out-of-worktree write that Claude would *prompt* on is instead **hard-denied** (fail safe). The user's escape hatch remains `worktree.allow_external_writes` in `.taskyou.yml`. Documented at the top of `worktree_guard_hooks.go`.
- **Fully-bypassed/dangerous mode.** In each CLI's fully-bypassed mode the hook may not fire. For **Codex** specifically, the default `--sandbox workspace-write` already confines writes to the worktree at the OS level — the recommended defense-in-depth when running without the guard. (Codex project-local hooks also require the folder to be *trusted*.)
- Hooks are installed in the primary `Execute`/`Resume` path (mirrors Claude's `setupClaudeHooks`); the manual `BuildCommand` launch path is unchanged, same as Claude.

## Tests
- `worktree_guard_test.go` — added `apply_patch` (multi-file, Move, mixed in/out) + Gemini `write_file`/`replace`/`run_shell_command` cases to the existing table-driven suite.
- `worktree_guard_hooks_test.go` — new: each setup writes the correct hook config wired to `worktree-guard --format <x>`; cleanup removes it; merge preserves a pre-existing config and restores it byte-for-byte.
- End-to-end smoke-tested the built `worktree-guard` subcommand for all three formats (deny JSON / `{decision:deny}` / exit-1+reason).
- `go build ./...`, `go vet ./...`, `golangci-lint run` (CI-pinned v2.8.0), and the full `internal/executor` suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
