### PR TITLE
Park PR-bearing tasks for review instead of auto-marking them done

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,11 @@ jobs:
           check-latest: true  # use the newest released 1.25.x, not a stale cached patch, so stdlib CVE fixes (e.g. 1.25.11) are present
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned: v1.4.0 (2026-06-17) bundles golang.org/x/tools@v0.46.0, whose SSA
+        # callgraph pass panics on Go generics ("ForEachElement called on type
+        # containing *types.TypeParam"), failing every run. @latest silently broke
+        # CI the day v1.4.0 shipped. Pin until a fixed release is out.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -721,6 +721,39 @@ func (db *DB) UpdateTaskPRInfo(taskID int64, prURL string, prNumber int, prInfoJ
 	return nil
 }
 
+// prAutoDoneLineType is the task_logs line_type used to record that a specific PR
+// already drove a task to 'done'. It is an internal marker (not shown in the UI)
+// that makes auto-completion idempotent: once a task has been auto-completed for
+// PR #N, reopening the task and finishing again against that same merged/closed PR
+// must NOT bounce it straight back to 'done'. A genuinely new PR (different number)
+// is not marked, so it can still auto-complete when it merges.
+const prAutoDoneLineType = "pr_done_marker"
+
+// MarkPRAutoCompleted records that PR #prNumber has auto-completed this task, so a
+// later reconcile pass won't re-complete the task for the same PR after a human
+// reopens it to keep working.
+func (db *DB) MarkPRAutoCompleted(taskID int64, prNumber int) error {
+	return db.AppendTaskLog(taskID, prAutoDoneLineType, fmt.Sprintf("%d", prNumber))
+}
+
+// WasPRAutoCompleted reports whether PR #prNumber has already auto-completed this
+// task in a prior reconcile pass.
+func (db *DB) WasPRAutoCompleted(taskID int64, prNumber int) (bool, error) {
+	var exists int
+	err := db.QueryRow(`
+		SELECT 1 FROM task_logs
+		WHERE task_id = ? AND line_type = ? AND content = ?
+		LIMIT 1
+	`, taskID, prAutoDoneLineType, fmt.Sprintf("%d", prNumber)).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("query pr auto-done marker: %w", err)
+	}
+	return true, nil
+}
+
 // UpdateTaskClaudeSessionID updates only the Claude session ID for a task.
 func (db *DB) UpdateTaskClaudeSessionID(taskID int64, sessionID string) error {
 	_, err := db.Exec(`

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -2569,3 +2569,53 @@ func TestGetStaleWorktreeTasks(t *testing.T) {
 		t.Fatalf("expected 2 stale tasks, got %d", len(tasks))
 	}
 }
+
+func TestPRAutoCompletedMarker(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.CreateProject(&Project{Name: "test", Path: tmpDir}); err != nil {
+		t.Fatalf("failed to create test project: %v", err)
+	}
+	task := &Task{Title: "t", Status: StatusBlocked, Type: TypeCode, Project: "test"}
+	if err := db.CreateTask(task); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	// No marker yet.
+	if done, err := db.WasPRAutoCompleted(task.ID, 100); err != nil || done {
+		t.Fatalf("expected not auto-completed, got done=%v err=%v", done, err)
+	}
+
+	// Mark PR #100 as having auto-completed the task.
+	if err := db.MarkPRAutoCompleted(task.ID, 100); err != nil {
+		t.Fatalf("MarkPRAutoCompleted: %v", err)
+	}
+
+	// PR #100 is now consumed (reopen-after-merge must not re-complete).
+	if done, err := db.WasPRAutoCompleted(task.ID, 100); err != nil || !done {
+		t.Fatalf("expected PR #100 auto-completed, got done=%v err=%v", done, err)
+	}
+
+	// A different PR number is still eligible to auto-complete.
+	if done, err := db.WasPRAutoCompleted(task.ID, 101); err != nil || done {
+		t.Fatalf("expected PR #101 not auto-completed, got done=%v err=%v", done, err)
+	}
+
+	// The marker must not leak into the displayed conversation log.
+	logs, err := db.GetTaskLogs(task.ID, 100)
+	if err != nil {
+		t.Fatalf("GetTaskLogs: %v", err)
+	}
+	for _, l := range logs {
+		if l.LineType == "question" || l.LineType == "output" || l.LineType == "text" {
+			t.Fatalf("unexpected visible log line_type %q from marker", l.LineType)
+		}
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -849,9 +849,10 @@ func (e *Executor) worker(ctx context.Context) {
 	// Check for stale worktrees to archive every 10 minutes (300 ticks)
 	tickCount := 0
 	const suspendCheckInterval = 30
-	const doneCleanupInterval = 150   // 5 minutes at 2 second ticks
-	const staleWorktreeInterval = 300 // 10 minutes at 2 second ticks
-	const authCheckInterval = 15      // 30 seconds at 2 second ticks
+	const doneCleanupInterval = 150    // 5 minutes at 2 second ticks
+	const staleWorktreeInterval = 300  // 10 minutes at 2 second ticks
+	const authCheckInterval = 15       // 30 seconds at 2 second ticks
+	const reviewReconcileInterval = 30 // 60 seconds at 2 second ticks
 
 	for {
 		select {
@@ -878,6 +879,12 @@ func (e *Executor) worker(ctx context.Context) {
 				e.checkAuthStuckTasks()
 			}
 
+			// Periodically promote blocked "PR ready for review" tasks to done
+			// once their PR has merged or closed.
+			if tickCount%reviewReconcileInterval == 0 {
+				e.reconcileReviewTasks()
+			}
+
 			// Periodically cleanup Claude processes for inactive done tasks
 			if tickCount%doneCleanupInterval == 0 {
 				e.cleanupInactiveDoneTasks()
@@ -887,6 +894,88 @@ func (e *Executor) worker(ctx context.Context) {
 			if tickCount%staleWorktreeInterval == 0 {
 				e.cleanupStaleWorktrees()
 			}
+		}
+	}
+}
+
+// shouldPromoteReviewTask reports whether a PR's state means its task is finished
+// and should move to 'done' — i.e. the PR has merged or been closed. An open or
+// draft PR is still awaiting the human, so the task stays in 'blocked'.
+func shouldPromoteReviewTask(info *github.PRInfo) bool {
+	return info != nil && (info.State == github.PRStateMerged || info.State == github.PRStateClosed)
+}
+
+// reconcileReviewTasks promotes blocked "PR ready for review" tasks to 'done' once
+// a human has merged or closed their PR. This is the other half of the completion
+// flow: taskyou_complete parks PR-bearing tasks in 'blocked' (see internal/mcp),
+// and this loop watches those PRs and finishes the task when the PR reaches a
+// terminal state. It runs daemon-side so it works whether or not the TUI is open
+// (the TUI only ever refreshed PR state for display, never the task status).
+//
+// Idempotency: each promotion is recorded against the PR number via
+// MarkPRAutoCompleted. If a human reopens an already-completed task to keep working
+// against the same merged/closed PR, this loop will not bounce it straight back to
+// 'done' — only a genuinely new PR (different number) can auto-complete it again.
+func (e *Executor) reconcileReviewTasks() {
+	if e.prCache == nil {
+		return
+	}
+
+	tasks, err := e.db.ListTasks(db.ListTasksOptions{Status: db.StatusBlocked, Limit: 200})
+	if err != nil {
+		return
+	}
+
+	// Group candidate tasks by project so each repo's open PRs are fetched once.
+	byProject := make(map[string][]*db.Task)
+	for _, task := range tasks {
+		if task.PRNumber > 0 && task.BranchName != "" {
+			byProject[task.Project] = append(byProject[task.Project], task)
+		}
+	}
+
+	for project, ptasks := range byProject {
+		projectDir := e.getProjectDir(project)
+		if projectDir == "" {
+			continue
+		}
+
+		// One API call lists the repo's OPEN PRs. A task whose PR is absent here has
+		// left the open set (merged or closed) — the only case worth a targeted fetch.
+		openPRs := github.FetchAllPRsForRepo(projectDir)
+
+		for _, task := range ptasks {
+			// Skip PRs that have already auto-completed this task (reopen-after-merge).
+			if done, _ := e.db.WasPRAutoCompleted(task.ID, task.PRNumber); done {
+				continue
+			}
+			// Still in the open set → the human hasn't merged/closed it yet.
+			if !github.NeedsReconcile(openPRs, task.BranchName, task.PRNumber) {
+				continue
+			}
+
+			// Fetch the terminal state, bypassing any stale OPEN cache entry.
+			e.prCache.InvalidateCache(projectDir, task.BranchName)
+			info := e.prCache.GetPRForBranch(projectDir, task.BranchName)
+			if !shouldPromoteReviewTask(info) {
+				continue
+			}
+
+			verb := "merged"
+			if info.State == github.PRStateClosed {
+				verb = "closed"
+			}
+
+			e.db.UpdateTaskPRInfo(task.ID, info.URL, info.Number, github.MarshalPRInfo(info))
+			if err := e.db.MarkPRAutoCompleted(task.ID, task.PRNumber); err != nil {
+				e.logger.Warn("reconcileReviewTasks: failed to record auto-done marker", "task", task.ID, "error", err)
+			}
+			e.db.AppendTaskLog(task.ID, "system", fmt.Sprintf("PR #%d %s — task auto-completed.", info.Number, verb))
+			if err := e.db.UpdateTaskStatus(task.ID, db.StatusDone); err != nil {
+				e.logger.Error("reconcileReviewTasks: failed to mark task done", "task", task.ID, "error", err)
+				continue
+			}
+			e.logger.Info("Auto-completed reviewed task", "task", task.ID, "pr", info.Number, "state", verb)
 		}
 	}
 }
@@ -1509,7 +1598,9 @@ func (e *Executor) buildUniversalGuidance(task *db.Task) string {
 	b.WriteString(`
 
 Completion signaling (REQUIRED — nothing else watches for completion):
-- When the task is done, call taskyou_complete with a one-paragraph summary (PR link, files touched, follow-ups). This moves the task to 'done'. Do NOT just print a summary and stop — without this call the task stays in 'processing'/'blocked' forever and a human has to close it by hand.
+- When your work is finished, call taskyou_complete with a one-paragraph summary (PR link, files touched, follow-ups). Do NOT just print a summary and stop — without this call the task stalls forever and a human has to close it by hand.
+  - If you opened a PR: the task moves to 'blocked' and waits for a human to review and merge it. It is promoted to 'done' automatically once the PR is merged or closed — so calling taskyou_complete does NOT mean the work shipped, you must NOT wait for the merge yourself, and you must NOT call taskyou_complete more than once.
+  - If the task produced no PR (e.g. a quick config change or moving a file): it moves straight to 'done'.
 - When you need clarification, call taskyou_needs_input with the question. This moves the task to 'blocked' so a human is notified. Do not prompt in the terminal — the task system can't see TTY prompts.`)
 
 	if e.taskUsesWorktrees(task) {

--- a/internal/executor/review_reconcile_test.go
+++ b/internal/executor/review_reconcile_test.go
@@ -1,0 +1,28 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/bborn/workflow/internal/github"
+)
+
+func TestShouldPromoteReviewTask(t *testing.T) {
+	cases := []struct {
+		name string
+		info *github.PRInfo
+		want bool
+	}{
+		{"nil (no PR / lookup failed)", nil, false},
+		{"open PR still awaiting review", &github.PRInfo{State: github.PRStateOpen}, false},
+		{"draft PR", &github.PRInfo{State: github.PRStateDraft}, false},
+		{"merged PR", &github.PRInfo{State: github.PRStateMerged}, true},
+		{"closed PR (abandoned counts as done)", &github.PRInfo{State: github.PRStateClosed}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldPromoteReviewTask(c.info); got != c.want {
+				t.Fatalf("shouldPromoteReviewTask(%+v) = %v, want %v", c.info, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/github"
 	"github.com/bborn/workflow/internal/spotlight"
 	"github.com/bborn/workflow/internal/tasksummary"
 )
@@ -49,6 +50,28 @@ func NewServer(database *db.DB, taskID int64) *Server {
 func (s *Server) SetCallbacks(onComplete func(), onNeedsInput func(question string)) {
 	s.onComplete = onComplete
 	s.onNeedsInput = onNeedsInput
+}
+
+// lookupPR returns the PR number and URL associated with the task's branch, or
+// (0, "") if the task has no PR. It prefers a live `gh` lookup — the agent often
+// opens the PR moments before calling taskyou_complete, so the DB copy is stale —
+// and persists any fresh result so the board and the daemon reconciler both see
+// it. Falls back to whatever PR info is already stored on the task.
+func (s *Server) lookupPR(task *db.Task) (int, string) {
+	if task == nil {
+		return 0, ""
+	}
+	if task.BranchName != "" {
+		repoDir := task.WorktreePath
+		if repoDir == "" {
+			repoDir, _ = os.Getwd()
+		}
+		if info := github.NewPRCache().GetPRForBranch(repoDir, task.BranchName); info != nil {
+			_ = s.db.UpdateTaskPRInfo(task.ID, info.URL, info.Number, github.MarshalPRInfo(info))
+			return info.Number, info.URL
+		}
+	}
+	return task.PRNumber, task.PRURL
 }
 
 // JSON-RPC types
@@ -313,23 +336,54 @@ func (s *Server) handleToolCall(id interface{}, params *toolCallParams) {
 	case "taskyou_complete":
 		summary, _ := params.Arguments["summary"].(string)
 
+		task, _ := s.db.GetTask(s.taskID)
+
 		// Check if we should remind about saving project context
 		var contextReminder string
-		if s.contextWasEmpty {
-			// Check if context is still empty
-			if task, err := s.db.GetTask(s.taskID); err == nil && task != nil && task.Project != "" {
-				if ctx, err := s.db.GetProjectContext(task.Project); err == nil && ctx == "" {
-					contextReminder = "\n\n⚠️ REMINDER: You explored this codebase but didn't save project context. Consider calling taskyou_set_project_context to help future tasks skip exploration."
-				}
+		if s.contextWasEmpty && task != nil && task.Project != "" {
+			if ctx, err := s.db.GetProjectContext(task.Project); err == nil && ctx == "" {
+				contextReminder = "\n\n⚠️ REMINDER: You explored this codebase but didn't save project context. Consider calling taskyou_set_project_context to help future tasks skip exploration."
 			}
 		}
 
 		// Log the completion summary
 		s.db.AppendTaskLog(s.taskID, "system", fmt.Sprintf("Task completed: %s", summary))
 
-		// Mark the task as done. Agents are trusted to signal their own completion —
-		// otherwise tasks stall in `processing`/`blocked` and the orchestrator has to
-		// close them by hand. Humans can always reopen if the work isn't actually finished.
+		// Decide where the finished task lands. A task that produced a PR is NOT
+		// truly done until a human merges/closes that PR — auto-marking it 'done'
+		// buries an open PR in the Done column where it gets overlooked. So PR-bearing
+		// tasks park in 'blocked' (the "human's turn" lane, alongside needs-input
+		// questions) and the daemon promotes them to 'done' once the PR merges/closes
+		// (see reconcileReviewTasks). Tasks with no PR (e.g. "move file X to Y") are
+		// genuinely complete the moment the agent signals it.
+		prNumber, prURL := s.lookupPR(task)
+		if prNumber > 0 {
+			if err := s.db.UpdateTaskStatus(s.taskID, db.StatusBlocked); err != nil {
+				s.sendError(id, -32603, fmt.Sprintf("Failed to move task to review: %v", err))
+				return
+			}
+			// Surface it in the blocked lane like a needs-input item so it's easy to spot.
+			reviewMsg := fmt.Sprintf("✅ PR #%d ready for review — merge or close it to complete this task.", prNumber)
+			if prURL != "" {
+				reviewMsg += " " + prURL
+			}
+			s.db.AppendTaskLog(s.taskID, "question", reviewMsg)
+
+			// The agent's turn is over; let the executor tear down the session.
+			if s.onComplete != nil {
+				s.onComplete()
+			}
+
+			resultText := fmt.Sprintf("Work finished. PR #%d is up for review — the task is now 'blocked' awaiting a human merge, and will move to 'done' automatically once the PR is merged or closed. Do not call taskyou_complete again.", prNumber)
+			s.sendResult(id, toolCallResult{
+				Content: []contentBlock{
+					{Type: "text", Text: resultText + contextReminder},
+				},
+			})
+			return
+		}
+
+		// No PR — the task is genuinely done.
 		if err := s.db.UpdateTaskStatus(s.taskID, db.StatusDone); err != nil {
 			s.sendError(id, -32603, fmt.Sprintf("Failed to mark task done: %v", err))
 			return

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2972,7 +2972,7 @@ func (m *DetailModel) renderContent() string {
 
 		for _, log := range m.logs {
 			// Skip internal-only log entries not meant for display
-			if log.LineType == "pending_tool" {
+			if log.LineType == "pending_tool" || log.LineType == "pr_done_marker" {
 				continue
 			}
 			icon := "  "


### PR DESCRIPTION
## Problem

Tasks were moving themselves to **done** before the PR was merged. The agent calls `taskyou_complete` the instant its code is written and the PR is opened, and the handler (`internal/mcp/server.go`) ran `UpdateTaskStatus(StatusDone)` unconditionally — no PR check. An open, unmerged PR then sits in the **Done** column where it gets overlooked. "Done" stopped meaning done.

It wasn't task-type instructions driving this — it's the *universal* guidance (`buildUniversalGuidance`, appended to every task) telling the agent to call `taskyou_complete` when "done," combined with the tool unconditionally setting `done`.

## Approach

Make completion PR-aware, reusing the existing `blocked` lane (no new Kanban column, no schema migration):

| Column | Meaning |
|---|---|
| `processing` | agent actively working |
| `blocked` | **human's turn** — a needs-input question *or* a PR ready to merge |
| `done` | truly done — PR merged/closed, or a non-PR task completed |

### Changes
- **`taskyou_complete` is PR-aware** (`internal/mcp/server.go`): live-checks the branch for a PR (the DB copy is stale — the agent just opened it). **PR exists → `blocked`**, surfaced like a needs-input item (`✅ PR #N ready for review`). **No PR → `done`** (covers "move file X to Y" style tasks).
- **Daemon-side reconciler** (`reconcileReviewTasks`, worker loop every 60s): promotes a blocked task to `done` once its PR is **merged or closed**. Runs headlessly — the TUI previously only refreshed PR state for *display*, never the task status.
- **Idempotent per PR** via an internal `task_logs` marker (`pr_done_marker`, hidden from the UI): reopening an already-completed task to keep iterating against the same merged/closed PR will **not** bounce it back to `done`; only a genuinely new PR (different number) can auto-complete it again.
- **Universal guidance updated** so agents understand `taskyou_complete` parks PR work for human merge (and not to call it twice or wait for the merge themselves).

### Decisions (per discussion)
- **Closed-unmerged PR → `done`** (off your plate).
- **Merged-but-reopened → stays `blocked`** until you act (the idempotency marker prevents re-completion).

## Tests
- `internal/db`: `TestPRAutoCompletedMarker` — marker set/query is per-PR and stays out of the visible log.
- `internal/executor`: `TestShouldPromoteReviewTask` — only merged/closed promote; open/draft/nil stay blocked.
- `go build ./...`, `go vet`, and the `db` / `mcp` / `executor` package suites pass; gofmt clean.

## Follow-ups (not in this PR)
- Activity-summary generation currently runs only on the no-PR `done` path; could also run when the reconciler auto-completes a PR task.
- If `gh` is unavailable at completion time, a PR task with no DB-recorded PR number could still fall through to `done` (matches prior behavior, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)