### PR TITLE
feat: curl|bash installer for the macOS desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,22 @@ See [Full CLI Scriptability](#full-cli-scriptability) for the complete command s
 ![Web UI](docs/screenshots/gui-board.png)
 *The same Kanban board in the desktop app or any browser*
 
-Just want the GUI? Grab a prebuilt bundle from the [latest release](https://github.com/bborn/taskyou/releases/latest):
+Just want the GUI? On macOS, install it with one command:
+
+```sh
+curl -fsSL taskyou.dev/install-macos.sh | bash
+```
+
+This downloads the latest DMG, verifies it, installs **TaskYou.app** to `~/Applications`, and launches it — no Gatekeeper prompts, no sudo. Set `TASKYOU_INSTALL_SYSTEM=1` to install to `/Applications` for all users instead.
+
+Or grab a prebuilt bundle from the [latest release](https://github.com/bborn/taskyou/releases/latest):
 
 - **macOS**: `TaskYou-macos-arm64.dmg` (Apple Silicon) or `TaskYou-macos-x64.dmg` (Intel)
 - **Linux**: `TaskYou-linux-x64.AppImage` or `.deb`
 
 The app is self-contained — it ships its own `ty` engine and starts the server and daemon for you. Two things must be installed on your machine: **tmux** (`brew install tmux`) and at least one executor CLI (e.g. [Claude Code](https://claude.com/claude-code)).
 
-The macOS bundles are ad-hoc signed but not notarized, so macOS flags them on first launch. Drag **TaskYou.app** to Applications, then either right-click it → **Open** → **Open**, or clear the download quarantine flag:
+The macOS bundles are ad-hoc signed but not notarized, so macOS flags DMGs downloaded in a browser on first launch (the install script above avoids this entirely). If you installed from a browser-downloaded DMG, drag **TaskYou.app** to Applications, then either right-click it → **Open** → **Open**, or clear the download quarantine flag:
 
 ```sh
 xattr -dr com.apple.quarantine /Applications/TaskYou.app

--- a/docs/_headers
+++ b/docs/_headers
@@ -2,3 +2,6 @@
 /install.sh
   Content-Type: text/plain; charset=utf-8
   Cache-Control: no-cache
+/install-macos.sh
+  Content-Type: text/plain; charset=utf-8
+  Cache-Control: no-cache

--- a/docs/install-macos.sh
+++ b/docs/install-macos.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# TaskYou Desktop (macOS) Installation Script
+# Usage: curl -fsSL taskyou.dev/install-macos.sh | bash
+#
+# Downloads the TaskYou desktop app DMG from the latest GitHub release,
+# verifies it, and installs TaskYou.app. Because curl downloads never get
+# the com.apple.quarantine flag, this skips Gatekeeper's "unidentified
+# developer" prompt entirely — no right-click → Open dance needed.
+#
+# Installs to ~/Applications by default (no sudo required).
+#
+# Environment variables:
+#   TASKYOU_INSTALL_SYSTEM=1   Install to /Applications for all users (uses sudo)
+#   TASKYOU_NO_LAUNCH=1        Don't launch the app after installing
+#   TASKYOU_GITHUB_REPO        Override the GitHub repo (default: bborn/taskyou)
+
+set -euo pipefail
+
+REPO="${TASKYOU_GITHUB_REPO:-bborn/taskyou}"
+APP_NAME="TaskYou.app"
+SYSTEM_APP="/Applications/${APP_NAME}"
+USER_APP="${HOME}/Applications/${APP_NAME}"
+
+# Colors for output (only when attached to a terminal)
+RED=""
+GREEN=""
+YELLOW=""
+BOLD=""
+NC=""
+if [ -t 1 ]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[1;33m'
+    BOLD=$'\033[1m'
+    NC=$'\033[0m'
+fi
+
+banner() {
+    printf '%s' "${BOLD}"
+    cat <<'EOF'
+
+ ████████╗ █████╗ ███████╗██╗  ██╗██╗   ██╗ ██████╗ ██╗   ██╗
+ ╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝╚██╗ ██╔╝██╔═══██╗██║   ██║
+    ██║   ███████║███████╗█████╔╝  ╚████╔╝ ██║   ██║██║   ██║
+    ██║   ██╔══██║╚════██║██╔═██╗   ╚██╔╝  ██║   ██║██║   ██║
+    ██║   ██║  ██║███████║██║  ██╗   ██║   ╚██████╔╝╚██████╔╝
+    ╚═╝   ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝   ╚═╝    ╚═════╝  ╚═════╝
+
+EOF
+    printf '%s' "${NC}"
+    printf '%sTaskYou · macOS desktop installer%s\n\n' "${BOLD}" "${NC}"
+}
+
+step() {
+    printf '%s✓%s %s\n' "${GREEN}" "${NC}" "$1"
+}
+
+info() {
+    printf '%s==>%s %s\n' "${GREEN}" "${NC}" "$1"
+}
+
+warn() {
+    printf '%sWarning:%s %s\n' "${YELLOW}" "${NC}" "$1" >&2
+}
+
+error() {
+    printf '%sError:%s %s\n' "${RED}" "${NC}" "$1" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || error "Required command not found: $1"
+}
+
+# Map the machine architecture to a release DMG asset
+detect_asset() {
+    local arch
+    arch=$(uname -m)
+    case "$arch" in
+        arm64) echo "TaskYou-macos-arm64.dmg" ;;
+        x86_64) echo "TaskYou-macos-x64.dmg" ;;
+        *) error "Unsupported architecture: ${arch}. TaskYou Desktop ships for arm64 (Apple Silicon) and x86_64 (Intel)." ;;
+    esac
+}
+
+# Globals for the EXIT trap (locals would be gone by the time it fires)
+TMP_DIR=""
+MOUNT_POINT=""
+cleanup() {
+    if [ -n "${MOUNT_POINT}" ] && [ -d "${MOUNT_POINT}" ]; then
+        hdiutil detach "${MOUNT_POINT}" >/dev/null 2>&1 || true
+    fi
+    if [ -n "${TMP_DIR}" ]; then
+        rm -rf "${TMP_DIR}"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+main() {
+    banner
+
+    if [ "$(uname -s)" != "Darwin" ]; then
+        error "This installer is macOS-only. For the CLI/TUI (macOS and Linux): curl -fsSL taskyou.dev/install.sh | bash"
+    fi
+
+    require_command curl
+    require_command hdiutil
+    require_command ditto
+    require_command xattr
+    require_command open
+
+    local asset
+    asset=$(detect_asset)
+    step "Detected macOS $(uname -m) → ${asset}"
+
+    # Pick the install destination
+    local dest other_copy sudo_cmd=""
+    if [ -n "${TASKYOU_INSTALL_SYSTEM:-}" ]; then
+        dest="${SYSTEM_APP}"
+        other_copy="${USER_APP}"
+        if [ "$(id -u)" -ne 0 ]; then
+            command -v sudo >/dev/null 2>&1 || error "sudo is required to install into /Applications. Unset TASKYOU_INSTALL_SYSTEM to install to ~/Applications without a password."
+            sudo_cmd="sudo"
+        fi
+    else
+        dest="${USER_APP}"
+        other_copy="${SYSTEM_APP}"
+    fi
+
+    # Warn if a copy already lives in the *other* location — macOS may keep
+    # launching that one instead of the copy we are about to install.
+    if [ -e "${other_copy}" ]; then
+        echo "" >&2
+        warn "TaskYou is already installed at: ${other_copy}"
+        printf '  Remove that copy to avoid two installs (macOS may launch it instead of this one):\n' >&2
+        if [ "${other_copy}" = "${SYSTEM_APP}" ]; then
+            printf "    sudo rm -rf '%s'\n\n" "${other_copy}" >&2
+        else
+            printf "    rm -rf '%s'\n\n" "${other_copy}" >&2
+        fi
+    fi
+
+    TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/taskyou-macos-install.XXXXXX")
+    MOUNT_POINT="${TMP_DIR}/volume"
+    local dmg_path="${TMP_DIR}/${asset}"
+    local url="https://github.com/${REPO}/releases/latest/download/${asset}"
+
+    info "Downloading ${asset}..."
+    if ! curl -fL --retry 3 --retry-delay 2 --progress-bar -o "${dmg_path}" "${url}"; then
+        error "Download failed. ${asset} may not be attached to the latest release for this architecture — check https://github.com/${REPO}/releases/latest"
+    fi
+    step "Download complete"
+
+    info "Verifying disk image..."
+    hdiutil verify -quiet "${dmg_path}" || error "The downloaded DMG failed verification (corrupt or incomplete download). Please retry."
+    step "Disk image verified"
+
+    info "Mounting disk image..."
+    mkdir -p "${MOUNT_POINT}"
+    hdiutil attach -nobrowse -readonly -mountpoint "${MOUNT_POINT}" "${dmg_path}" >/dev/null || error "Could not mount the disk image."
+    step "Disk image mounted"
+
+    local app_src
+    app_src=$(find "${MOUNT_POINT}" -maxdepth 3 -name "${APP_NAME}" -type d | head -n 1)
+    if [ -z "${app_src}" ]; then
+        error "${APP_NAME} was not found inside the disk image (unexpected layout)."
+    fi
+    step "Found ${APP_NAME} in disk image"
+
+    if [ "${dest}" = "${SYSTEM_APP}" ]; then
+        info "Installing to /Applications (admin password may be required)..."
+    else
+        info "Installing to ~/Applications..."
+        mkdir -p "${HOME}/Applications"
+    fi
+    if [ -e "${dest}" ]; then
+        ${sudo_cmd} rm -rf "${dest}"
+    fi
+    ${sudo_cmd} ditto "${app_src}" "${dest}" || error "Failed to copy ${APP_NAME} to ${dest}"
+    step "Installed to ${dest}"
+
+    hdiutil detach "${MOUNT_POINT}" >/dev/null 2>&1 || true
+    MOUNT_POINT=""
+    step "Disk image ejected"
+
+    # curl downloads are never quarantined, but clear the flag just in case
+    # (e.g. the script itself was saved via a browser first).
+    ${sudo_cmd} xattr -dr com.apple.quarantine "${dest}" 2>/dev/null || true
+    step "Gatekeeper quarantine cleared"
+
+    if [ -n "${TASKYOU_NO_LAUNCH:-}" ]; then
+        step "Skipping launch (TASKYOU_NO_LAUNCH is set)"
+    else
+        info "Launching TaskYou..."
+        open "${dest}" || error "TaskYou is installed at ${dest} but failed to launch — try opening it from your Applications folder."
+        step "TaskYou started"
+    fi
+
+    echo ""
+    info "All set! Reminder: TaskYou needs tmux and at least one executor CLI (e.g. Claude Code) installed to run tasks."
+    echo ""
+}
+
+main "$@"

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# TaskYou Desktop (macOS) Installation Script
+# Usage: curl -fsSL taskyou.dev/install-macos.sh | bash
+#
+# Downloads the TaskYou desktop app DMG from the latest GitHub release,
+# verifies it, and installs TaskYou.app. Because curl downloads never get
+# the com.apple.quarantine flag, this skips Gatekeeper's "unidentified
+# developer" prompt entirely — no right-click → Open dance needed.
+#
+# Installs to ~/Applications by default (no sudo required).
+#
+# Environment variables:
+#   TASKYOU_INSTALL_SYSTEM=1   Install to /Applications for all users (uses sudo)
+#   TASKYOU_NO_LAUNCH=1        Don't launch the app after installing
+#   TASKYOU_GITHUB_REPO        Override the GitHub repo (default: bborn/taskyou)
+
+set -euo pipefail
+
+REPO="${TASKYOU_GITHUB_REPO:-bborn/taskyou}"
+APP_NAME="TaskYou.app"
+SYSTEM_APP="/Applications/${APP_NAME}"
+USER_APP="${HOME}/Applications/${APP_NAME}"
+
+# Colors for output (only when attached to a terminal)
+RED=""
+GREEN=""
+YELLOW=""
+BOLD=""
+NC=""
+if [ -t 1 ]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[1;33m'
+    BOLD=$'\033[1m'
+    NC=$'\033[0m'
+fi
+
+banner() {
+    printf '%s' "${BOLD}"
+    cat <<'EOF'
+
+ ████████╗ █████╗ ███████╗██╗  ██╗██╗   ██╗ ██████╗ ██╗   ██╗
+ ╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝╚██╗ ██╔╝██╔═══██╗██║   ██║
+    ██║   ███████║███████╗█████╔╝  ╚████╔╝ ██║   ██║██║   ██║
+    ██║   ██╔══██║╚════██║██╔═██╗   ╚██╔╝  ██║   ██║██║   ██║
+    ██║   ██║  ██║███████║██║  ██╗   ██║   ╚██████╔╝╚██████╔╝
+    ╚═╝   ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝   ╚═╝    ╚═════╝  ╚═════╝
+
+EOF
+    printf '%s' "${NC}"
+    printf '%sTaskYou · macOS desktop installer%s\n\n' "${BOLD}" "${NC}"
+}
+
+step() {
+    printf '%s✓%s %s\n' "${GREEN}" "${NC}" "$1"
+}
+
+info() {
+    printf '%s==>%s %s\n' "${GREEN}" "${NC}" "$1"
+}
+
+warn() {
+    printf '%sWarning:%s %s\n' "${YELLOW}" "${NC}" "$1" >&2
+}
+
+error() {
+    printf '%sError:%s %s\n' "${RED}" "${NC}" "$1" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || error "Required command not found: $1"
+}
+
+# Map the machine architecture to a release DMG asset
+detect_asset() {
+    local arch
+    arch=$(uname -m)
+    case "$arch" in
+        arm64) echo "TaskYou-macos-arm64.dmg" ;;
+        x86_64) echo "TaskYou-macos-x64.dmg" ;;
+        *) error "Unsupported architecture: ${arch}. TaskYou Desktop ships for arm64 (Apple Silicon) and x86_64 (Intel)." ;;
+    esac
+}
+
+# Globals for the EXIT trap (locals would be gone by the time it fires)
+TMP_DIR=""
+MOUNT_POINT=""
+cleanup() {
+    if [ -n "${MOUNT_POINT}" ] && [ -d "${MOUNT_POINT}" ]; then
+        hdiutil detach "${MOUNT_POINT}" >/dev/null 2>&1 || true
+    fi
+    if [ -n "${TMP_DIR}" ]; then
+        rm -rf "${TMP_DIR}"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+main() {
+    banner
+
+    if [ "$(uname -s)" != "Darwin" ]; then
+        error "This installer is macOS-only. For the CLI/TUI (macOS and Linux): curl -fsSL taskyou.dev/install.sh | bash"
+    fi
+
+    require_command curl
+    require_command hdiutil
+    require_command ditto
+    require_command xattr
+    require_command open
+
+    local asset
+    asset=$(detect_asset)
+    step "Detected macOS $(uname -m) → ${asset}"
+
+    # Pick the install destination
+    local dest other_copy sudo_cmd=""
+    if [ -n "${TASKYOU_INSTALL_SYSTEM:-}" ]; then
+        dest="${SYSTEM_APP}"
+        other_copy="${USER_APP}"
+        if [ "$(id -u)" -ne 0 ]; then
+            command -v sudo >/dev/null 2>&1 || error "sudo is required to install into /Applications. Unset TASKYOU_INSTALL_SYSTEM to install to ~/Applications without a password."
+            sudo_cmd="sudo"
+        fi
+    else
+        dest="${USER_APP}"
+        other_copy="${SYSTEM_APP}"
+    fi
+
+    # Warn if a copy already lives in the *other* location — macOS may keep
+    # launching that one instead of the copy we are about to install.
+    if [ -e "${other_copy}" ]; then
+        echo "" >&2
+        warn "TaskYou is already installed at: ${other_copy}"
+        printf '  Remove that copy to avoid two installs (macOS may launch it instead of this one):\n' >&2
+        if [ "${other_copy}" = "${SYSTEM_APP}" ]; then
+            printf "    sudo rm -rf '%s'\n\n" "${other_copy}" >&2
+        else
+            printf "    rm -rf '%s'\n\n" "${other_copy}" >&2
+        fi
+    fi
+
+    TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/taskyou-macos-install.XXXXXX")
+    MOUNT_POINT="${TMP_DIR}/volume"
+    local dmg_path="${TMP_DIR}/${asset}"
+    local url="https://github.com/${REPO}/releases/latest/download/${asset}"
+
+    info "Downloading ${asset}..."
+    if ! curl -fL --retry 3 --retry-delay 2 --progress-bar -o "${dmg_path}" "${url}"; then
+        error "Download failed. ${asset} may not be attached to the latest release for this architecture — check https://github.com/${REPO}/releases/latest"
+    fi
+    step "Download complete"
+
+    info "Verifying disk image..."
+    hdiutil verify -quiet "${dmg_path}" || error "The downloaded DMG failed verification (corrupt or incomplete download). Please retry."
+    step "Disk image verified"
+
+    info "Mounting disk image..."
+    mkdir -p "${MOUNT_POINT}"
+    hdiutil attach -nobrowse -readonly -mountpoint "${MOUNT_POINT}" "${dmg_path}" >/dev/null || error "Could not mount the disk image."
+    step "Disk image mounted"
+
+    local app_src
+    app_src=$(find "${MOUNT_POINT}" -maxdepth 3 -name "${APP_NAME}" -type d | head -n 1)
+    if [ -z "${app_src}" ]; then
+        error "${APP_NAME} was not found inside the disk image (unexpected layout)."
+    fi
+    step "Found ${APP_NAME} in disk image"
+
+    if [ "${dest}" = "${SYSTEM_APP}" ]; then
+        info "Installing to /Applications (admin password may be required)..."
+    else
+        info "Installing to ~/Applications..."
+        mkdir -p "${HOME}/Applications"
+    fi
+    if [ -e "${dest}" ]; then
+        ${sudo_cmd} rm -rf "${dest}"
+    fi
+    ${sudo_cmd} ditto "${app_src}" "${dest}" || error "Failed to copy ${APP_NAME} to ${dest}"
+    step "Installed to ${dest}"
+
+    hdiutil detach "${MOUNT_POINT}" >/dev/null 2>&1 || true
+    MOUNT_POINT=""
+    step "Disk image ejected"
+
+    # curl downloads are never quarantined, but clear the flag just in case
+    # (e.g. the script itself was saved via a browser first).
+    ${sudo_cmd} xattr -dr com.apple.quarantine "${dest}" 2>/dev/null || true
+    step "Gatekeeper quarantine cleared"
+
+    if [ -n "${TASKYOU_NO_LAUNCH:-}" ]; then
+        step "Skipping launch (TASKYOU_NO_LAUNCH is set)"
+    else
+        info "Launching TaskYou..."
+        open "${dest}" || error "TaskYou is installed at ${dest} but failed to launch — try opening it from your Applications folder."
+        step "TaskYou started"
+    fi
+
+    echo ""
+    info "All set! Reminder: TaskYou needs tmux and at least one executor CLI (e.g. Claude Code) installed to run tasks."
+    echo ""
+}
+
+main "$@"


### PR DESCRIPTION
## What

A Nora-style `curl | bash` installer for the TaskYou desktop app:

```sh
curl -fsSL taskyou.dev/install-macos.sh | bash
```

Our DMGs are ad-hoc signed only (#78ced384), so browser downloads hit Gatekeeper's "unidentified developer" prompt. Files downloaded via curl never receive the `com.apple.quarantine` xattr, so this script gives a zero-prompt install with no Apple Developer account.

## How it works

1. ASCII banner + green `✓` step output (style follows `scripts/install.sh`)
2. Requires macOS; maps `uname -m` to the real release assets from the desktop workflow matrix: `arm64` → `TaskYou-macos-arm64.dmg`, `x86_64` → `TaskYou-macos-x64.dmg`; clear error for anything else or if the asset isn't attached to the latest release
3. Requires `curl`, `hdiutil`, `ditto`, `xattr`, `open`
4. Downloads from `releases/latest/download/<asset>` into a `mktemp -d` dir (`--retry 3 --progress-bar`, `trap` cleanup detaches + removes on any exit)
5. `hdiutil verify`, then `attach -nobrowse -readonly -mountpoint`
6. `ditto` to `~/Applications` by default (no sudo); `TASKYOU_INSTALL_SYSTEM=1` opts into `/Applications` with sudo; warns when a copy exists in the *other* Applications folder (macOS may keep launching that one)
7. Detaches, `xattr -dr com.apple.quarantine` on the installed app (belt-and-braces — curl downloads aren't quarantined), then `open`s it; `TASKYOU_NO_LAUNCH=1` skips the launch for testing/CI

## Placement

`scripts/install.sh` and `docs/install.sh` are identical duplicated copies with no sync mechanism (docs/ is the GitHub Pages root for taskyou.dev), so this follows suit: `scripts/install-macos.sh` + identical `docs/install-macos.sh`. Also added a `docs/_headers` entry mirroring the existing `/install.sh` one, and the one-liner in the README's GUI section (existing CLI/TUI/GUI structure untouched).

## Testing

- `bash -n`: clean. `shellcheck` (v0.11.0 via npx): clean.
- **Real end-to-end run** on an arm64 Mac with `TASKYOU_NO_LAUNCH=1`: downloaded the actual v0.3.8 `TaskYou-macos-arm64.dmg`, verified, mounted, installed to `~/Applications/TaskYou.app`, ejected, cleared quarantine, skipped launch:

```
✓ Detected macOS arm64 → TaskYou-macos-arm64.dmg

Warning: TaskYou is already installed at: /Applications/TaskYou.app
  Remove that copy to avoid two installs (macOS may launch it instead of this one):
    sudo rm -rf '/Applications/TaskYou.app'

==> Downloading TaskYou-macos-arm64.dmg...
######################################################################## 100.0%
✓ Download complete
==> Verifying disk image...
✓ Disk image verified
==> Mounting disk image...
✓ Disk image mounted
✓ Found TaskYou.app in disk image
==> Installing to ~/Applications...
✓ Installed to /Users/bruno/Applications/TaskYou.app
✓ Disk image ejected
✓ Gatekeeper quarantine cleared
✓ Skipping launch (TASKYOU_NO_LAUNCH is set)
```

- Post-install checks: installed app had **no** `com.apple.quarantine` xattr, valid ad-hoc Mach-O arm64 bundle per `codesign -dv`; temp dir removed and no leftover mounts. (The pre-existing `/Applications/TaskYou.app` on the test machine — a local dev build — was left untouched; it usefully exercised the other-location warning above. The `~/Applications` test install was removed afterwards.)
- **Failure path**: ran with `TASKYOU_GITHUB_REPO=bborn/definitely-not-a-repo` → curl 404 → `Error: Download failed. TaskYou-macos-arm64.dmg may not be attached to the latest release for this architecture — check …`, exit code 1.

## Notes

- **Intel asset gap**: the desktop workflow matrix builds both `macos-arm64` and `macos-x64` DMGs, but the latest release (v0.3.8, the first with any DMG) only has the arm64 asset — `TaskYou-macos-x64.dmg` 404s today. The script supports both archs; Intel users get the clear "may not be attached to the latest release" error until the macos-13 job's asset actually ships.
- The script won't be live at `taskyou.dev/install-macos.sh` until this merges and Pages redeploys; until then it works via `curl -fsSL https://raw.githubusercontent.com/bborn/taskyou/feat/macos-gui-installer/scripts/install-macos.sh | bash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)