### PR TITLE
Fix lost executor pane for projects with a custom CLAUDE_CONFIG_DIR

### DIFF
--- a/internal/executor/claude_config_dir_test.go
+++ b/internal/executor/claude_config_dir_test.go
@@ -1,0 +1,54 @@
+package executor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+// TestBuildCommandIncludesProjectConfigDir is a regression test for "lost executor
+// pane". The TUI detail view resumes a task's executor via BuildCommand. If
+// BuildCommand omits CLAUDE_CONFIG_DIR for a project with a custom config dir, then
+// `claude --resume <id>` runs against the default ~/.claude, can't find the session
+// (which lives in the custom dir), and exits immediately — leaving only a placeholder
+// pane. BuildCommand must carry the project's config dir like the daemon launch path.
+func TestBuildCommandIncludesProjectConfigDir(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "tasks.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	if err := database.CreateProject(&db.Project{Name: "ik", Path: "/tmp/ik", ClaudeConfigDir: "~/.claude-ik"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.CreateProject(&db.Project{Name: "plain", Path: "/tmp/plain"}); err != nil {
+		t.Fatal(err)
+	}
+
+	exec := New(database, &config.Config{})
+	claude := exec.executorFactory.Get(db.ExecutorClaude)
+
+	// Custom-config project: the prefix must be present and precede `claude`.
+	custom := claude.BuildCommand(
+		&db.Task{ID: 1, Project: "ik", Port: 8080, WorktreePath: "/tmp/ik/.task-worktrees/1-x"},
+		"sess-123", "")
+	if !strings.Contains(custom, "CLAUDE_CONFIG_DIR=") {
+		t.Errorf("custom-config project: BuildCommand must set CLAUDE_CONFIG_DIR; got:\n  %s", custom)
+	}
+	if ci, pi := strings.Index(custom, "CLAUDE_CONFIG_DIR="), strings.Index(custom, " claude "); ci < 0 || pi < 0 || ci > pi {
+		t.Errorf("CLAUDE_CONFIG_DIR must precede `claude`; got:\n  %s", custom)
+	}
+
+	// Default-config project: no prefix (setting CLAUDE_CONFIG_DIR to the default
+	// breaks MCP discovery, so claudeEnvPrefix returns "").
+	def := claude.BuildCommand(
+		&db.Task{ID: 2, Project: "plain", Port: 8081, WorktreePath: "/tmp/plain"},
+		"sess-456", "")
+	if strings.Contains(def, "CLAUDE_CONFIG_DIR=") {
+		t.Errorf("default-config project: BuildCommand must NOT set CLAUDE_CONFIG_DIR; got:\n  %s", def)
+	}
+}

--- a/internal/executor/claude_executor.go
+++ b/internal/executor/claude_executor.go
@@ -149,10 +149,17 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 		worktreeSessionID = fmt.Sprintf("%d", os.Getpid())
 	}
 
+	// Per-project CLAUDE_CONFIG_DIR prefix (empty for the default dir). The daemon
+	// launch path sets this via claudeEnvPrefix; the interactive/TUI launch path
+	// (DetailModel.startResumableSession) must too, or `claude --resume <id>` for a
+	// project with a custom config dir looks in the default ~/.claude, can't find the
+	// session, and exits — leaving only a placeholder pane ("lost executor pane").
+	configPrefix := c.configDirPrefix(task)
+
 	// Build command - resume if we have a session ID, otherwise start fresh
 	if sessionID != "" {
-		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s--resume %s`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, sessionID)
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s--resume %s`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort, sessionID)
 	}
 
 	// Start fresh - if prompt is provided, write to temp file and pass it
@@ -161,18 +168,30 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 		promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
 		if err != nil {
 			c.logger.Error("BuildCommand: failed to create temp file", "error", err)
-			return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s`,
-				task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort)
+			return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s`,
+				task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort)
 		}
 		promptFile.WriteString(prompt)
 		promptFile.Close()
 
-		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s"$(cat %q)"; rm -f %q`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort, promptFile.Name(), promptFile.Name())
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s"$(cat %q)"; rm -f %q`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort, promptFile.Name(), promptFile.Name())
 	}
 
-	return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q claude %s%s`,
-		task.ID, worktreeSessionID, task.Port, task.WorktreePath, dangerousFlag, effort)
+	return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort)
+}
+
+// configDirPrefix returns the `CLAUDE_CONFIG_DIR=<dir> ` shell prefix for the task's
+// project, or "" when the project uses the default config dir. It mirrors the daemon
+// launch path (claudeEnvPrefix in executor.go), keeping the two command-builders from
+// diverging — a divergence that previously broke executor resume for projects with a
+// custom config dir.
+func (c *ClaudeExecutor) configDirPrefix(task *db.Task) string {
+	if c.executor == nil {
+		return ""
+	}
+	return claudeEnvPrefix(c.executor.claudePathsForProject(task.Project).configDir)
 }
 
 // ---- Session and Dangerous Mode Support ----


### PR DESCRIPTION
## Symptom

Opening a task's detail view "lost the executor pane" — the tmux window held only the `tail -f /dev/null` placeholder, no live executor. It hit **every task in the influencekit project** and **no** tasks in `tasks`/`personal`, regardless of status. influencekit is the only project with a custom `claude_config_dir` (`~/.claude-ik`).

## Root cause

Two diverged command-builders:

- **Daemon launch path** (executor.go:2409/2419) prepends `CLAUDE_CONFIG_DIR=<dir>` via `claudeEnvPrefix(paths.configDir)`.
- **TUI launch path** — `ClaudeExecutor.BuildCommand`, used by `DetailModel.startResumableSession` (detail.go:1023) — **omitted it** on all return paths.

So when the detail view resumed an executor, it ran `claude --resume <id>` **without** `CLAUDE_CONFIG_DIR`. For a custom-config project, claude looked in the default `~/.claude`, couldn't find the session (it lives in `~/.claude-ik`), and exited immediately. The placeholder pane — only killed *after* a successful join (detail.go:2149) — was all that remained. Default-config projects need no prefix, so they were unaffected. Opening the detail view is what triggered (and re-triggered) the loss.

Verified end to end: task 4244's session `0da9d131…` exists only under `~/.claude-ik`, not `~/.claude`; affected tasks' windows each held a lone `tail`/placeholder pane while their recorded `claude_pane_id` pointed at panes that no longer exist.

## Fix

`BuildCommand` now prepends the project's config-dir prefix on every return path, via a new `configDirPrefix(task)` helper that reuses the **same** `claudePathsForProject` + `claudeEnvPrefix` the daemon uses — so the two builders can't diverge again. Scoped to `ClaudeExecutor` (the config dir is Claude-specific; codex/gemini/opencode are unaffected).

No data loss: the sessions are intact in the custom dir, so resume now reconnects correctly and the pane + full scrollback come back on next open.

## Tests

- New `TestBuildCommandIncludesProjectConfigDir`: asserts the prefix is present and precedes `claude` for a custom-config project, and absent for the default. Written failing-first against the bug, passes with the fix.
- Full `internal/executor` suite, `go vet`, `go build ./...` all green.

## Recovery note

The running `ty` needs to be rebuilt/reinstalled with this fix; then reopening an affected task resumes correctly and replaces the placeholder. No DB cleanup required (stale `claude_pane_id` is re-resolved on open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
