### PR TITLE
feat(parity): CI-enforced multi-surface parity harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,38 @@ Local:  ty -l (launches TUI + daemon)
 Remote: ssh -p 2222 user@server
 ```
 
+## Multi-Surface Parity (CI-enforced)
+
+TaskYou has three user surfaces over one Go core: **CLI** (cobra), **TUI**
+(Bubble Tea), and **GUI** (`desktop/`, also served in the browser by
+`ty serve`). Parity between them is enforced — not watched — by
+`internal/parity`, which runs in the normal test suite and fails CI on drift.
+
+**The rule: a user-facing feature is not done until its logic lives below
+`internal/ui` and is reachable through the HTTP API.** UIs are thin views;
+putting logic only in TUI keybinding handlers makes it invisible to the GUI,
+the browser, and agents.
+
+How the harness works:
+
+1. The TUI's capability surface is derived mechanically from `ui.KeyMap` —
+   every exported `key.Binding` field is a user-facing action.
+2. Every action must appear in **`desktop/capabilities.json`** (the GUI covers
+   it; optional `api` entries are verified against the routes registered in
+   `internal/web/server.go`) **or** in **`parity-ignore.json`** with a written
+   reason. Anything else fails the build.
+3. Stale entries (covering or ignoring actions that no longer exist) also fail,
+   so the files cannot rot.
+
+When you add a TUI feature:
+
+- Implement it in the GUI too and add it to `desktop/capabilities.json`, **or**
+- Make skipping the GUI a deliberate decision: add it to `parity-ignore.json`
+  with a reason (and ideally a date). Deleting the ignore entry later is the
+  signal that the gap was closed.
+
+Do not weaken the parity test to get CI green.
+
 ## Repository Structure
 
 ```

--- a/desktop/capabilities.json
+++ b/desktop/capabilities.json
@@ -1,0 +1,153 @@
+{
+  "covers": {
+    "Archive": {
+      "api": [
+        "POST /api/tasks/{id}/status"
+      ],
+      "note": "a with confirm"
+    },
+    "Back": {
+      "note": "Esc walks back through overlays/views"
+    },
+    "ChangeStatus": {
+      "api": [
+        "POST /api/tasks/{id}/status"
+      ],
+      "note": "S dialog"
+    },
+    "Close": {
+      "api": [
+        "POST /api/tasks/{id}/close"
+      ],
+      "note": "c, drag to Done"
+    },
+    "CollapseBacklog": {
+      "note": "["
+    },
+    "CollapseDone": {
+      "note": "]"
+    },
+    "CommandPalette": {
+      "note": "p, f, \u2318P \u2014 cmdk palette"
+    },
+    "Delete": {
+      "api": [
+        "DELETE /api/tasks/{id}"
+      ],
+      "note": "d with confirm"
+    },
+    "Down": {
+      "note": "Arrow keys move board selection"
+    },
+    "Edit": {
+      "api": [
+        "PATCH /api/tasks/{id}"
+      ],
+      "note": "e, detail Edit button"
+    },
+    "Enter": {
+      "note": "Open task detail"
+    },
+    "Filter": {
+      "note": "/ \u2014 text, #id, [project] with autocomplete dropdown"
+    },
+    "FocusBacklog": {
+      "note": "B"
+    },
+    "FocusBlocked": {
+      "note": "L"
+    },
+    "FocusDone": {
+      "note": "D"
+    },
+    "FocusInProgress": {
+      "note": "P"
+    },
+    "Help": {
+      "note": "? shortcut overlay"
+    },
+    "JumpToNotification": {
+      "note": "g; toasts also carry an Open action"
+    },
+    "JumpToPinned": {
+      "note": "shift+\u2191 jumps to first pinned task in column"
+    },
+    "JumpToUnpinned": {
+      "note": "shift+\u2193 jumps to first unpinned task in column"
+    },
+    "Left": {
+      "note": "Arrow keys move board selection"
+    },
+    "New": {
+      "api": [
+        "POST /api/tasks"
+      ],
+      "note": "n, \u2318N, titlebar button"
+    },
+    "OpenBrowser": {
+      "note": "b \u2014 opens task branch in browser"
+    },
+    "OpenPR": {
+      "note": "G / PR button"
+    },
+    "OpenWorktree": {
+      "note": "o / Editor button \u2014 opens worktree in code editor"
+    },
+    "Queue": {
+      "api": [
+        "POST /api/tasks/{id}/execute"
+      ],
+      "note": "x, Execute button, drag to In Progress"
+    },
+    "QueueDangerous": {
+      "api": [
+        "PATCH /api/tasks/{id}",
+        "POST /api/tasks/{id}/execute"
+      ],
+      "note": "X"
+    },
+    "Quit": {
+      "note": "\u2318Q / native window close"
+    },
+    "Refresh": {
+      "api": [
+        "GET /api/tasks"
+      ],
+      "note": "R; SSE keeps board live anyway"
+    },
+    "Retry": {
+      "api": [
+        "POST /api/tasks/{id}/retry"
+      ],
+      "note": "r, Reply dialog"
+    },
+    "Right": {
+      "note": "Arrow keys move board selection"
+    },
+    "Settings": {
+      "note": "s, \u2318,, titlebar gear"
+    },
+    "Spotlight": {
+      "note": "f opens the fuzzy task palette"
+    },
+    "ToggleDangerous": {
+      "note": "! cycles permission mode for new executions"
+    },
+    "TogglePin": {
+      "api": [
+        "POST /api/tasks/{id}/pin"
+      ],
+      "note": "t"
+    },
+    "Up": {
+      "note": "Arrow keys move board selection"
+    }
+  },
+  "gui_only": [
+    "BrowserMirrorTerminal",
+    "DragAndDropBoard",
+    "NativeNotifications",
+    "RealPtyTerminal",
+    "ThemeToggle"
+  ]
+}

--- a/internal/parity/parity_test.go
+++ b/internal/parity/parity_test.go
@@ -1,0 +1,199 @@
+// Package parity enforces multi-surface feature parity in CI.
+//
+// The TUI's capability surface is derived mechanically from ui.KeyMap (every
+// exported key.Binding field is a user-facing action). Each action must be
+// either:
+//
+//   - covered by the GUI: listed in desktop/capabilities.json, or
+//   - explicitly ignored: listed in parity-ignore.json with a reason.
+//
+// Anything else fails the build. Stale entries (covering or ignoring actions
+// that no longer exist) also fail, so the files can't rot. Capabilities that
+// declare API routes are checked against the routes actually registered in
+// internal/web/server.go.
+//
+// Adding a TUI feature? Either implement it in the GUI and add it to
+// desktop/capabilities.json, or make the skip a deliberate, documented
+// decision in parity-ignore.json.
+package parity
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/key"
+
+	"github.com/bborn/workflow/internal/ui"
+)
+
+// capability is one GUI-covered TUI action.
+type capability struct {
+	// API routes (e.g. "POST /api/tasks/{id}/execute") this capability uses;
+	// verified against internal/web/server.go.
+	API []string `json:"api,omitempty"`
+	// Note for humans reading the manifest.
+	Note string `json:"note,omitempty"`
+}
+
+type manifest struct {
+	// Covers maps TUI action names (ui.KeyMap field names) to how the GUI
+	// implements them.
+	Covers map[string]capability `json:"covers"`
+	// GUIOnly documents capabilities with no TUI equivalent (informational).
+	GUIOnly []string `json:"gui_only,omitempty"`
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate source file")
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(file)))
+}
+
+func loadJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+}
+
+// tuiActions enumerates the TUI's user-facing actions from the keymap struct.
+func tuiActions() []string {
+	var names []string
+	bindingType := reflect.TypeOf(key.Binding{})
+	keyMapType := reflect.TypeOf(ui.KeyMap{})
+	for i := 0; i < keyMapType.NumField(); i++ {
+		field := keyMapType.Field(i)
+		if field.IsExported() && field.Type == bindingType {
+			names = append(names, field.Name)
+		}
+	}
+	return names
+}
+
+// apiRoutes parses internal/web/server.go and returns every literal route
+// pattern registered on the mux (e.g. "POST /api/tasks/{id}/execute").
+func apiRoutes(t *testing.T) map[string]bool {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "internal", "web", "server.go")
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	routes := make(map[string]bool)
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) < 1 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || (sel.Sel.Name != "HandleFunc" && sel.Sel.Name != "Handle") {
+			return true
+		}
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		pattern := strings.Trim(lit.Value, `"`)
+		routes[pattern] = true
+		return true
+	})
+	if len(routes) == 0 {
+		t.Fatal("no routes parsed from server.go — parser drift?")
+	}
+	return routes
+}
+
+func TestGUICoversTUISurface(t *testing.T) {
+	root := repoRoot(t)
+
+	var caps manifest
+	loadJSON(t, filepath.Join(root, "desktop", "capabilities.json"), &caps)
+
+	var ignored map[string]string
+	loadJSON(t, filepath.Join(root, "parity-ignore.json"), &ignored)
+
+	actions := tuiActions()
+	if len(actions) < 10 {
+		t.Fatalf("suspiciously few TUI actions (%d) — keymap reflection drift?", len(actions))
+	}
+	actionSet := make(map[string]bool, len(actions))
+	for _, a := range actions {
+		actionSet[a] = true
+	}
+
+	// Every TUI action is covered or explicitly ignored.
+	for _, action := range actions {
+		_, covered := caps.Covers[action]
+		reason, isIgnored := ignored[action]
+		switch {
+		case covered && isIgnored:
+			t.Errorf("%s is both covered and ignored — remove it from parity-ignore.json", action)
+		case !covered && !isIgnored:
+			t.Errorf(
+				"GUI parity gap: TUI action %q is not covered by desktop/capabilities.json.\n"+
+					"Either implement it in the GUI and add it to the manifest, or explicitly skip it\n"+
+					"by adding it to parity-ignore.json with a reason.",
+				action,
+			)
+		case isIgnored && strings.TrimSpace(reason) == "":
+			t.Errorf("parity-ignore.json entry %q needs a non-empty reason", action)
+		}
+	}
+
+	// No stale or misspelled entries.
+	for name := range caps.Covers {
+		if !actionSet[name] {
+			t.Errorf("desktop/capabilities.json covers %q, which is not a TUI action (typo or removed feature?)", name)
+		}
+	}
+	for name := range ignored {
+		if !actionSet[name] {
+			t.Errorf("parity-ignore.json ignores %q, which is not a TUI action — remove the stale entry", name)
+		}
+	}
+
+	// Declared API routes must exist.
+	routes := apiRoutes(t)
+	for name, capability := range caps.Covers {
+		for _, route := range capability.API {
+			if !routes[route] {
+				t.Errorf("capability %q references API route %q, which is not registered in internal/web/server.go", name, route)
+			}
+		}
+	}
+}
+
+// TestParityFilesParse keeps the manifest and ignore files valid JSON.
+func TestParityFilesParse(t *testing.T) {
+	root := repoRoot(t)
+	for _, rel := range []string{
+		filepath.Join("desktop", "capabilities.json"),
+		"parity-ignore.json",
+	} {
+		raw, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		var v any
+		if err := json.Unmarshal(raw, &v); err != nil {
+			t.Errorf("parse %s: %v", rel, err)
+		}
+	}
+}

--- a/parity-ignore.json
+++ b/parity-ignore.json
@@ -1,0 +1,5 @@
+{
+  "Routines": "GUI routines view not built yet \u2014 acknowledged gap (2026-06-11). Needs /api/routines endpoints first; remove this entry when the GUI ships it.",
+  "SpotlightSync": "macOS Spotlight metadata export is a local-indexing concern; intentionally TUI/CLI-only.",
+  "ToggleShellPane": "The GUI terminal renders the full tmux window (executor + shell panes together), so there is no separate shell pane to toggle."
+}


### PR DESCRIPTION
Makes CLI/TUI/GUI parity drift a **build failure** instead of a thing to watch for.

## How it works

1. The TUI's capability surface is derived mechanically from `ui.KeyMap` — every exported `key.Binding` field is a user-facing action (38 today). No manual list to forget to update.
2. Every action must be either **covered** in `desktop/capabilities.json` or **explicitly ignored** in `parity-ignore.json` with a written reason. An uncovered action fails CI with instructions:
   ```
   GUI parity gap: TUI action "Routines" is not covered by desktop/capabilities.json.
   Either implement it in the GUI and add it to the manifest, or explicitly skip it
   by adding it to parity-ignore.json with a reason.
   ```
3. Capabilities may declare the API routes they use (`"api": ["POST /api/tasks/{id}/execute"]`); these are verified against the routes actually registered in `internal/web/server.go` (AST-parsed). The manifest can't reference endpoints that don't exist — and deleting a route the GUI depends on fails too.
4. **Stale entries fail**: covering or ignoring an action that no longer exists in the keymap is an error, so the files can't rot.

Runs as a plain `go test` in the existing Test job — no new CI wiring.

## Current state, encoded honestly

- `Routines` → ignored with a dated reason (GUI view not built yet; needs `/api/routines` first). Removing the ignore entry is the signal the gap closed.
- `SpotlightSync`, `ToggleShellPane` → deliberate non-goals with reasons (the GUI terminal shows the whole tmux window; Spotlight export is local-indexing).
- Everything else (35 actions) is covered.

AGENTS.md codifies the underlying rule: **a feature isn't done until its logic lives below `internal/ui` and is reachable through the API** — UIs are thin views.

Both failure modes verified by mutation (removed an ignore → gap failure; pointed a capability at a fake route → route failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)