### PR TITLE
fix(ui): Done column shows pinned-only slice, hiding recently completed tasks

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -381,12 +381,13 @@ func (db *DB) GetTask(id int64) (*Task, error) {
 
 // ListTasksOptions defines options for listing tasks.
 type ListTasksOptions struct {
-	Status        string
-	Type          string
-	Project       string
-	Limit         int
-	Offset        int
-	IncludeClosed bool // Include closed tasks even when Status is empty
+	Status         string
+	Type           string
+	Project        string
+	Limit          int
+	Offset         int
+	IncludeClosed  bool // Include closed tasks even when Status is empty
+	OrderByRecency bool // Sort purely by recency, ignoring pinned-first ordering
 }
 
 // ListTasks retrieves tasks with optional filters.
@@ -430,9 +431,18 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 		query += " AND status NOT IN ('done', 'archived')"
 	}
 
-	// Pinning takes precedence, then sort done/blocked tasks by completed_at (most recently closed first)
-	// and other tasks by created_at (newest first). Use id DESC as secondary sort for consistency.
-	query += " ORDER BY pinned DESC, CASE WHEN status IN ('done', 'blocked') THEN completed_at ELSE created_at END DESC, id DESC"
+	// Sort done/blocked tasks by completed_at (most recently closed first) and
+	// other tasks by created_at (newest first). Use id DESC as secondary sort for
+	// consistency. Pinning takes precedence unless OrderByRecency is set: a capped
+	// slice (e.g. the kanban's Done column) must select the most recent tasks, and
+	// pinned-first selection would let old pinned tasks crowd newer ones out of the
+	// limit entirely.
+	recency := " CASE WHEN status IN ('done', 'blocked') THEN completed_at ELSE created_at END DESC, id DESC"
+	if opts.OrderByRecency {
+		query += " ORDER BY" + recency
+	} else {
+		query += " ORDER BY pinned DESC," + recency
+	}
 
 	if opts.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", opts.Limit)

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -739,6 +739,75 @@ func TestListTasksPinnedFirst(t *testing.T) {
 	}
 }
 
+func TestListTasksOrderByRecencyIgnoresPinned(t *testing.T) {
+	// Create temporary database
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	database, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer database.Close()
+	defer os.Remove(dbPath)
+
+	if err := database.CreateProject(&Project{Name: "test", Path: tmpDir}); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	makeTask := func(title string) *Task {
+		return &Task{Title: title, Status: StatusBacklog, Type: TypeCode, Project: "test"}
+	}
+
+	pinned := makeTask("Pinned older task")
+	recent := makeTask("Recent task")
+	newest := makeTask("Newest task")
+
+	for _, task := range []*Task{pinned, recent, newest} {
+		if err := database.CreateTask(task); err != nil {
+			t.Fatalf("failed to create task %q: %v", task.Title, err)
+		}
+		if err := database.UpdateTaskStatus(task.ID, StatusDone); err != nil {
+			t.Fatalf("failed to complete task %q: %v", task.Title, err)
+		}
+	}
+
+	// Give each task a distinct completed_at so ordering is deterministic
+	for _, tc := range []struct {
+		id     int64
+		offset string
+	}{
+		{pinned.ID, "-10 minutes"},
+		{recent.ID, "-1 minute"},
+		{newest.ID, "-1 second"},
+	} {
+		if _, err := database.Exec(`UPDATE tasks SET completed_at = datetime('now', ?) WHERE id = ?`, tc.offset, tc.id); err != nil {
+			t.Fatalf("failed to adjust completed_at: %v", err)
+		}
+	}
+
+	if err := database.UpdateTaskPinned(pinned.ID, true); err != nil {
+		t.Fatalf("failed to pin task: %v", err)
+	}
+
+	// With OrderByRecency, a capped slice must return the most recently
+	// completed tasks — an old pinned task must not crowd out newer ones.
+	tasks, err := database.ListTasks(ListTasksOptions{Status: StatusDone, Limit: 2, OrderByRecency: true})
+	if err != nil {
+		t.Fatalf("failed to list tasks: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+
+	if tasks[0].ID != newest.ID {
+		t.Fatalf("expected newest task #%d first, got #%d", newest.ID, tasks[0].ID)
+	}
+	if tasks[1].ID != recent.ID {
+		t.Fatalf("expected recent task #%d second, got #%d", recent.ID, tasks[1].ID)
+	}
+}
+
 func TestCreateTaskSavesLastType(t *testing.T) {
 	// Create temporary database
 	tmpDir := t.TempDir()

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4013,8 +4013,10 @@ func (m *AppModel) loadTasks() tea.Cmd {
 			return tasksLoadedMsg{err: err}
 		}
 
-		// Load limited done tasks (most recent)
-		doneTasks, err := m.db.ListTasks(db.ListTasksOptions{Status: db.StatusDone, Limit: maxDoneTasksInKanban})
+		// Load limited done tasks (most recently completed). OrderByRecency keeps
+		// old pinned tasks from crowding newer ones out of the capped slice; the
+		// kanban still floats pinned tasks to the top of the visible column.
+		doneTasks, err := m.db.ListTasks(db.ListTasksOptions{Status: db.StatusDone, Limit: maxDoneTasksInKanban, OrderByRecency: true})
 		if err != nil {
 			return tasksLoadedMsg{err: err}
 		}


### PR DESCRIPTION
## Problem

The kanban board loads only the 20 most recent done tasks (`maxDoneTasksInKanban`), but `ListTasks` orders by `pinned DESC` before recency. Once 20+ pinned done tasks accumulate, they monopolize the capped slice: recently completed tasks are never loaded into the UI at all, and the project filter can't surface them (it only filters loaded tasks).

Observed live: 111 pinned done tasks meant the Done column's newest visible task was from June 9, while the most recently completed task in the DB (#4304, completed June 10) ranked 112th in the query and was invisible — even filtered by its project.

## Fix

- Add `ListTasksOptions.OrderByRecency` — sorts purely by recency (completed_at/created_at), skipping the pinned-first ordering.
- Use it for the kanban's capped Done slice in `loadTasks()`.

Pin behavior is preserved: the default ordering is unchanged for all other callers (`TestListTasksPinnedFirst` still passes), and the kanban presentation layer (`sortColumnTasks`) still floats pinned tasks to the top of the visible column. The only change is that an old pinned done task no longer evicts newer tasks from the 20-task selection window.

## Tests

- New: `TestListTasksOrderByRecencyIgnoresPinned` — a capped recency-ordered slice excludes an old pinned task in favor of newer ones.
- `go test ./internal/db/ ./internal/ui/ ./internal/web/` green; golangci-lint v2.8.0 clean.

## Known follow-up (not in this PR)

The web board (`handleBoard` → `BuildBoardSnapshot`) has the same crowding pattern in its single 500-row pinned-first selection. Fixing it properly means per-status loads like the TUI; left out to keep this change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)