### PR TITLE
fix(ui): rebuild stale executor windows instead of rejoining a dead pane

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -64,6 +64,39 @@ func pendingPaneAction(task *db.Task) paneAction {
 	return paneActionStartExecutor
 }
 
+// liveExecutorInPaneCommands reports whether any of the given tmux pane
+// current-commands indicates a live executor process (Claude, Codex, Gemini, a
+// subprocess it spawned, etc.).
+//
+// While a detail view is closed, breakTmuxPanes joins the executor pane back into
+// its daemon window, so a healthy window holds the executor plus (optionally) a
+// shell. When an executor exits — e.g. a `claude --resume` that ran against the
+// wrong CLAUDE_CONFIG_DIR before the #577 fix — the window is left with only its
+// keep-alive `tail` placeholder and/or a plain shell. Such a window must be
+// rebuilt rather than rejoined, or the detail view rejoins a dead pane forever
+// ("lost executor pane") and never reruns BuildCommand. A command is therefore a
+// live executor unless it is blank, the `tail` placeholder, or a shell.
+func liveExecutorInPaneCommands(cmds []string) bool {
+	for _, c := range cmds {
+		c = strings.TrimSpace(c)
+		if c == "" || c == "tail" || isShellCommand(c) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// isShellCommand reports whether a tmux pane_current_command is an interactive
+// shell. Login shells report with a leading dash (e.g. "-zsh").
+func isShellCommand(cmd string) bool {
+	switch strings.TrimPrefix(cmd, "-") {
+	case "zsh", "bash", "sh", "fish", "dash", "ksh", "tcsh", "csh":
+		return true
+	}
+	return false
+}
+
 // DetailModel represents the task detail view.
 type DetailModel struct {
 	task     *db.Task
@@ -602,8 +635,19 @@ func (m *DetailModel) setupPanesAsync() tea.Cmd {
 		m.cachedWindowTarget = m.findTaskWindow()
 		log.Info("setupPanesAsync: cachedWindowTarget=%q", m.cachedWindowTarget)
 
-		// Fast path: an active window exists — join it. This is the heavy ~30-call
-		// path that used to block the UI thread.
+		// Fast path: an active window exists AND still holds a live executor — join
+		// it. This is the heavy ~30-call path that used to block the UI thread.
+		//
+		// A window left with only its `tail` placeholder and/or a shell (its executor
+		// exited — e.g. a pre-#577 resume against the wrong CLAUDE_CONFIG_DIR) must NOT
+		// be rejoined: doing so reconnects to a dead pane forever and never reruns
+		// BuildCommand. Kill the stale window so the start path below rebuilds the
+		// executor (with the correct per-project config dir).
+		if m.cachedWindowTarget != "" && !m.windowHasLiveExecutor(m.cachedWindowTarget) {
+			log.Info("setupPanesAsync: window %q has no live executor (stale placeholder); killing to rebuild", m.cachedWindowTarget)
+			m.killStaleWindow(m.cachedWindowTarget)
+			m.cachedWindowTarget = ""
+		}
 		if m.cachedWindowTarget != "" {
 			m.joinTmuxPane()
 			log.Info("setupPanesAsync: joined existing window, claudePaneID=%q, workdirPaneID=%q",
@@ -925,6 +969,42 @@ func (m *DetailModel) findTaskWindow() string {
 	}
 	log.Info("findTaskWindow: window not found for task %d", m.task.ID)
 	return ""
+}
+
+// windowHasLiveExecutor reports whether the given daemon task window currently
+// holds a live executor pane. A window with only its `tail` placeholder and/or a
+// shell is a stale leftover whose executor exited; it should be rebuilt rather
+// than rejoined (see liveExecutorInPaneCommands). If the window can't be inspected
+// we assume it is live and let the normal join path surface any error — we never
+// destroy a window we failed to look at.
+func (m *DetailModel) windowHasLiveExecutor(windowTarget string) bool {
+	if windowTarget == "" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := osExec.CommandContext(ctx, "tmux", "list-panes", "-t", windowTarget, "-F", "#{pane_current_command}").Output()
+	if err != nil {
+		GetLogger().Debug("windowHasLiveExecutor: list-panes failed for %q: %v (assuming live)", windowTarget, err)
+		return true
+	}
+	return liveExecutorInPaneCommands(strings.Split(strings.TrimSpace(string(out)), "\n"))
+}
+
+// killStaleWindow removes a daemon task window that no longer has a live executor
+// pane so the caller can recreate it cleanly. Best-effort; also clears the stale
+// stored window ID so a later findTaskWindow doesn't resurrect the dead target.
+func (m *DetailModel) killStaleWindow(windowTarget string) {
+	if windowTarget == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	osExec.CommandContext(ctx, "tmux", "kill-window", "-t", windowTarget).Run()
+	if m.database != nil && m.task != nil {
+		m.database.UpdateTaskWindowID(m.task.ID, "")
+		m.task.TmuxWindowID = ""
+	}
 }
 
 // startResumableSession starts a new tmux window with the task's executor.

--- a/internal/ui/detail_live_executor_test.go
+++ b/internal/ui/detail_live_executor_test.go
@@ -1,0 +1,35 @@
+package ui
+
+import "testing"
+
+// TestLiveExecutorInPaneCommands is the core of the "lost executor pane" self-heal.
+// When the detail view opens a task that already has a daemon tmux window, it must
+// rejoin that window ONLY if the window still holds a live executor pane. A window
+// left with just its keep-alive `tail` placeholder and/or a plain shell (e.g. an
+// executor that exited before the CLAUDE_CONFIG_DIR fix) must be treated as dead so
+// the open path rebuilds it instead of rejoining a corpse forever.
+func TestLiveExecutorInPaneCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		cmds []string
+		want bool
+	}{
+		{"live claude (version) beside shell", []string{"2.1.169", "zsh"}, true},
+		{"live codex beside shell", []string{"codex", "zsh"}, true},
+		{"live subprocess (agent spawned node)", []string{"node"}, true},
+		{"dead: placeholder + shell", []string{"tail", "zsh"}, false},
+		{"dead: placeholder only", []string{"tail"}, false},
+		{"dead: interactive shell only", []string{"zsh"}, false},
+		{"dead: login shell only", []string{"-zsh"}, false},
+		{"dead: login bash + placeholder", []string{"-bash", "tail"}, false},
+		{"dead: empty list", nil, false},
+		{"dead: blank entries", []string{"", "  "}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := liveExecutorInPaneCommands(tt.cmds); got != tt.want {
+				t.Errorf("liveExecutorInPaneCommands(%q) = %v, want %v", tt.cmds, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
InfluenceKit (custom `CLAUDE_CONFIG_DIR`) tasks still showed **missing executors** after #577 ("pass CLAUDE_CONFIG_DIR when the detail view resumes an executor").

#577 fixed the command builder, but it only heals tasks whose tmux window was already gone. The open-detail path (`setupPanesAsync`) rejoins **any existing daemon window without checking whether it still holds a live executor** — and never goes through `startResumableSession`/`BuildCommand`. So a window left as a bare `tail` placeholder by a pre-fix failed `claude --resume` (which ran against the wrong config dir, exited, and left the keep-alive placeholder) is rejoined forever: the detail view shows a dead pane and never rebuilds.

## Root cause detail
On leaving a detail view, `breakTmuxPanes` join-moves the live executor pane **back** into the daemon window; the per-task `tail -f /dev/null` placeholder only holds an empty window open and is killed once a real pane rejoins. So a daemon window whose panes are **all** `tail`/shell = genuinely dead executor (Claude reports as its version string, e.g. `2.1.169`, in `pane_current_command` — not the literal `claude`).

Verified against the live system: the post-fix binary builds the correct `CLAUDE_CONFIG_DIR=…/.claude-ik claude --resume …` command (TUI log), the session files exist in `~/.claude-ik`, and ik tasks reopened *after* the fix recovered — but ones with a lingering placeholder window did not.

## Fix
`setupPanesAsync` now treats a window with no live executor pane as stale: it kills the window and falls through to the start path, which rebuilds the executor via `BuildCommand` (carrying the correct per-project config dir). Healthy windows — any pane running a non-shell, non-`tail` process — are rejoined exactly as before. If the window can't be inspected we assume it's live and never destroy it.

- `liveExecutorInPaneCommands` + `isShellCommand` — pure, unit-tested decision logic
- `windowHasLiveExecutor` / `killStaleWindow` — thin tmux-backed helpers

## Test
- New `TestLiveExecutorInPaneCommands` covers live (claude version / codex / spawned subprocess) vs dead (`tail`, login/interactive shells, placeholder+shell, empty).
- `go build ./...`, `go vet ./internal/ui/`, full `internal/ui` and executor suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)