### PR TITLE
feat: per-task worktree/branch strategy (engine + CLI + TUI + GUI)

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -578,7 +578,10 @@ Examples:
   task create "Refactor auth" --executor codex  # Use Codex instead of Claude
   task create "Urgent bug" --tags "bug,urgent" --pinned  # Tagged and pinned task
   task create --body "The login button is broken on mobile devices" # AI generates title
-  task create "QA: PR #2526" --branch fix/ui-overflow --project myapp  # Checkout existing branch`,
+  task create "QA: PR #2526" --branch fix/ui-overflow --project myapp  # Checkout existing branch
+  task create "Quick fix" --in-place               # Run in the project dir, no worktree
+  task create "Risky refactor" --worktree          # Force a fresh worktree
+  task create "Backport fix" --base-branch release/2.0  # Worktree branches from release/2.0`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var title string
@@ -598,6 +601,9 @@ Examples:
 			pinned, _ := cmd.Flags().GetBool("pinned")
 			remoteControl, _ := cmd.Flags().GetBool("remote-control")
 			branch, _ := cmd.Flags().GetString("branch")
+			forceWorktree, _ := cmd.Flags().GetBool("worktree")
+			inPlace, _ := cmd.Flags().GetBool("in-place")
+			baseBranch, _ := cmd.Flags().GetString("base-branch")
 			outputJSON, _ := cmd.Flags().GetBool("json")
 
 			// Validate that either title or body is provided
@@ -712,6 +718,15 @@ Examples:
 				permMode = db.PermissionModeDangerous
 			}
 
+			// Resolve worktree mode: --worktree and --in-place are mutually
+			// exclusive (enforced by cobra); neither inherits the project setting.
+			worktreeMode := db.WorktreeModeInherit
+			if forceWorktree {
+				worktreeMode = db.WorktreeModeWorktree
+			} else if inPlace {
+				worktreeMode = db.WorktreeModeInPlace
+			}
+
 			// Create the task
 			task := &db.Task{
 				Title:          title,
@@ -724,6 +739,8 @@ Examples:
 				Tags:           tags,
 				Pinned:         pinned,
 				SourceBranch:   branch,
+				WorktreeMode:   worktreeMode,
+				BaseBranch:     baseBranch,
 				PermissionMode: permMode,
 				RemoteControl:  remoteControl,
 			}
@@ -744,6 +761,12 @@ Examples:
 				}
 				if task.SourceBranch != "" {
 					output["source_branch"] = task.SourceBranch
+				}
+				if task.WorktreeMode != "" {
+					output["worktree_mode"] = task.WorktreeMode
+				}
+				if task.BaseBranch != "" {
+					output["base_branch"] = task.BaseBranch
 				}
 				if task.EffortLevel != "" {
 					output["effort_level"] = task.EffortLevel
@@ -778,6 +801,10 @@ Examples:
 	createCmd.Flags().Bool("pinned", false, "Pin the task to the top of its column")
 	createCmd.Flags().Bool("remote-control", false, "Launch Claude with --remote-control (interactive, remote-drivable session)")
 	createCmd.Flags().StringP("branch", "b", "", "Existing branch to checkout for worktree (e.g., fix/ui-overflow)")
+	createCmd.Flags().Bool("worktree", false, "Force a fresh git worktree even if the project default is off")
+	createCmd.Flags().Bool("in-place", false, "Run directly in the project directory on the current checkout (no worktree)")
+	createCmd.Flags().String("base-branch", "", "Git ref a new worktree branches from (default: the project's default branch)")
+	createCmd.MarkFlagsMutuallyExclusive("worktree", "in-place")
 	createCmd.Flags().Bool("json", false, "Output in JSON format")
 	createCmd.RegisterFlagCompletionFunc("project", completeFlagProjects)
 	createCmd.RegisterFlagCompletionFunc("type", completeFlagTypes)

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -78,6 +78,8 @@ export const api = {
     pinned?: boolean;
     permission_mode?: string;
     tags?: string;
+    worktree_mode?: string;
+    base_branch?: string;
   }) => request<Task>("POST", "/api/tasks", task),
   updateTask: (
     id: number,
@@ -93,6 +95,8 @@ export const api = {
         | "pinned"
         | "permission_mode"
         | "effort_level"
+        | "worktree_mode"
+        | "base_branch"
       >
     >,
   ) => request<Task>("PATCH", `/api/tasks/${id}`, patch),

--- a/desktop/src/api/types.ts
+++ b/desktop/src/api/types.ts
@@ -23,6 +23,8 @@ export interface Task {
   has_executor: boolean;
   effort_level?: string;
   source_branch?: string;
+  worktree_mode?: string;
+  base_branch?: string;
   daemon_session?: string;
   tmux_window_id?: string;
   claude_pane_id?: string;

--- a/desktop/src/components/TaskForm.tsx
+++ b/desktop/src/components/TaskForm.tsx
@@ -47,6 +47,12 @@ const PERMISSION_MODES = [
 
 const EFFORT_LEVELS = [NONE, "low", "medium", "high"];
 
+const WORKTREE_MODES = [
+  { value: NONE, label: "Project default" },
+  { value: "worktree", label: "Worktree" },
+  { value: "in-place", label: "In place" },
+];
+
 export function TaskForm({ form }: { form: NonNullable<FormState> }) {
   const { projects, types, executors, tasks, permissionMode } = useAppState();
   const editing = form.kind === "edit" ? tasks.find((t) => t.id === form.taskId) : null;
@@ -62,6 +68,8 @@ export function TaskForm({ form }: { form: NonNullable<FormState> }) {
   const [permission, setPermission] = useState(
     editing && editing.permission_mode !== "default" ? editing.permission_mode : permissionMode,
   );
+  const [worktreeMode, setWorktreeMode] = useState(editing?.worktree_mode ?? "");
+  const [baseBranch, setBaseBranch] = useState(editing?.base_branch ?? "");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [files, setFiles] = useState<File[]>([]);
   const [executeNow, setExecuteNow] = useState(false);
@@ -70,6 +78,13 @@ export function TaskForm({ form }: { form: NonNullable<FormState> }) {
 
   const titleRef = useRef<HTMLInputElement>(null);
   const ghostTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Base branch only applies when a fresh worktree will be created: forced per
+  // task, or inherited from a project with worktrees enabled.
+  const projectUsesWorktrees = projects.find((p) => p.name === project)?.use_worktrees !== false;
+  const baseBranchRelevant =
+    worktreeMode === "worktree" || (worktreeMode === "" && projectUsesWorktrees);
+  const effectiveBaseBranch = baseBranchRelevant ? baseBranch.trim() : "";
 
   // Ghost-text autocomplete on the title, debounced; best-effort.
   function onTitleChange(value: string) {
@@ -109,6 +124,8 @@ export function TaskForm({ form }: { form: NonNullable<FormState> }) {
           executor,
           execute: executeNow || dangerous,
           permission_mode: dangerous ? "dangerous" : permission,
+          worktree_mode: worktreeMode,
+          base_branch: effectiveBaseBranch,
         });
         if (effort) await api.updateTask(created.id, { effort_level: effort }).catch(() => {});
         for (const file of files) {
@@ -125,6 +142,8 @@ export function TaskForm({ form }: { form: NonNullable<FormState> }) {
           executor,
           effort_level: effort,
           permission_mode: permission,
+          worktree_mode: worktreeMode,
+          base_branch: effectiveBaseBranch,
         });
         for (const file of files) {
           const data = await fileToBase64(file);
@@ -296,6 +315,31 @@ export function TaskForm({ form }: { form: NonNullable<FormState> }) {
           </button>
           {showAdvanced && (
             <div className="grid grid-cols-2 gap-3.5">
+              <div className="grid gap-1.5">
+                <Label>Worktree</Label>
+                <Select value={toSelect(worktreeMode)} onValueChange={(v) => setWorktreeMode(fromSelect(v))}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {WORKTREE_MODES.map((m) => (
+                      <SelectItem key={m.value} value={m.value}>
+                        {m.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {baseBranchRelevant && (
+                <div className="grid gap-1.5">
+                  <Label>Base branch</Label>
+                  <Input
+                    value={baseBranch}
+                    placeholder="Default branch if empty"
+                    onChange={(e) => setBaseBranch(e.target.value)}
+                  />
+                </div>
+              )}
               <div className="grid gap-1.5">
                 <Label>Effort</Label>
                 <Select value={toSelect(effort)} onValueChange={(v) => setEffort(fromSelect(v))}>

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -297,6 +297,12 @@ func (db *DB) migrate() error {
 		`ALTER TABLE tasks ADD COLUMN effort_level TEXT DEFAULT ''`,
 
 		`ALTER TABLE tasks ADD COLUMN remote_control INTEGER DEFAULT 0`, // Whether to launch claude with --remote-control
+
+		// Per-task worktree override: "" inherits the project's use_worktrees setting,
+		// "worktree" forces a fresh worktree, "in-place" runs directly in the project dir
+		`ALTER TABLE tasks ADD COLUMN worktree_mode TEXT DEFAULT ''`,
+		// Git ref a new worktree branches from ("" = project's default branch)
+		`ALTER TABLE tasks ADD COLUMN base_branch TEXT DEFAULT ''`,
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -37,6 +37,8 @@ type Task struct {
 	Pinned          bool   // Whether the task is pinned to the top of its column
 	Tags            string // Comma-separated tags for categorization (e.g., "customer-support,email,influence-kit")
 	SourceBranch    string // Existing branch to checkout for worktree (e.g., "fix/ui-overflow") instead of creating new branch
+	WorktreeMode    string // Per-task worktree override: "" inherits the project's UseWorktrees setting, "worktree" forces a fresh worktree, "in-place" runs directly in the project directory
+	BaseBranch      string // Git ref a new worktree branches from (e.g., "release/2.0"); empty uses the project's default branch
 	Summary         string // Distilled summary of what was accomplished (for search and context)
 	CreatedAt       LocalTime
 	UpdatedAt       LocalTime
@@ -192,6 +194,64 @@ func (t *Task) IsAcceptEdits() bool {
 	return t.EffectivePermissionMode() == PermissionModeAcceptEdits
 }
 
+// Worktree modes are per-task overrides for the project's UseWorktrees setting.
+// The default (empty string) inherits the project setting, so existing tasks and
+// callers that never set a mode behave exactly as before.
+const (
+	// WorktreeModeInherit uses the project's UseWorktrees setting (the default).
+	WorktreeModeInherit = ""
+	// WorktreeModeWorktree forces a fresh git worktree even if the project
+	// default is off.
+	WorktreeModeWorktree = "worktree"
+	// WorktreeModeInPlace runs the task directly in the project directory on the
+	// current checkout even if the project default is on.
+	WorktreeModeInPlace = "in-place"
+)
+
+// NormalizeWorktreeMode coerces a raw value into a known worktree mode.
+// Matching is case- and whitespace-insensitive; "in_place" and "inplace"
+// normalize to WorktreeModeInPlace. Unknown values return WorktreeModeInherit
+// so a bad value can never change where a task executes.
+func NormalizeWorktreeMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case WorktreeModeWorktree:
+		return WorktreeModeWorktree
+	case WorktreeModeInPlace, "in_place", "inplace":
+		return WorktreeModeInPlace
+	}
+	return WorktreeModeInherit
+}
+
+// ShouldUseWorktree reports whether a task should run in an isolated git
+// worktree: the task's WorktreeMode override wins, otherwise the project's
+// UseWorktrees setting decides. A nil project defaults to worktrees on,
+// matching the use_worktrees column default and Config.ProjectUsesWorktrees.
+func ShouldUseWorktree(project *Project, task *Task) bool {
+	if task != nil {
+		switch NormalizeWorktreeMode(task.WorktreeMode) {
+		case WorktreeModeWorktree:
+			return true
+		case WorktreeModeInPlace:
+			return false
+		}
+	}
+	if project != nil {
+		return project.UsesWorktrees()
+	}
+	return true
+}
+
+// ResolveWorktreeBase returns the git ref a new worktree should branch from:
+// the task's BaseBranch when set, otherwise the given default branch.
+func ResolveWorktreeBase(task *Task, defaultBranch string) string {
+	if task != nil {
+		if base := strings.TrimSpace(task.BaseBranch); base != "" {
+			return base
+		}
+	}
+	return defaultBranch
+}
+
 // Task types (default values, actual types are stored in task_types table)
 const (
 	TypeCode     = "code"
@@ -297,10 +357,13 @@ func (db *DB) CreateTask(t *Task) error {
 	// Keep the legacy boolean consistent with the resolved mode.
 	t.DangerousMode = t.PermissionMode == PermissionModeDangerous
 
+	// Store a normalized worktree mode so sloppy spellings never reach the DB.
+	t.WorktreeMode = NormalizeWorktreeMode(t.WorktreeMode)
+
 	result, err := db.Exec(`
-		INSERT INTO tasks (title, body, status, type, project, executor, pinned, tags, source_branch, dangerous_mode, permission_mode, remote_control, effort_level)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor, t.Pinned, t.Tags, t.SourceBranch, t.DangerousMode, t.PermissionMode, t.RemoteControl, t.EffortLevel)
+		INSERT INTO tasks (title, body, status, type, project, executor, pinned, tags, source_branch, worktree_mode, base_branch, dangerous_mode, permission_mode, remote_control, effort_level)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor, t.Pinned, t.Tags, t.SourceBranch, t.WorktreeMode, t.BaseBranch, t.DangerousMode, t.PermissionMode, t.RemoteControl, t.EffortLevel)
 	if err != nil {
 		return fmt.Errorf("insert task: %w", err)
 	}
@@ -353,7 +416,7 @@ func (db *DB) GetTask(id int64) (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(worktree_mode, ''), COALESCE(base_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -365,7 +428,7 @@ func (db *DB) GetTask(id int64) (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary, &t.EffortLevel,
+		&t.SourceBranch, &t.WorktreeMode, &t.BaseBranch, &t.Summary, &t.EffortLevel,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -399,7 +462,7 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(worktree_mode, ''), COALESCE(base_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -468,7 +531,7 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary, &t.EffortLevel,
+			&t.SourceBranch, &t.WorktreeMode, &t.BaseBranch, &t.Summary, &t.EffortLevel,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -493,7 +556,7 @@ func (db *DB) GetMostRecentlyCreatedTask() (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(worktree_mode, ''), COALESCE(base_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -507,7 +570,7 @@ func (db *DB) GetMostRecentlyCreatedTask() (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary, &t.EffortLevel,
+		&t.SourceBranch, &t.WorktreeMode, &t.BaseBranch, &t.Summary, &t.EffortLevel,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -536,7 +599,7 @@ func (db *DB) SearchTasks(query string, limit int) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(worktree_mode, ''), COALESCE(base_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -569,7 +632,7 @@ func (db *DB) SearchTasks(query string, limit int) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary, &t.EffortLevel,
+			&t.SourceBranch, &t.WorktreeMode, &t.BaseBranch, &t.Summary, &t.EffortLevel,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -671,13 +734,13 @@ func (db *DB) UpdateTask(t *Task) error {
 			title = ?, body = ?, status = ?, type = ?, project = ?, executor = ?,
 			worktree_path = ?, branch_name = ?, port = ?, claude_session_id = ?,
 			daemon_session = ?, pr_url = ?, pr_number = ?, pr_info_json = ?, dangerous_mode = ?, permission_mode = ?, remote_control = ?,
-			pinned = ?, tags = ?, source_branch = ?, effort_level = ?,
+			pinned = ?, tags = ?, source_branch = ?, worktree_mode = ?, base_branch = ?, effort_level = ?,
 			updated_at = CURRENT_TIMESTAMP
 		WHERE id = ?
 	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor,
 		t.WorktreePath, t.BranchName, t.Port, t.ClaudeSessionID,
 		t.DaemonSession, t.PRURL, t.PRNumber, t.PRInfoJSON, t.DangerousMode, t.PermissionMode, t.RemoteControl,
-		t.Pinned, t.Tags, t.SourceBranch, t.EffortLevel, t.ID)
+		t.Pinned, t.Tags, t.SourceBranch, NormalizeWorktreeMode(t.WorktreeMode), t.BaseBranch, t.EffortLevel, t.ID)
 	if err != nil {
 		return fmt.Errorf("update task: %w", err)
 	}
@@ -1003,7 +1066,7 @@ func (db *DB) GetNextQueuedTask() (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(worktree_mode, ''), COALESCE(base_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -1018,7 +1081,7 @@ func (db *DB) GetNextQueuedTask() (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary, &t.EffortLevel,
+		&t.SourceBranch, &t.WorktreeMode, &t.BaseBranch, &t.Summary, &t.EffortLevel,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -1041,7 +1104,7 @@ func (db *DB) GetQueuedTasks() ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(worktree_mode, ''), COALESCE(base_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -1064,7 +1127,7 @@ func (db *DB) GetQueuedTasks() ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary, &t.EffortLevel,
+			&t.SourceBranch, &t.WorktreeMode, &t.BaseBranch, &t.Summary, &t.EffortLevel,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -2007,7 +2070,7 @@ func (db *DB) GetStaleWorktreeTasks(maxAge time.Duration) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(worktree_mode, ''), COALESCE(base_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -2034,7 +2097,7 @@ func (db *DB) GetStaleWorktreeTasks(maxAge time.Duration) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary, &t.EffortLevel,
+			&t.SourceBranch, &t.WorktreeMode, &t.BaseBranch, &t.Summary, &t.EffortLevel,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,

--- a/internal/db/worktree_mode_test.go
+++ b/internal/db/worktree_mode_test.go
@@ -1,0 +1,172 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeWorktreeMode(t *testing.T) {
+	cases := map[string]string{
+		"worktree":   WorktreeModeWorktree,
+		"  Worktree": WorktreeModeWorktree, // trimmed + case-insensitive
+		"in-place":   WorktreeModeInPlace,
+		"in_place":   WorktreeModeInPlace,
+		"inplace":    WorktreeModeInPlace,
+		"In-Place":   WorktreeModeInPlace,
+		"":           WorktreeModeInherit,
+		"bogus":      WorktreeModeInherit, // unknown values inherit the project setting
+	}
+	for in, want := range cases {
+		if got := NormalizeWorktreeMode(in); got != want {
+			t.Errorf("NormalizeWorktreeMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestShouldUseWorktree(t *testing.T) {
+	worktreesOn := &Project{Name: "on", UseWorktrees: true}
+	worktreesOff := &Project{Name: "off", UseWorktrees: false}
+
+	cases := []struct {
+		name    string
+		project *Project
+		task    *Task
+		want    bool
+	}{
+		// Inherit (default): the project setting decides, exactly as before.
+		{"inherit follows project on", worktreesOn, &Task{}, true},
+		{"inherit follows project off", worktreesOff, &Task{}, false},
+		{"inherit with nil project defaults on", nil, &Task{}, true},
+		{"nil task follows project on", worktreesOn, nil, true},
+		{"nil task follows project off", worktreesOff, nil, false},
+
+		// Force worktree: wins even when the project default is off.
+		{"force worktree in worktrees-off project", worktreesOff, &Task{WorktreeMode: WorktreeModeWorktree}, true},
+		{"force worktree in worktrees-on project", worktreesOn, &Task{WorktreeMode: WorktreeModeWorktree}, true},
+
+		// Force in-place: wins even when the project default is on.
+		{"force in-place in worktrees-on project", worktreesOn, &Task{WorktreeMode: WorktreeModeInPlace}, false},
+		{"force in-place in worktrees-off project", worktreesOff, &Task{WorktreeMode: WorktreeModeInPlace}, false},
+
+		// Unknown values inherit (never crash, never surprise).
+		{"unknown mode inherits project on", worktreesOn, &Task{WorktreeMode: "bogus"}, true},
+		{"unknown mode inherits project off", worktreesOff, &Task{WorktreeMode: "bogus"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ShouldUseWorktree(c.project, c.task); got != c.want {
+				t.Errorf("ShouldUseWorktree(%v, %v) = %v, want %v", c.project, c.task, got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveWorktreeBase(t *testing.T) {
+	cases := []struct {
+		name          string
+		task          *Task
+		defaultBranch string
+		want          string
+	}{
+		{"empty base branch uses default", &Task{}, "main", "main"},
+		{"explicit base branch wins", &Task{BaseBranch: "release/2.0"}, "main", "release/2.0"},
+		{"whitespace-only base branch uses default", &Task{BaseBranch: "  "}, "main", "main"},
+		{"base branch is trimmed", &Task{BaseBranch: " develop "}, "main", "develop"},
+		{"nil task uses default", nil, "main", "main"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ResolveWorktreeBase(c.task, c.defaultBranch); got != c.want {
+				t.Errorf("ResolveWorktreeBase(%v, %q) = %q, want %q", c.task, c.defaultBranch, got, c.want)
+			}
+		})
+	}
+}
+
+// TestTaskWorktreeModePersists verifies the worktree_mode and base_branch
+// columns round-trip through CreateTask, GetTask, ListTasks, and UpdateTask
+// (i.e. the migration ran and every scan site includes the new columns).
+func TestTaskWorktreeModePersists(t *testing.T) {
+	tmpDir := t.TempDir()
+	database, err := Open(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.CreateProject(&Project{Name: "p", Path: t.TempDir()}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	task := &Task{
+		Title:        "T",
+		Status:       StatusBacklog,
+		Type:         TypeCode,
+		Project:      "p",
+		WorktreeMode: WorktreeModeInPlace,
+		BaseBranch:   "release/2.0",
+	}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	got, err := database.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.WorktreeMode != WorktreeModeInPlace {
+		t.Errorf("WorktreeMode = %q, want %q", got.WorktreeMode, WorktreeModeInPlace)
+	}
+	if got.BaseBranch != "release/2.0" {
+		t.Errorf("BaseBranch = %q, want %q", got.BaseBranch, "release/2.0")
+	}
+
+	tasks, err := database.ListTasks(ListTasksOptions{Project: "p"})
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].WorktreeMode != WorktreeModeInPlace || tasks[0].BaseBranch != "release/2.0" {
+		t.Errorf("ListTasks did not round-trip worktree fields: %+v", tasks)
+	}
+
+	got.WorktreeMode = WorktreeModeWorktree
+	got.BaseBranch = ""
+	if err := database.UpdateTask(got); err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+	got, err = database.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("get task after update: %v", err)
+	}
+	if got.WorktreeMode != WorktreeModeWorktree || got.BaseBranch != "" {
+		t.Errorf("after update: WorktreeMode = %q, BaseBranch = %q; want %q, %q",
+			got.WorktreeMode, got.BaseBranch, WorktreeModeWorktree, "")
+	}
+}
+
+// TestCreateTaskNormalizesWorktreeMode verifies CreateTask stores a normalized
+// worktree mode so sloppy spellings from API callers don't leak into the DB.
+func TestCreateTaskNormalizesWorktreeMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	database, err := Open(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.CreateProject(&Project{Name: "p", Path: t.TempDir()}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	task := &Task{Title: "T", Status: StatusBacklog, Type: TypeCode, Project: "p", WorktreeMode: "In_Place"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	got, err := database.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.WorktreeMode != WorktreeModeInPlace {
+		t.Errorf("WorktreeMode = %q, want %q", got.WorktreeMode, WorktreeModeInPlace)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -991,8 +991,8 @@ func (e *Executor) cleanupStaleWorktrees() {
 			continue
 		}
 
-		// Skip non-worktree projects - they share the project directory and should not be archived
-		if !e.config.ProjectUsesWorktrees(task.Project) {
+		// Skip non-worktree tasks - they share the project directory and should not be archived
+		if !e.taskUsesWorktrees(task) {
 			e.db.ClearTaskWorktreePath(task.ID)
 			continue
 		}
@@ -1053,8 +1053,8 @@ func (e *Executor) CleanupStaleWorktreesManual(maxAge time.Duration, dryRun bool
 
 	var cleaned []*db.Task
 	for _, task := range tasks {
-		// Skip non-worktree projects
-		if !e.config.ProjectUsesWorktrees(task.Project) {
+		// Skip non-worktree tasks
+		if !e.taskUsesWorktrees(task) {
 			e.db.ClearTaskWorktreePath(task.ID)
 			cleaned = append(cleaned, task)
 			continue
@@ -1498,8 +1498,8 @@ func (e *Executor) buildPrompt(task *db.Task, attachmentPaths []string) string {
 
 // buildUniversalGuidance returns task-type-agnostic execution guidance appended to every
 // prompt. The project-context section is always included; the worktree-safety constraint
-// is included only when the task's project uses git worktrees (UseWorktrees defaults to on,
-// so the guardrail is shown unless a project has explicitly opted out).
+// is included only when the task runs in a git worktree (the task's WorktreeMode override
+// or, by default, the project's UseWorktrees setting, which defaults to on).
 func (e *Executor) buildUniversalGuidance(task *db.Task) string {
 	var b strings.Builder
 
@@ -1523,14 +1523,16 @@ Working directory constraint (isolated git worktree):
 	return b.String()
 }
 
-// taskUsesWorktrees reports whether the task's project runs in git worktrees. It defaults
-// to true when the project cannot be loaded, matching the use_worktrees column default and
-// ensuring the worktree-safety guardrail is shown unless a project has explicitly opted out.
+// taskUsesWorktrees reports whether the task runs in a git worktree: the task's
+// WorktreeMode override wins, otherwise the project's UseWorktrees setting
+// decides. It defaults to true when the project cannot be loaded, matching the
+// use_worktrees column default.
 func (e *Executor) taskUsesWorktrees(task *db.Task) bool {
-	if p, err := e.db.GetProjectByName(task.Project); err == nil && p != nil {
-		return p.UsesWorktrees()
+	var project *db.Project
+	if p, err := e.db.GetProjectByName(task.Project); err == nil {
+		project = p
 	}
-	return true
+	return db.ShouldUseWorktree(project, task)
 }
 
 // applyTemplateSubstitutions replaces template placeholders in task type instructions.
@@ -3593,8 +3595,9 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 		return "", fmt.Errorf("project directory not found for project: %s", task.Project)
 	}
 
-	// For non-worktree projects, all tasks share the project directory directly
-	if !e.config.ProjectUsesWorktrees(task.Project) {
+	// Non-worktree tasks (per-task in-place override, or a project with
+	// worktrees off) run in the project directory directly
+	if !e.taskUsesWorktrees(task) {
 		return e.setupSharedWorkDir(task, projectDir, paths)
 	}
 
@@ -3754,11 +3757,11 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 		task.WorktreePath = worktreePath
 		task.BranchName = branchName
 	} else {
-		// Get default branch name
-		defaultBranch := e.getDefaultBranch(projectDir)
+		// Branch from the task's base branch when set, otherwise the default branch
+		baseRef := db.ResolveWorktreeBase(task, e.getDefaultBranch(projectDir))
 
 		// Create new branch and worktree
-		cmd := exec.Command("git", "worktree", "add", "-b", branchName, worktreePath, defaultBranch)
+		cmd := exec.Command("git", "worktree", "add", "-b", branchName, worktreePath, baseRef)
 		cmd.Dir = projectDir
 		output, err := cmd.CombinedOutput()
 		if err != nil {
@@ -4721,9 +4724,9 @@ func (e *Executor) ArchiveWorktree(task *db.Task) error {
 		return nil
 	}
 
-	// For non-worktree projects, just clear the worktree path reference.
+	// For non-worktree tasks, just clear the worktree path reference.
 	// The shared working directory is never removed.
-	if !e.config.ProjectUsesWorktrees(task.Project) {
+	if !e.taskUsesWorktrees(task) {
 		e.db.ClearTaskWorktreePath(task.ID)
 		return nil
 	}
@@ -4849,8 +4852,8 @@ func (e *Executor) ArchiveWorktree(task *db.Task) error {
 // 3. Runs init script
 // 4. Clears the archive state from the database
 func (e *Executor) UnarchiveWorktree(task *db.Task) error {
-	// For non-worktree projects, just restore the worktree path to the project dir
-	if !e.config.ProjectUsesWorktrees(task.Project) {
+	// For non-worktree tasks, just restore the worktree path to the project dir
+	if !e.taskUsesWorktrees(task) {
 		projectDir := e.getProjectDir(task.Project)
 		if projectDir == "" {
 			return fmt.Errorf("could not find project directory for project: %s", task.Project)

--- a/internal/executor/worktree_mode_test.go
+++ b/internal/executor/worktree_mode_test.go
@@ -1,7 +1,10 @@
 package executor
 
 import (
+	"os"
+	osexec "os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bborn/workflow/internal/config"
@@ -51,4 +54,109 @@ func TestTaskUsesWorktreesPerTaskOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+// gitInTestRepo runs a git command in dir, failing the test on error.
+func gitInTestRepo(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := osexec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestSetupWorktreePerTaskOverride exercises setupWorktree end-to-end with the
+// per-task overrides: an in-place task in a worktrees-on project runs in the
+// project directory itself, and a forced-worktree task in a worktrees-off
+// project gets a real git worktree branched from the task's BaseBranch.
+func TestSetupWorktreePerTaskOverride(t *testing.T) {
+	if _, err := osexec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmpDir := t.TempDir()
+	database, err := db.Open(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	newRepo := func(name string) string {
+		dir := filepath.Join(tmpDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		gitInTestRepo(t, dir, "init", "-b", "main")
+		gitInTestRepo(t, dir, "commit", "--allow-empty", "-m", "base")
+		gitInTestRepo(t, dir, "branch", "develop")
+		// Advance main so develop and main point at different commits.
+		gitInTestRepo(t, dir, "commit", "--allow-empty", "-m", "main only")
+		return dir
+	}
+	onDir := newRepo("wt-on-repo")
+	offDir := newRepo("wt-off-repo")
+
+	if err := database.CreateProject(&db.Project{Name: "wt-on", Path: onDir, UseWorktrees: true}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if err := database.CreateProject(&db.Project{Name: "wt-off", Path: offDir, UseWorktrees: false}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	e := New(database, config.New(database))
+
+	t.Run("in-place task in worktrees-on project uses project dir", func(t *testing.T) {
+		task := &db.Task{Title: "in place", Status: db.StatusQueued, Project: "wt-on", WorktreeMode: db.WorktreeModeInPlace}
+		if err := database.CreateTask(task); err != nil {
+			t.Fatal(err)
+		}
+		workDir, err := e.setupWorktree(task)
+		if err != nil {
+			t.Fatalf("setupWorktree: %v", err)
+		}
+		if workDir != onDir {
+			t.Errorf("workDir = %q, want project dir %q", workDir, onDir)
+		}
+		if _, err := os.Stat(filepath.Join(onDir, ".task-worktrees")); !os.IsNotExist(err) {
+			t.Error("no .task-worktrees directory should be created for an in-place task")
+		}
+	})
+
+	t.Run("forced worktree in worktrees-off project branches from base branch", func(t *testing.T) {
+		task := &db.Task{
+			Title:        "forced worktree",
+			Status:       db.StatusQueued,
+			Project:      "wt-off",
+			WorktreeMode: db.WorktreeModeWorktree,
+			BaseBranch:   "develop",
+		}
+		if err := database.CreateTask(task); err != nil {
+			t.Fatal(err)
+		}
+		workDir, err := e.setupWorktree(task)
+		if err != nil {
+			t.Fatalf("setupWorktree: %v", err)
+		}
+		wantPrefix := filepath.Join(offDir, ".task-worktrees") + string(filepath.Separator)
+		if !strings.HasPrefix(workDir, wantPrefix) {
+			t.Fatalf("workDir = %q, want a worktree under %q", workDir, wantPrefix)
+		}
+
+		// The worktree's HEAD must match develop (the base branch), not main.
+		head := gitInTestRepo(t, workDir, "rev-parse", "HEAD")
+		develop := gitInTestRepo(t, offDir, "rev-parse", "develop")
+		main := gitInTestRepo(t, offDir, "rev-parse", "main")
+		if head != develop {
+			t.Errorf("worktree HEAD = %s, want develop %s", head, develop)
+		}
+		if head == main {
+			t.Error("worktree HEAD should not be main when a base branch is set")
+		}
+	})
 }

--- a/internal/executor/worktree_mode_test.go
+++ b/internal/executor/worktree_mode_test.go
@@ -1,0 +1,54 @@
+package executor
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+// TestTaskUsesWorktreesPerTaskOverride verifies the executor's worktree
+// decision combines the task's WorktreeMode override with the project's
+// UseWorktrees setting: inherit follows the project, "worktree" forces a
+// fresh worktree even when the project default is off, and "in-place" runs
+// in the project directory even when the default is on.
+func TestTaskUsesWorktreesPerTaskOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	database, err := db.Open(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.CreateProject(&db.Project{Name: "wt-on", Path: t.TempDir(), UseWorktrees: true}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if err := database.CreateProject(&db.Project{Name: "wt-off", Path: t.TempDir(), UseWorktrees: false}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	exec := New(database, &config.Config{})
+
+	cases := []struct {
+		name string
+		task *db.Task
+		want bool
+	}{
+		// No mode set: identical to the previous project-level behavior.
+		{"inherit in worktrees-on project", &db.Task{Project: "wt-on"}, true},
+		{"inherit in worktrees-off project", &db.Task{Project: "wt-off"}, false},
+		{"inherit in unknown project defaults on", &db.Task{Project: "nope"}, true},
+
+		// Per-task overrides win over the project setting.
+		{"in-place overrides worktrees-on project", &db.Task{Project: "wt-on", WorktreeMode: db.WorktreeModeInPlace}, false},
+		{"worktree overrides worktrees-off project", &db.Task{Project: "wt-off", WorktreeMode: db.WorktreeModeWorktree}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := exec.taskUsesWorktrees(c.task); got != c.want {
+				t.Errorf("taskUsesWorktrees(%+v) = %v, want %v", c.task, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -31,6 +31,8 @@ const (
 	FieldExecutor
 	FieldEffort
 	FieldPermission
+	FieldWorktree
+	FieldBaseBranch
 	FieldCount
 )
 
@@ -51,33 +53,38 @@ type FormModel struct {
 	titleInput       textinput.Model
 	bodyInput        textarea.Model
 	attachmentsInput textinput.Model
+	baseBranchInput  textinput.Model
 
 	// Select values
-	project            string
-	projectIdx         int
-	projects           []string
-	projectSearchMode  bool     // true when typing to search/filter projects
-	projectSearchQuery string   // current search query
-	projectFiltered    []string // filtered project list (fuzzy matched)
-	projectFilteredIdx int      // selected index in filtered list
-	taskType           string
-	typeIdx            int
-	types              []string
-	executor           string // "claude", "codex", "gemini"
-	executorIdx        int
-	executors          []string
-	availableExecutors []string // Original list of available executors (for rebuilding when project changes)
-	effortLevel        string   // Per-task Claude effort override ("" = use global/Claude default)
-	effortIdx          int
-	effortLevels       []string // Selectable effort values; "" (first) means "default"
-	effortTouched      bool     // user picked an effort explicitly; stop following project default
-	permissionMode     string   // Per-task permission mode ("default"/"auto"/"dangerous")
-	permissionIdx      int
-	permissionModes    []string // Selectable permission modes
-	permissionTouched  bool     // user picked a permission explicitly; stop following project default
-	queue              bool
-	attachments        []string // Parsed file paths
-	attachmentCursor   int      // Index of the currently selected attachment chip
+	project              string
+	projectIdx           int
+	projects             []string
+	projectSearchMode    bool     // true when typing to search/filter projects
+	projectSearchQuery   string   // current search query
+	projectFiltered      []string // filtered project list (fuzzy matched)
+	projectFilteredIdx   int      // selected index in filtered list
+	taskType             string
+	typeIdx              int
+	types                []string
+	executor             string // "claude", "codex", "gemini"
+	executorIdx          int
+	executors            []string
+	availableExecutors   []string // Original list of available executors (for rebuilding when project changes)
+	effortLevel          string   // Per-task Claude effort override ("" = use global/Claude default)
+	effortIdx            int
+	effortLevels         []string // Selectable effort values; "" (first) means "default"
+	effortTouched        bool     // user picked an effort explicitly; stop following project default
+	permissionMode       string   // Per-task permission mode ("default"/"auto"/"dangerous")
+	permissionIdx        int
+	permissionModes      []string // Selectable permission modes
+	permissionTouched    bool     // user picked a permission explicitly; stop following project default
+	worktreeMode         string   // Per-task worktree override ("" = project default, "worktree", "in-place")
+	worktreeModeIdx      int
+	worktreeModes        []string // Selectable worktree modes; "" (first) means "project default"
+	projectUsesWorktrees bool     // selected project's UseWorktrees setting (drives base-branch visibility)
+	queue                bool
+	attachments          []string // Parsed file paths
+	attachmentCursor     int      // Index of the currently selected attachment chip
 
 	// Magic paste fields (populated when pasting URLs)
 	prURL    string // GitHub PR URL if pasted
@@ -189,6 +196,36 @@ func permissionIndexFor(options []string, mode string) int {
 	return 0
 }
 
+// worktreeModeOptions returns the selectable worktree modes for the form. The
+// first entry is the empty string, which represents "project default" (inherit
+// the project's UseWorktrees setting — no per-task override).
+func worktreeModeOptions() []string {
+	return []string{db.WorktreeModeInherit, db.WorktreeModeWorktree, db.WorktreeModeInPlace}
+}
+
+// worktreeModeLabel returns the display label for a worktree mode option.
+func worktreeModeLabel(mode string) string {
+	switch mode {
+	case db.WorktreeModeWorktree:
+		return "worktree"
+	case db.WorktreeModeInPlace:
+		return "in place"
+	default:
+		return "project default"
+	}
+}
+
+// worktreeModeIndexFor returns the index of the given worktree mode in the
+// options list, defaulting to 0 ("project default") when not found.
+func worktreeModeIndexFor(options []string, mode string) int {
+	for i, o := range options {
+		if o == mode {
+			return i
+		}
+	}
+	return 0
+}
+
 // NewEditFormModel creates a form model pre-populated with an existing task's data for editing.
 func NewEditFormModel(database *db.DB, task *db.Task, width, height int, availableExecutors []string) *FormModel {
 	// Set executor to default if not specified
@@ -261,6 +298,9 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int, availab
 		permissionModes:     permissionModeOptions(),
 		permissionIdx:       permissionIndexFor(permissionModeOptions(), task.EffectivePermissionMode()),
 		permissionTouched:   true, // editing: keep the task's existing mode unless changed
+		worktreeMode:        db.NormalizeWorktreeMode(task.WorktreeMode),
+		worktreeModes:       worktreeModeOptions(),
+		worktreeModeIdx:     worktreeModeIndexFor(worktreeModeOptions(), db.NormalizeWorktreeMode(task.WorktreeMode)),
 		isEdit:              true,
 		prURL:               task.PRURL,
 		prNumber:            task.PRNumber,
@@ -339,6 +379,17 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int, availab
 	m.attachmentsInput.Cursor.SetMode(cursor.CursorStatic)
 	m.attachmentsInput.Width = width - 24
 
+	// Base branch input - pre-populate with existing base branch
+	m.baseBranchInput = textinput.New()
+	m.baseBranchInput.Placeholder = "Base branch (default branch if empty)"
+	m.baseBranchInput.Prompt = ""
+	m.baseBranchInput.Cursor.SetMode(cursor.CursorStatic)
+	m.baseBranchInput.Width = width - 24
+	m.baseBranchInput.SetValue(task.BaseBranch)
+
+	// Load the project's worktree setting for base-branch visibility
+	m.refreshProjectWorktreeSetting()
+
 	// Apply modal-aware input widths and body height now that modal is set.
 	m.SetSize(width, height)
 
@@ -383,7 +434,8 @@ func NewFormModel(database *db.DB, width, height int, workingDir string, availab
 		attachmentCursor:    -1,
 		effortLevels:        effortLevelOptions(), // Defaults to "" (Claude's global default)
 		permissionModes:     permissionModeOptions(),
-		showAdvanced:        showAdvanced, // Load from user preference
+		worktreeModes:       worktreeModeOptions(), // Defaults to "" (project default)
+		showAdvanced:        showAdvanced,          // Load from user preference
 	}
 
 	// Load task types from database
@@ -460,6 +512,7 @@ func NewFormModel(database *db.DB, width, height int, workingDir string, availab
 	// previous task in that project.
 	m.refreshPermissionDefaultForProject()
 	m.refreshEffortDefaultForProject()
+	m.refreshProjectWorktreeSetting()
 
 	// Title input
 	m.titleInput = textinput.New()
@@ -490,6 +543,13 @@ func NewFormModel(database *db.DB, width, height int, workingDir string, availab
 	m.attachmentsInput.Prompt = ""
 	m.attachmentsInput.Cursor.SetMode(cursor.CursorStatic)
 	m.attachmentsInput.Width = width - 24
+
+	// Base branch input (shown only when the task will run in a worktree)
+	m.baseBranchInput = textinput.New()
+	m.baseBranchInput.Placeholder = "Base branch (default branch if empty)"
+	m.baseBranchInput.Prompt = ""
+	m.baseBranchInput.Cursor.SetMode(cursor.CursorStatic)
+	m.baseBranchInput.Width = width - 24
 
 	return m
 }
@@ -806,6 +866,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.loadLastExecutorForProject()
 				m.refreshPermissionDefaultForProject()
 				m.refreshEffortDefaultForProject()
+				m.refreshProjectWorktreeSetting()
 				return m, nil
 			}
 			if m.focused == FieldType {
@@ -830,6 +891,11 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.permissionTouched = true
 				return m, nil
 			}
+			if m.focused == FieldWorktree && len(m.worktreeModes) > 0 {
+				m.worktreeModeIdx = (m.worktreeModeIdx - 1 + len(m.worktreeModes)) % len(m.worktreeModes)
+				m.worktreeMode = m.worktreeModes[m.worktreeModeIdx]
+				return m, nil
+			}
 
 		case "right":
 			if m.handleAttachmentNavigation(1) {
@@ -843,6 +909,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.loadLastExecutorForProject()
 				m.refreshPermissionDefaultForProject()
 				m.refreshEffortDefaultForProject()
+				m.refreshProjectWorktreeSetting()
 				return m, nil
 			}
 			if m.focused == FieldType {
@@ -865,6 +932,11 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.permissionIdx = (m.permissionIdx + 1) % len(m.permissionModes)
 				m.permissionMode = m.permissionModes[m.permissionIdx]
 				m.permissionTouched = true
+				return m, nil
+			}
+			if m.focused == FieldWorktree && len(m.worktreeModes) > 0 {
+				m.worktreeModeIdx = (m.worktreeModeIdx + 1) % len(m.worktreeModes)
+				m.worktreeMode = m.worktreeModes[m.worktreeModeIdx]
 				return m, nil
 			}
 
@@ -920,7 +992,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			// Type-to-select for other selector fields
-			if m.focused == FieldType || m.focused == FieldExecutor || m.focused == FieldEffort || m.focused == FieldPermission {
+			if m.focused == FieldType || m.focused == FieldExecutor || m.focused == FieldEffort || m.focused == FieldPermission || m.focused == FieldWorktree {
 				key := msg.String()
 				if len(key) == 1 && unicode.IsLetter(rune(key[0])) {
 					m.selectByPrefix(strings.ToLower(key))
@@ -961,6 +1033,8 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.attachmentsInput.Value() != "" && m.attachmentCursor != -1 {
 			m.clearAttachmentSelection()
 		}
+	case FieldBaseBranch:
+		m.baseBranchInput, cmd = m.baseBranchInput.Update(msg)
 	}
 
 	return m, cmd
@@ -1128,6 +1202,7 @@ func (m *FormModel) selectProjectFromSearch() {
 	m.loadLastExecutorForProject()
 	m.refreshPermissionDefaultForProject()
 	m.refreshEffortDefaultForProject()
+	m.refreshProjectWorktreeSetting()
 }
 
 // filterProjects updates the filtered project list based on the search query.
@@ -1208,6 +1283,14 @@ func (m *FormModel) selectByPrefix(prefix string) {
 				m.permissionIdx = i
 				m.permissionMode = p
 				m.permissionTouched = true
+				return
+			}
+		}
+	case FieldWorktree:
+		for i, mode := range m.worktreeModes {
+			if strings.HasPrefix(strings.ToLower(worktreeModeLabel(mode)), prefix) {
+				m.worktreeModeIdx = i
+				m.worktreeMode = mode
 				return
 			}
 		}
@@ -1320,6 +1403,32 @@ func (m *FormModel) refreshEffortDefaultForProject() {
 	m.effortIdx = effortIndexFor(m.effortLevels, m.effortLevel)
 }
 
+// refreshProjectWorktreeSetting reloads the selected project's UseWorktrees
+// setting, which drives whether the base-branch input is relevant when the
+// worktree mode is "project default". Defaults to true (the use_worktrees
+// column default) when the project cannot be loaded.
+func (m *FormModel) refreshProjectWorktreeSetting() {
+	m.projectUsesWorktrees = true
+	if m.db != nil && m.project != "" {
+		if p, err := m.db.GetProjectByName(m.project); err == nil && p != nil {
+			m.projectUsesWorktrees = p.UsesWorktrees()
+		}
+	}
+}
+
+// baseBranchRelevant reports whether the base-branch input applies: only when
+// the task will run in a fresh worktree (forced per task, or inherited from a
+// worktrees-on project).
+func (m *FormModel) baseBranchRelevant() bool {
+	switch m.worktreeMode {
+	case db.WorktreeModeWorktree:
+		return true
+	case db.WorktreeModeInPlace:
+		return false
+	}
+	return m.projectUsesWorktrees
+}
+
 // rebuildExecutorListForProject rebuilds the executor list sorted by usage for the current project.
 // This should be called when the project changes to re-sort executors by usage count.
 func (m *FormModel) rebuildExecutorListForProject() {
@@ -1362,6 +1471,10 @@ func (m *FormModel) isFieldVisible(field FormField) bool {
 		// Effort is a Claude-specific override (claude --effort), only shown in
 		// advanced mode and only when the Claude executor is selected.
 		return m.showAdvanced && m.executor == db.ExecutorClaude
+	}
+	if field == FieldBaseBranch {
+		// Base branch only applies when a fresh worktree will be created.
+		return m.showAdvanced && m.baseBranchRelevant()
 	}
 	if m.showAdvanced {
 		return true
@@ -1423,6 +1536,7 @@ func (m *FormModel) blurAll() {
 	m.titleInput.Blur()
 	m.bodyInput.Blur()
 	m.attachmentsInput.Blur()
+	m.baseBranchInput.Blur()
 	m.clearAttachmentSelection()
 	if m.projectSearchMode {
 		m.exitProjectSearch()
@@ -1437,6 +1551,8 @@ func (m *FormModel) focusCurrent() {
 		m.bodyInput.Focus()
 	case FieldAttachments:
 		m.attachmentsInput.Focus()
+	case FieldBaseBranch:
+		m.baseBranchInput.Focus()
 	}
 }
 
@@ -1927,6 +2043,30 @@ func (m *FormModel) View() string {
 			b.WriteString(cursor + " " + labelStyle.Render("Permission") + m.renderSelector(m.permissionModes, m.permissionIdx, m.focused == FieldPermission, selectedStyle, optionStyle, dimStyle))
 			b.WriteString("\n\n")
 		}
+
+		// Worktree selector (per-task override of the project's worktree setting)
+		if m.isFieldVisible(FieldWorktree) {
+			cursor = " "
+			if m.focused == FieldWorktree {
+				cursor = cursorStyle.Render("▸")
+			}
+			worktreeLabels := make([]string, len(m.worktreeModes))
+			for i, mode := range m.worktreeModes {
+				worktreeLabels[i] = worktreeModeLabel(mode)
+			}
+			b.WriteString(cursor + " " + labelStyle.Render("Worktree") + m.renderSelector(worktreeLabels, m.worktreeModeIdx, m.focused == FieldWorktree, selectedStyle, optionStyle, dimStyle))
+			b.WriteString("\n\n")
+		}
+
+		// Base branch input (only when a fresh worktree will be created)
+		if m.isFieldVisible(FieldBaseBranch) {
+			cursor = " "
+			if m.focused == FieldBaseBranch {
+				cursor = cursorStyle.Render("▸")
+			}
+			b.WriteString(cursor + " " + labelStyle.Render("Base branch") + m.baseBranchInput.View())
+			b.WriteString("\n\n")
+		}
 	} else {
 		// Show compact summary of defaults and toggle hint
 		b.WriteString("\n")
@@ -2021,6 +2161,7 @@ func (m *FormModel) hasFormData() bool {
 	return strings.TrimSpace(m.titleInput.Value()) != "" ||
 		strings.TrimSpace(m.bodyInput.Value()) != "" ||
 		strings.TrimSpace(m.attachmentsInput.Value()) != "" ||
+		strings.TrimSpace(m.baseBranchInput.Value()) != "" ||
 		len(m.attachments) > 0
 }
 
@@ -2061,6 +2202,15 @@ func (m *FormModel) ApplyTo(task *db.Task) {
 	// task, keeping the legacy DangerousMode boolean consistent with it.
 	task.PermissionMode = m.resolvedPermissionMode()
 	task.DangerousMode = task.PermissionMode == db.PermissionModeDangerous
+
+	// Worktree override; the base branch only applies when a worktree will be
+	// created, so don't carry it for in-place tasks.
+	task.WorktreeMode = db.NormalizeWorktreeMode(m.worktreeMode)
+	if m.baseBranchRelevant() {
+		task.BaseBranch = strings.TrimSpace(m.baseBranchInput.Value())
+	} else {
+		task.BaseBranch = ""
+	}
 }
 
 // SetQueue sets whether to queue the task.
@@ -2086,6 +2236,7 @@ func (m *FormModel) SetSize(width, height int) {
 	m.titleInput.Width = inputWidth
 	m.bodyInput.SetWidth(inputWidth)
 	m.attachmentsInput.Width = inputWidth
+	m.baseBranchInput.Width = inputWidth
 	// Recalculate body height based on new dimensions
 	m.updateBodyHeight()
 }

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -2272,6 +2272,17 @@ func (m *FormModel) calculateBodyHeight() int {
 		// Advanced adds: project(1+blank) + attachments(blank+label+input+blank=4) +
 		// type(1+blank) + executor(1+blank) = 10
 		modeOverhead = 10
+		// Attachment chips render one line each plus a help line.
+		if n := len(m.attachments); n > 0 {
+			modeOverhead += n + 1
+		}
+		// Conditional rows (Effort/Permission/Worktree/Base branch) each render
+		// as a selector line plus a blank when visible.
+		for _, f := range []FormField{FieldEffort, FieldPermission, FieldWorktree, FieldBaseBranch} {
+			if m.isFieldVisible(f) {
+				modeOverhead += 2
+			}
+		}
 	} else {
 		// Simple adds: blank + summary + blank(2) = 3
 		modeOverhead = 3

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -94,9 +94,17 @@ func TestBodyHeightFillsAvailableSpace(t *testing.T) {
 
 			height := m.calculateBodyHeight()
 
-			// Body should fill available space (screen minus overhead)
-			// In advanced mode: boxChrome(6) + common(6) + advanced(10) = 22
-			expectedHeight := screenHeight - 22
+			// Body should fill available space (screen minus overhead).
+			// In advanced mode: boxChrome(6) + common(6) + advanced(10) plus
+			// 2 per visible conditional row (Effort/Permission/Worktree/Base
+			// branch) — mirror the model so the expectation tracks visibility.
+			overhead := 22
+			for _, f := range []FormField{FieldEffort, FieldPermission, FieldWorktree, FieldBaseBranch} {
+				if m.isFieldVisible(f) {
+					overhead += 2
+				}
+			}
+			expectedHeight := screenHeight - overhead
 			if expectedHeight < 8 {
 				expectedHeight = 8
 			}

--- a/internal/ui/form_worktree_test.go
+++ b/internal/ui/form_worktree_test.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// TestFormWorktreeModeDefaultsToInherit verifies a new form starts on
+// "project default" so creating a task without touching the field preserves
+// the project-level worktree behavior exactly.
+func TestFormWorktreeModeDefaultsToInherit(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", nil)
+
+	if m.worktreeMode != db.WorktreeModeInherit {
+		t.Errorf("worktreeMode = %q, want inherit (empty)", m.worktreeMode)
+	}
+
+	task := m.GetDBTask()
+	if task.WorktreeMode != db.WorktreeModeInherit {
+		t.Errorf("GetDBTask().WorktreeMode = %q, want inherit (empty)", task.WorktreeMode)
+	}
+	if task.BaseBranch != "" {
+		t.Errorf("GetDBTask().BaseBranch = %q, want empty", task.BaseBranch)
+	}
+}
+
+// TestFormApplyToCarriesWorktreeFields verifies the selected worktree mode and
+// base branch are applied to the task.
+func TestFormApplyToCarriesWorktreeFields(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", nil)
+	m.worktreeMode = db.WorktreeModeWorktree
+	m.baseBranchInput.SetValue("  release/2.0  ")
+
+	task := m.GetDBTask()
+	if task.WorktreeMode != db.WorktreeModeWorktree {
+		t.Errorf("WorktreeMode = %q, want %q", task.WorktreeMode, db.WorktreeModeWorktree)
+	}
+	if task.BaseBranch != "release/2.0" {
+		t.Errorf("BaseBranch = %q, want trimmed %q", task.BaseBranch, "release/2.0")
+	}
+}
+
+// TestFormInPlaceClearsBaseBranch verifies the base branch is not carried for
+// in-place tasks, where no worktree is ever created.
+func TestFormInPlaceClearsBaseBranch(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", nil)
+	m.baseBranchInput.SetValue("release/2.0")
+	m.worktreeMode = db.WorktreeModeInPlace
+
+	task := m.GetDBTask()
+	if task.WorktreeMode != db.WorktreeModeInPlace {
+		t.Errorf("WorktreeMode = %q, want %q", task.WorktreeMode, db.WorktreeModeInPlace)
+	}
+	if task.BaseBranch != "" {
+		t.Errorf("BaseBranch = %q, want empty for in-place task", task.BaseBranch)
+	}
+}
+
+// TestFormBaseBranchVisibility verifies the base-branch input only shows when
+// a fresh worktree will be created.
+func TestFormBaseBranchVisibility(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", nil)
+	m.showAdvanced = true
+
+	cases := []struct {
+		name                 string
+		mode                 string
+		projectUsesWorktrees bool
+		want                 bool
+	}{
+		{"inherit with worktrees-on project", db.WorktreeModeInherit, true, true},
+		{"inherit with worktrees-off project", db.WorktreeModeInherit, false, false},
+		{"forced worktree in worktrees-off project", db.WorktreeModeWorktree, false, true},
+		{"in-place in worktrees-on project", db.WorktreeModeInPlace, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m.worktreeMode = c.mode
+			m.projectUsesWorktrees = c.projectUsesWorktrees
+			if got := m.isFieldVisible(FieldBaseBranch); got != c.want {
+				t.Errorf("isFieldVisible(FieldBaseBranch) = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestEditFormPrepopulatesWorktreeFields verifies editing keeps the task's
+// existing worktree mode and base branch.
+func TestEditFormPrepopulatesWorktreeFields(t *testing.T) {
+	task := &db.Task{
+		Title:        "T",
+		WorktreeMode: db.WorktreeModeWorktree,
+		BaseBranch:   "release/2.0",
+	}
+	m := NewEditFormModel(nil, task, 100, 50, nil)
+
+	if m.worktreeMode != db.WorktreeModeWorktree {
+		t.Errorf("worktreeMode = %q, want %q", m.worktreeMode, db.WorktreeModeWorktree)
+	}
+	if m.worktreeModeIdx != worktreeModeIndexFor(worktreeModeOptions(), db.WorktreeModeWorktree) {
+		t.Errorf("worktreeModeIdx = %d not aligned with mode", m.worktreeModeIdx)
+	}
+	if got := m.baseBranchInput.Value(); got != "release/2.0" {
+		t.Errorf("baseBranchInput = %q, want %q", got, "release/2.0")
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -125,6 +125,8 @@ type createTaskRequest struct {
 	Tags           string `json:"tags"`
 	Pinned         bool   `json:"pinned"`
 	PermissionMode string `json:"permission_mode"`
+	WorktreeMode   string `json:"worktree_mode"`
+	BaseBranch     string `json:"base_branch"`
 }
 
 func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
@@ -171,6 +173,8 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 		Tags:           req.Tags,
 		Pinned:         req.Pinned,
 		PermissionMode: db.NormalizePermissionMode(req.PermissionMode),
+		WorktreeMode:   db.NormalizeWorktreeMode(req.WorktreeMode),
+		BaseBranch:     req.BaseBranch,
 	}
 
 	if err := s.db.CreateTask(task); err != nil {
@@ -215,6 +219,8 @@ type updateTaskRequest struct {
 	Pinned         *bool   `json:"pinned"`
 	PermissionMode *string `json:"permission_mode"`
 	EffortLevel    *string `json:"effort_level"`
+	WorktreeMode   *string `json:"worktree_mode"`
+	BaseBranch     *string `json:"base_branch"`
 }
 
 func (s *Server) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
@@ -259,6 +265,12 @@ func (s *Server) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.EffortLevel != nil {
 		task.EffortLevel = *req.EffortLevel
+	}
+	if req.WorktreeMode != nil {
+		task.WorktreeMode = db.NormalizeWorktreeMode(*req.WorktreeMode)
+	}
+	if req.BaseBranch != nil {
+		task.BaseBranch = *req.BaseBranch
 	}
 
 	if err := s.db.UpdateTask(task); err != nil {
@@ -1043,6 +1055,8 @@ type taskJSON struct {
 	HasExecutor    bool   `json:"has_executor"`
 	EffortLevel    string `json:"effort_level,omitempty"`
 	SourceBranch   string `json:"source_branch,omitempty"`
+	WorktreeMode   string `json:"worktree_mode,omitempty"`
+	BaseBranch     string `json:"base_branch,omitempty"`
 	DaemonSession  string `json:"daemon_session,omitempty"`
 	TmuxWindowID   string `json:"tmux_window_id,omitempty"`
 	ClaudePaneID   string `json:"claude_pane_id,omitempty"`
@@ -1081,6 +1095,8 @@ func toTaskJSON(t *db.Task) *taskJSON {
 		HasExecutor:    t.ClaudePaneID != "",
 		EffortLevel:    t.EffortLevel,
 		SourceBranch:   t.SourceBranch,
+		WorktreeMode:   t.WorktreeMode,
+		BaseBranch:     t.BaseBranch,
 		DaemonSession:  t.DaemonSession,
 		TmuxWindowID:   t.TmuxWindowID,
 		ClaudePaneID:   t.ClaudePaneID,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -156,6 +156,37 @@ func TestHandleCreateTask(t *testing.T) {
 	}
 }
 
+func TestHandleCreateTask_WorktreeFields(t *testing.T) {
+	srv, database, _ := setupServer(t)
+
+	body := `{"title":"Override task","type":"code","project":"personal","worktree_mode":"in-place","base_branch":"release/2.0"}`
+	req := httptest.NewRequest("POST", "/api/tasks", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleCreateTask(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var task taskJSON
+	json.NewDecoder(w.Body).Decode(&task)
+	if task.WorktreeMode != db.WorktreeModeInPlace {
+		t.Errorf("worktree_mode = %q, want %q", task.WorktreeMode, db.WorktreeModeInPlace)
+	}
+	if task.BaseBranch != "release/2.0" {
+		t.Errorf("base_branch = %q, want %q", task.BaseBranch, "release/2.0")
+	}
+
+	stored, err := database.GetTask(task.ID)
+	if err != nil || stored == nil {
+		t.Fatalf("get stored task: %v", err)
+	}
+	if stored.WorktreeMode != db.WorktreeModeInPlace || stored.BaseBranch != "release/2.0" {
+		t.Errorf("stored worktree fields = %q/%q, want in-place/release/2.0",
+			stored.WorktreeMode, stored.BaseBranch)
+	}
+}
+
 func TestHandleCreateTask_Empty(t *testing.T) {
 	srv, _, _ := setupServer(t)
 


### PR DESCRIPTION
## What

Per-task worktree/branch strategy across all four surfaces (engine, CLI, TUI, GUI). Today worktree behavior is a per-project boolean (`Project.UseWorktrees`); this PR adds a per-task override matching the four options in Nora's new-agent dialog, with **two small fields** instead of a new model:

| Nora option | TaskYou expression |
|---|---|
| New worktree | `WorktreeMode = "worktree"` (or inherit from a worktrees-on project) |
| Run in place on current branch | `WorktreeMode = "in-place"` |
| Create new branch from a ref | `BaseBranch = "<ref>"` (worktree branches from it instead of the default branch) |
| Checkout existing branch | already covered by the existing `SourceBranch` field (`ty create --branch`) — untouched |

## Why two fields

- `worktree_mode TEXT DEFAULT ''` — `""` = inherit the project setting (**the default everywhere**, preserving current behavior exactly), `"worktree"` = force a fresh worktree even if the project default is off, `"in-place"` = run directly in the project dir even if the default is on. Unknown values normalize to inherit, so a bad value can never change where a task executes.
- `base_branch TEXT DEFAULT ''` — git ref a new worktree branches from; empty keeps using the project's default branch.

The decision logic is two pure, table-tested functions in `internal/db`:
- `ShouldUseWorktree(project, task)` — inherit / force-on / force-off (nil project defaults on, matching the column default)
- `ResolveWorktreeBase(task, defaultBranch)` — base-ref resolution

The executor routes every task-scoped worktree decision through `taskUsesWorktrees` (now task-aware): `setupWorktree`, stale-worktree cleanup (auto + manual), `ArchiveWorktree`, `UnarchiveWorktree`. This also means an in-place task in a worktrees-on project can never have the project directory archived/removed, and a forced-worktree task in a worktrees-off project is cleaned up like any other worktree task.

## Default behavior unchanged

With no field set: `ShouldUseWorktree` returns exactly `project.UsesWorktrees()` (or true when the project can't be loaded — identical to the previous `taskUsesWorktrees`/`ProjectUsesWorktrees` fallbacks), and `ResolveWorktreeBase` returns the default branch, so `git worktree add -b <branch> <path> <defaultBranch>` is byte-identical to before. The TUI selector defaults to "Project default", the GUI select defaults to "Project default", and the CLI flags default to absent.

## Surfaces

- **CLI**: `ty create --worktree | --in-place` (mutually exclusive via cobra `MarkFlagsMutuallyExclusive`; absent = inherit) and `--base-branch <ref>`; help text + JSON output updated.
- **TUI**: "Worktree" selector (project default / worktree / in place) in the advanced section of the task form, following the existing selector-field pattern; a "Base branch" input appears only when a fresh worktree will actually be created. Parity test passes (no new key bindings).
- **GUI**: same three-option select + conditional base-branch input in `TaskForm.tsx` Advanced, wired through `api/client.ts` types, `POST /api/tasks` / `PATCH /api/tasks/{id}` handlers, and task JSON.

## Tests

| Package | Result |
|---|---|
| `internal/db` | ok (new: `NormalizeWorktreeMode`, `ShouldUseWorktree`, `ResolveWorktreeBase` table tests; column round-trip through Create/Get/List/Update; normalization on insert) |
| `internal/executor` | new tests pass (`TestTaskUsesWorktreesPerTaskOverride`, `TestSetupWorktreePerTaskOverride` — see below). Two **pre-existing, environment-dependent** failures (`TestBuildCommandIncludesProjectConfigDir`, `TestFindClaudeSessionID`) fail identically on pristine `main` on this machine (local `CLAUDE_CONFIG_DIR=~/.claude-ik` and local Claude session files); unrelated to this change. |
| `internal/ui` | ok (new: form default-inherit, ApplyTo carry, in-place clears base branch, base-branch visibility, edit-form prepopulation) |
| `internal/web` | ok (new: `TestHandleCreateTask_WorktreeFields`) |
| `internal/parity` + all other packages | ok |
| `desktop` | `pnpm build` (tsc --noEmit + vite) clean |

`go build ./...`, `go vet ./...` clean; `gofmt -l` clean on all touched packages (`extensions/ty-qmd/cmd/main.go` was already unformatted on `main` and is untouched).

## Manual test transcript (scratch DB via `WORKTREE_DB_PATH`)

```console
$ export WORKTREE_DB_PATH=/tmp/ty-qa-scratch/tasks.db
$ ty projects create wt-on --path /tmp/ty-qa-scratch/proj-on
Created project 'wt-on' at /tmp/ty-qa-scratch/proj-on
$ ty projects create wt-off --path /tmp/ty-qa-scratch/proj-off --no-git
Created project 'wt-off' at /tmp/ty-qa-scratch/proj-off (non-git, worktrees disabled)

$ ty create "QA in-place override" --project wt-on --in-place --json
{"executor":"claude","id":1,"project":"wt-on", ... "worktree_mode":"in-place"}
$ ty create "QA worktree override" --project wt-off --worktree --base-branch develop --json
{"base_branch":"develop","executor":"claude","id":2,"project":"wt-off", ... "worktree_mode":"worktree"}
$ ty create "QA inherit" --project wt-on --json
{"executor":"claude","id":3,"project":"wt-on", ...}            # no worktree_mode key — inherit
$ ty create "QA both" --project wt-on --worktree --in-place
Error: if any flags in the group [worktree in-place] are set none of the others can be

$ sqlite3 $WORKTREE_DB_PATH "SELECT id, project, worktree_mode, base_branch FROM tasks ORDER BY id;"
1|wt-on|in-place|
2|wt-off|worktree|develop
3|wt-on||
```

Resolution through the engine decision functions against that same scratch DB:

```
task #1 "QA in-place override"  project=wt-on(use_worktrees=true)  mode="in-place" -> worktree=false baseRef="main"
task #2 "QA worktree override"  project=wt-off(use_worktrees=false) mode="worktree" -> worktree=true  baseRef="develop"
task #3 "QA inherit"            project=wt-on(use_worktrees=true)  mode=""         -> worktree=true  baseRef="main"
```

**Where verification stopped:** the full agent path (tmux + a live Claude session) was not run in this environment. Verification goes one level past the decision-function boundary: `TestSetupWorktreePerTaskOverride` executes the real `setupWorktree` against temp git repos and asserts (a) an in-place task in a worktrees-on project resolves to the project directory with no `.task-worktrees` created, and (b) a forced-worktree task in a worktrees-off project gets a real `git worktree` whose `HEAD` equals the `BaseBranch` ref (`develop`), not `main`. Everything from there to the agent (tmux window creation, executor launch) is unchanged code that consumes the returned workDir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
