### PR TITLE
fix(release): build ty-chrome.zip outside dist/ so goreleaser's empty-dist check passes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,9 @@ before:
   hooks:
     # Package the Chrome extension as a release asset (load-unpacked install;
     # not distributed via the Web Store). demo/ is dev tooling, excluded.
-    - mkdir -p dist
-    - sh -c 'cd extensions && zip -r ../dist/ty-chrome.zip ty-chrome -x "ty-chrome/demo/*" -x "ty-chrome/screenshots/*"'
+    # Must NOT write into dist/ — before hooks run ahead of goreleaser's
+    # "dist must be empty" check, so anything placed there fails the release.
+    - sh -c 'rm -f /tmp/ty-chrome.zip && cd extensions && zip -r /tmp/ty-chrome.zip ty-chrome -x "ty-chrome/demo/*" -x "ty-chrome/screenshots/*"'
 
 builds:
   - id: ty
@@ -49,7 +50,7 @@ archives:
 release:
   draft: false
   extra_files:
-    - glob: dist/ty-chrome.zip
+    - glob: /tmp/ty-chrome.zip
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Why

The v0.3.4 release [failed](https://github.com/bborn/taskyou/actions/runs/27342371358/job/80782183420) with:

```
⨯ release failed after 0s  error=dist is not empty, remove it before running goreleaser or use the --clean flag
```

GoReleaser runs global `before` hooks **ahead of** its "dist must be empty" check, so the hook added in `afd7cda6` (zipping the Chrome extension into `dist/ty-chrome.zip`) trips the check on every release. `--clean` doesn't help — it cleans at startup, before the hooks run.

## Fix

Build the zip in `/tmp` instead and point `release.extra_files` there. `rm -f` first because `zip -r` appends to an existing archive.

## Verification

`goreleaser release --snapshot --clean --skip=publish` now passes locally: before hook runs, dist check passes, all 8 binaries build and archive; `/tmp/ty-chrome.zip` contains the extension with `demo/` and `screenshots/` excluded.

After merge, v0.3.4 needs to be re-tagged on main to re-trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
