### PR TITLE
fix(release): extra_files glob rejects absolute paths — build ty-chrome.zip at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ tmux-*.log
 .playwright-mcp/
 .mcp.json
 .gstack/
+
+# goreleaser before-hook output (release.extra_files)
+ty-chrome.zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,9 @@ before:
     # not distributed via the Web Store). demo/ is dev tooling, excluded.
     # Must NOT write into dist/ — before hooks run ahead of goreleaser's
     # "dist must be empty" check, so anything placed there fails the release.
-    - sh -c 'rm -f /tmp/ty-chrome.zip && cd extensions && zip -r /tmp/ty-chrome.zip ty-chrome -x "ty-chrome/demo/*" -x "ty-chrome/screenshots/*"'
+    # Must be a relative path — extra_files globs reject absolute paths.
+    # ty-chrome.zip is gitignored so leftovers don't trip the dirty-state check.
+    - sh -c 'rm -f ty-chrome.zip && cd extensions && zip -r ../ty-chrome.zip ty-chrome -x "ty-chrome/demo/*" -x "ty-chrome/screenshots/*"'
 
 builds:
   - id: ty
@@ -50,7 +52,7 @@ archives:
 release:
   draft: false
   extra_files:
-    - glob: /tmp/ty-chrome.zip
+    - glob: ./ty-chrome.zip
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Why

Follow-up to #587. The v0.3.5 release ([run 27343638135](https://github.com/bborn/taskyou/actions/runs/27343638135)) got past the empty-dist check and built everything, but failed at publish:

```
⨯ release failed: scm releases: failed to publish artifacts: globbing failed for pattern /tmp/ty-chrome.zip: stat static prefix .//tmp/ty-chrome.zip: invalid argument
```

GoReleaser's `extra_files` globbing prepends `./` and rejects absolute patterns — `/tmp` was the wrong place for the zip.

## Fix

Build the zip at the repo root (`./ty-chrome.zip`) — the documented relative form — and gitignore it so leftovers from local runs don't trip GoReleaser's git dirty-state check (`git status --porcelain` ignores ignored files).

## Verification

`goreleaser release --snapshot --clean --skip=publish` passes; the zip lands at the repo root with `demo/` and `screenshots/` excluded, and does not show up in `git status`.

## After merge

The empty **draft** v0.3.5 release (created by the failed run, no assets, not publicly visible) should be deleted, and a new tag cut from main to re-trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
