### PR TITLE
tui: remove always-on header fleet summary

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1699,23 +1699,6 @@ func (m *AppModel) viewDashboard() string {
 		m.notifyTaskID = 0
 	}
 
-	// One-line fleet summary, shown only when there's something to report.
-	running := m.kanban.RunningTaskCount()
-	needInput := m.kanban.NeedsInputCount()
-	if running > 0 || needInput > 0 {
-		dimStyle := lipgloss.NewStyle().Foreground(ColorMuted)
-		var parts []string
-		if running > 0 {
-			parts = append(parts, lipgloss.NewStyle().Foreground(ColorInProgress).Render(
-				fmt.Sprintf("%s %d running", IconInProgress(), running)))
-		}
-		if needInput > 0 {
-			parts = append(parts, lipgloss.NewStyle().Foreground(ColorWarning).Render(
-				fmt.Sprintf("%s %d need input", IconBlocked(), needInput)))
-		}
-		headerParts = append(headerParts, strings.Join(parts, dimStyle.Render("  ·  ")))
-	}
-
 	// Show filter bar if filter is active or has text
 	filterBar := ""
 	filterBarHeight := 0


### PR DESCRIPTION
## What
Removes the always-on `N running · N need input` line from the board header.

## Why
It was made always-on in `2a1d7efd` ("tui: drop the live-mode toggle and make it the only state"), having originally been a live-mode-only indicator in `1ae58192`. It's noise in the header now, so drop it.

## Notes
- Removes the "One-line fleet summary" block in `internal/ui/app.go`.
- The underlying `RunningTaskCount`/`NeedsInputCount` methods stay (still used elsewhere); no tests asserted the summary line.
- `internal/ui` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)