### PR TITLE
fix(routine): launchd schedule test fails on Linux CI (main is red)

### DIFF
--- a/internal/routine/schedule_test.go
+++ b/internal/routine/schedule_test.go
@@ -203,6 +203,11 @@ func TestCalendarCronUsesLaunchdOnDarwin(t *testing.T) {
 
 func TestInstallAndRemoveLaunchdSchedule(t *testing.T) {
 	agents, _ := setupScheduleTest(t)
+	// Interval schedules pick launchd only on darwin; force it so the test
+	// exercises the launchd path on Linux CI too (everything else is stubbed).
+	prev := osGOOS
+	osGOOS = "darwin"
+	t.Cleanup(func() { osGOOS = prev })
 
 	sched, err := InstallSchedule("scout", ScheduleOptions{Every: 30 * time.Minute})
 	if err != nil {


### PR DESCRIPTION
Main's Test job has been red since #589: `TestInstallAndRemoveLaunchdSchedule` asserts the launchd backend, but interval schedules only pick launchd on darwin — on ubuntu runners it installs a cron schedule and the assertion fails.

One-line-ish fix: force `osGOOS = "darwin"` through the existing test seam, exactly as `TestCalendarCronUsesLaunchdOnDarwin` already does. Everything else in the test is already platform-stubbed (launchctl/crontab stubs, isolated dirs).

This also un-reds the merge-result CI of every open PR (e.g. #583).

🤖 Generated with [Claude Code](https://claude.com/claude-code)