### PR TITLE
chore(desktop): drop Intel macOS build — Apple Silicon only

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -22,17 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS is Apple Silicon only. No Intel (x86_64) desktop build:
+          # GitHub retired the Intel macos-13 runners and the cross-compile
+          # job starved in the macos-14 queue, so we don't ship an Intel DMG.
           - name: macos-arm64
             runner: macos-14
             triple: aarch64-apple-darwin
             goarch: arm64
-            bundles: "dmg"
-          # GitHub retired the Intel macos-13 runners (jobs queue forever),
-          # so the x64 build cross-compiles on Apple Silicon instead.
-          - name: macos-x64
-            runner: macos-14
-            triple: x86_64-apple-darwin
-            goarch: amd64
             bundles: "dmg"
           - name: linux-x64
             runner: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This downloads the latest DMG, verifies it, installs **TaskYou.app** to `~/Appli
 
 Or grab a prebuilt bundle from the [latest release](https://github.com/bborn/taskyou/releases/latest):
 
-- **macOS**: `TaskYou-macos-arm64.dmg` (Apple Silicon) or `TaskYou-macos-x64.dmg` (Intel)
+- **macOS**: `TaskYou-macos-arm64.dmg` (Apple Silicon only)
 - **Linux**: `TaskYou-linux-x64.AppImage` or `.deb`
 
 The app is self-contained — it ships its own `ty` engine and starts the server and daemon for you. Two things must be installed on your machine: **tmux** (`brew install tmux`) and at least one executor CLI (e.g. [Claude Code](https://claude.com/claude-code)).

--- a/docs/install-macos.sh
+++ b/docs/install-macos.sh
@@ -72,14 +72,15 @@ require_command() {
     command -v "$1" >/dev/null 2>&1 || error "Required command not found: $1"
 }
 
-# Map the machine architecture to a release DMG asset
+# Map the machine architecture to a release DMG asset.
+# TaskYou Desktop is Apple Silicon only.
 detect_asset() {
     local arch
     arch=$(uname -m)
     case "$arch" in
         arm64) echo "TaskYou-macos-arm64.dmg" ;;
-        x86_64) echo "TaskYou-macos-x64.dmg" ;;
-        *) error "Unsupported architecture: ${arch}. TaskYou Desktop ships for arm64 (Apple Silicon) and x86_64 (Intel)." ;;
+        x86_64) error "TaskYou Desktop is Apple Silicon only — there is no Intel (x86_64) build. Run the CLI instead: curl -fsSL taskyou.dev/install.sh | bash" ;;
+        *) error "Unsupported architecture: ${arch}. TaskYou Desktop requires an Apple Silicon Mac." ;;
     esac
 }
 

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -72,14 +72,15 @@ require_command() {
     command -v "$1" >/dev/null 2>&1 || error "Required command not found: $1"
 }
 
-# Map the machine architecture to a release DMG asset
+# Map the machine architecture to a release DMG asset.
+# TaskYou Desktop is Apple Silicon only.
 detect_asset() {
     local arch
     arch=$(uname -m)
     case "$arch" in
         arm64) echo "TaskYou-macos-arm64.dmg" ;;
-        x86_64) echo "TaskYou-macos-x64.dmg" ;;
-        *) error "Unsupported architecture: ${arch}. TaskYou Desktop ships for arm64 (Apple Silicon) and x86_64 (Intel)." ;;
+        x86_64) error "TaskYou Desktop is Apple Silicon only — there is no Intel (x86_64) build. Run the CLI instead: curl -fsSL taskyou.dev/install.sh | bash" ;;
+        *) error "Unsupported architecture: ${arch}. TaskYou Desktop requires an Apple Silicon Mac." ;;
     esac
 }
 


### PR DESCRIPTION
## Why

GitHub retired the Intel `macos-13` runners, so #597 moved the x86_64 build to cross-compile on `macos-14`. That builds fine (5 min on a test dispatch), but on the actual v0.3.9 release the `macos-x64` job **starved in GitHub's macOS queue** — 90+ minutes with no runner assigned, on two separate attempts, while the *identical* `runs-on: macos-14` arm64 job finished in ~2 min. No GitHub incident; the account is just being handed one macOS runner at a time and Intel keeps losing. Gating every release on that for a shrinking platform isn't worth it.

## Changes

- **`desktop.yml`**: remove the `macos-x64` matrix entry. macOS = Apple Silicon only; Linux x64 is unaffected.
- **`install-macos.sh`** (docs + scripts copies): x86_64 Macs now get an honest error — "TaskYou Desktop is Apple Silicon only … run the CLI instead" — instead of 404ing on a DMG we don't publish.
- **README**: macOS bundle listed as Apple Silicon only.

## Status

v0.3.9 is already out with the arm64 DMG (properly sealed — the "damaged" fix shipped) and the Linux AppImage/deb. This just stops chasing the Intel artifact and makes the project honest about not shipping it. Intel users are pointed at the CLI, which still builds for `darwin/amd64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)