### PR TITLE
Improve task creation form field UX

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -1889,7 +1889,7 @@ func (m *FormModel) View() string {
 			}
 		}
 		b.WriteString(cursor + " " + labelStyle.Render("Type") + m.renderSelector(typeLabels, m.typeIdx, m.focused == FieldType, selectedStyle, optionStyle, dimStyle))
-		b.WriteString("\n\n")
+		b.WriteString("\n")
 
 		// Executor selector
 		cursor = " "
@@ -1897,7 +1897,7 @@ func (m *FormModel) View() string {
 			cursor = cursorStyle.Render("▸")
 		}
 		b.WriteString(cursor + " " + labelStyle.Render("Executor") + m.renderSelector(m.executors, m.executorIdx, m.focused == FieldExecutor, selectedStyle, optionStyle, dimStyle))
-		b.WriteString("\n\n")
+		b.WriteString("\n")
 
 		// Effort selector (Claude-specific; only shown for the Claude executor)
 		if m.isFieldVisible(FieldEffort) {
@@ -1915,7 +1915,7 @@ func (m *FormModel) View() string {
 				}
 			}
 			b.WriteString(cursor + " " + labelStyle.Render("Effort") + m.renderSelector(effortLabels, m.effortIdx, m.focused == FieldEffort, selectedStyle, optionStyle, dimStyle))
-			b.WriteString("\n\n")
+			b.WriteString("\n")
 		}
 
 		// Permission selector
@@ -1925,8 +1925,11 @@ func (m *FormModel) View() string {
 				cursor = cursorStyle.Render("▸")
 			}
 			b.WriteString(cursor + " " + labelStyle.Render("Permission") + m.renderSelector(m.permissionModes, m.permissionIdx, m.focused == FieldPermission, selectedStyle, optionStyle, dimStyle))
-			b.WriteString("\n\n")
+			b.WriteString("\n")
 		}
+
+		// Trailing gap to separate the selector list from the help line.
+		b.WriteString("\n")
 	} else {
 		// Show compact summary of defaults and toggle hint
 		b.WriteString("\n")
@@ -1995,19 +1998,34 @@ func (m *FormModel) View() string {
 	return box.Render(b.String())
 }
 
+// renderSelector renders a single-choice field. When the field is not focused
+// it collapses to just the chosen value wrapped in dim ‹ › chevrons, so the
+// form reads like a calm settings list instead of a wall of options. When the
+// field is focused it expands into the full segmented control, putting every
+// option one keystroke away.
 func (m *FormModel) renderSelector(options []string, selected int, focused bool, selectedStyle, optionStyle, dimStyle lipgloss.Style) string {
-	var parts []string
-	for i, opt := range options {
-		label := opt
-		if label == "" {
-			label = "none"
+	labelFor := func(i int) string {
+		if i < 0 || i >= len(options) {
+			return ""
 		}
+		if options[i] == "" {
+			return "none"
+		}
+		return options[i]
+	}
+
+	// Collapsed: show only the current value with a stepper affordance.
+	if !focused {
+		value := optionStyle.Bold(true).Render(labelFor(selected))
+		return dimStyle.Render("‹ ") + value + dimStyle.Render(" ›")
+	}
+
+	// Expanded: full segmented control for the focused field.
+	var parts []string
+	for i := range options {
+		label := labelFor(i)
 		if i == selected {
-			if focused {
-				parts = append(parts, selectedStyle.Render(" "+label+" "))
-			} else {
-				parts = append(parts, optionStyle.Bold(true).Render(label))
-			}
+			parts = append(parts, selectedStyle.Render(" "+label+" "))
 		} else {
 			parts = append(parts, dimStyle.Render(label))
 		}

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/bborn/workflow/internal/db"
 )
@@ -1495,3 +1496,52 @@ func TestEditFormSeedsAndPreservesPermission(t *testing.T) {
 		}
 	})
 }
+
+// TestSelectorCollapsesWhenUnfocused verifies the form's single-choice fields
+// render as a compact "‹ value ›" stepper when not focused, and expand into the
+// full option list only when focused. This keeps the advanced section calm and
+// scannable instead of showing every option for every field at once.
+func TestSelectorCollapsesWhenUnfocused(t *testing.T) {
+	m := NewFormModel(nil, 120, 40, "myproject", nil)
+	selStyle := dummyStyle()
+	optStyle := dummyStyle()
+	dimStyle := dummyStyle()
+	options := []string{"default", "accept-edits", "auto", "dangerous"}
+
+	// Collapsed (unfocused): only the chosen value is shown, wrapped in chevrons.
+	collapsed := m.renderSelector(options, 3, false, selStyle, optStyle, dimStyle)
+	if !strings.Contains(collapsed, "dangerous") {
+		t.Errorf("collapsed selector should show the chosen value, got %q", collapsed)
+	}
+	if !strings.Contains(collapsed, "‹") || !strings.Contains(collapsed, "›") {
+		t.Errorf("collapsed selector should include chevron affordance, got %q", collapsed)
+	}
+	for _, other := range []string{"default", "accept-edits", "auto"} {
+		if strings.Contains(collapsed, other) {
+			t.Errorf("collapsed selector should hide non-selected option %q, got %q", other, collapsed)
+		}
+	}
+
+	// Expanded (focused): every option is visible so any choice is one keystroke away.
+	expanded := m.renderSelector(options, 3, true, selStyle, optStyle, dimStyle)
+	for _, opt := range options {
+		if !strings.Contains(expanded, opt) {
+			t.Errorf("expanded selector should show option %q, got %q", opt, expanded)
+		}
+	}
+	if strings.Contains(expanded, "‹") {
+		t.Errorf("expanded selector should not show the collapsed chevron, got %q", expanded)
+	}
+}
+
+// TestUnfocusedSelectorEmptyOptionShowsNone verifies an empty-string option
+// (e.g. "no type") collapses to the friendly "none" label.
+func TestUnfocusedSelectorEmptyOptionShowsNone(t *testing.T) {
+	m := NewFormModel(nil, 120, 40, "myproject", nil)
+	collapsed := m.renderSelector([]string{"", "code", "writing"}, 0, false, dummyStyle(), dummyStyle(), dummyStyle())
+	if !strings.Contains(collapsed, "none") {
+		t.Errorf("empty option should render as 'none', got %q", collapsed)
+	}
+}
+
+func dummyStyle() lipgloss.Style { return lipgloss.NewStyle() }


### PR DESCRIPTION
## Problem

The **Type**, **Executor**, **Effort**, and **Permission** fields on the task creation form each rendered their *entire* option list inline, all the time — four stacked rows of dimmed choices. The result felt heavy, cramped, and hard to scan (see the task screenshot).

## Change

Each single-choice field now **collapses to just its chosen value** in a compact `‹ value ›` stepper when it isn't focused, and **expands into the full segmented control** only when you tab onto it. Line spacing is tightened so the advanced section reads like a calm, aligned settings list.

Nothing about picking changes: `←/→` still cycles, type-to-select still works, and every option is one keystroke away once a field is focused.

### Before (always expanded)
```
  Type          none  pr-review  code  writing  thinking
  Executor      claude  codex  gemini  opencode  pi
  Effort        default  low  medium  high  xhigh  max
  Permission    default  accept-edits  auto  dangerous
```

### After (collapsed list; focused row expands)
```
    Type          ‹ code ›
  ▸ Executor       claude   codex  gemini  opencode  pi
    Effort        ‹ high ›
    Permission    ‹ dangerous ›
```

## Implementation

- `renderSelector` now branches on `focused`: collapsed → `‹ value ›`; focused → existing segmented control. (`internal/ui/form.go`)
- Advanced selector group switched from double- to single-line spacing for a tighter list, with one trailing gap before the help line.

## Tests

- `TestSelectorCollapsesWhenUnfocused` — asserts collapsed shows only the chosen value + chevrons and hides others; focused shows all options.
- `TestUnfocusedSelectorEmptyOptionShowsNone` — empty option collapses to `none`.
- Full `internal/ui` suite passes; `golangci-lint` (v2.8.0, CI-matched) clean; `gofmt` clean.

## Follow-ups

- The **Project** field (a typeahead/search field) keeps its existing affordance rather than the chevron stepper, since it behaves differently. Could be unified later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)