### PR TITLE
fix(ci): cross-compile macOS x64 desktop build on Apple Silicon runner

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -25,14 +25,19 @@ jobs:
           - name: macos-arm64
             runner: macos-14
             triple: aarch64-apple-darwin
+            goarch: arm64
             bundles: "dmg"
+          # GitHub retired the Intel macos-13 runners (jobs queue forever),
+          # so the x64 build cross-compiles on Apple Silicon instead.
           - name: macos-x64
-            runner: macos-13
+            runner: macos-14
             triple: x86_64-apple-darwin
+            goarch: amd64
             bundles: "dmg"
           - name: linux-x64
             runner: ubuntu-22.04
             triple: x86_64-unknown-linux-gnu
+            goarch: amd64
             bundles: "appimage deb"
     runs-on: ${{ matrix.runner }}
     steps:
@@ -54,6 +59,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.triple }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
@@ -79,6 +86,10 @@ jobs:
           pnpm build
 
       - name: Build ty sidecar (web UI embedded)
+        # Cross-arch (GOARCH != host) auto-disables CGO; the sqlite driver is
+        # pure Go (modernc.org/sqlite) so the cross build needs nothing else.
+        env:
+          GOARCH: ${{ matrix.goarch }}
         run: |
           rm -rf internal/web/ui/dist
           cp -R desktop/dist internal/web/ui/dist


### PR DESCRIPTION
## Problem

GitHub retired the Intel `macos-13` runner image. The `macos-x64` bundle job in `desktop.yml` now queues forever — yesterday's run ([27376820607](https://github.com/bborn/taskyou/actions/runs/27376820607)) has had it stuck in `queued` for ~19h while `macos-arm64` and `linux-x64` completed. Net effect: **v0.3.8 has no Intel DMG** (`TaskYou-macos-x64.dmg` 404s), which also blocks the Intel path of the new `install-macos.sh` (#595).

## Fix

Cross-compile the x64 bundle on an Apple Silicon runner:

- `macos-x64` matrix entry moves `macos-13` → `macos-14`
- `dtolnay/rust-toolchain` gets `targets: ${{ matrix.triple }}` so `x86_64-apple-darwin` is installed (`tauri build` already passes `--target`)
- the `ty` sidecar builds with a new per-entry `goarch` matrix value (`GOARCH=amd64` for the cross entry; native values elsewhere, so arm64/linux builds are unchanged)

Cross-arch Go auto-disables CGO, which is safe here: the sqlite driver is pure Go (`modernc.org/sqlite`).

## Verification

- `GOARCH=amd64 go build ./cmd/task` on an arm64 Mac → `Mach-O 64-bit executable x86_64` ✅
- Real proof needs a `workflow_dispatch` run of Desktop after merge — that will also backfill the missing x64 assets (re-tag or dispatch + `gh release upload` for v0.3.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)