### PR TITLE
fix(tui): single-instance lock to stop the dual-TUI executor interrupt loop

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -3687,6 +3687,18 @@ func runLocal(dangerousMode bool, debugStatePath, cpuProfilePath, memProfilePath
 	stopProfiling := setupProfiling(cpuProfilePath, memProfilePath)
 	defer stopProfiling() // safety net for early-return error paths below
 
+	// Only one interactive TUI may run at a time. A second one fights the first
+	// over the executor tmux panes and traps every task in a "claude --resume"
+	// interrupt loop (see acquireTUILock). Refuse to start rather than corrupt
+	// the running sessions; the daemon, desktop app, and web viewer are
+	// unaffected (they don't borrow panes).
+	releaseTUILock, err := acquireTUILock()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, dimStyle.Render("A ty session is already running on this machine — only one interactive TUI can manage the executor panes at a time. Close the other session first."))
+		return nil
+	}
+	defer releaseTUILock()
+
 	// Ensure daemon is running
 	if err := ensureDaemonRunning(dangerousMode); err != nil {
 		fmt.Fprintln(os.Stderr, dimStyle.Render("Warning: could not start daemon: "+err.Error()))
@@ -3803,6 +3815,45 @@ func ensureDaemonRunning(dangerousMode bool) error {
 
 	fmt.Fprintln(os.Stderr, dimStyle.Render(fmt.Sprintf("Started daemon (pid %d, %s mode)", cmd.Process.Pid, modeStr)))
 	return nil
+}
+
+// acquireTUILock takes an exclusive, process-lifetime lock so only one
+// interactive TUI runs at a time. Two concurrent TUIs fight over the executor
+// tmux panes — each borrows the Claude pane into its own session via join-pane,
+// which leaves the daemon window looking empty, so EnsureTaskWindow recreates it
+// with `claude --resume`. That resume replays into the in-flight tool call and
+// Claude Code records "[Request interrupted by user for tool use]", producing an
+// endless "Interrupted" loop that makes no progress.
+//
+// flock is tied to the open file description, so the lock is released
+// automatically when the holding process exits — a crashed TUI never leaves a
+// stale lock (unlike a pidfile). The lock lives next to the database so isolated
+// instances (custom WORKTREE_DB_PATH, e.g. QA harnesses) don't contend with the
+// real one.
+//
+// It retries briefly so a `ty restart` that momentarily overlaps the outgoing
+// TUI doesn't spuriously fail. Returns a release func, or an error when another
+// TUI already holds the lock.
+func acquireTUILock() (func(), error) {
+	lockPath := filepath.Join(filepath.Dir(db.DefaultPath()), "tui.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open TUI lock file: %w", err)
+	}
+
+	const attempts = 10
+	for i := 0; i < attempts; i++ {
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err == nil {
+			return func() {
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				_ = f.Close()
+			}, nil
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	_ = f.Close()
+	return nil, fmt.Errorf("another ty session is already running")
 }
 
 func getPidFilePath() string {

--- a/cmd/task/tui_lock_test.go
+++ b/cmd/task/tui_lock_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestAcquireTUILock verifies the singleton guard: a second acquisition is
+// refused while the first is held, and succeeds again once it's released. This
+// is what prevents two concurrent TUIs from fighting over the executor panes.
+func TestAcquireTUILock(t *testing.T) {
+	// Point the lock at an isolated temp dir via the DB path it derives from.
+	t.Setenv("WORKTREE_DB_PATH", filepath.Join(t.TempDir(), "tasks.db"))
+
+	release1, err := acquireTUILock()
+	if err != nil {
+		t.Fatalf("first acquire should succeed, got: %v", err)
+	}
+
+	if _, err := acquireTUILock(); err == nil {
+		t.Fatal("second acquire should fail while the first lock is held")
+	}
+
+	release1()
+
+	release2, err := acquireTUILock()
+	if err != nil {
+		t.Fatalf("acquire after release should succeed, got: %v", err)
+	}
+	release2()
+}


### PR DESCRIPTION
## What

Adds an exclusive, process-lifetime **flock** to the interactive TUI (`runLocal`) so only one `ty` TUI can run at a time — mirroring the daemon's existing singleton lock.

## Why (the bug)

Today a user hit every executor stuck on **`Interrupted · What should Claude do instead?`**, looping forever. Root cause:

1. Two `ty` TUIs were running at once (a stale one rooted in a long-dead May-11 tmux session + a freshly launched one).
2. ty's executor dock **borrows the Claude pane via tmux `join-pane`** into the TUI's own session for display. Two TUIs yank each pane back and forth.
3. When a pane is moved out, the daemon window looks empty/gone, so `EnsureTaskWindow` **recreates it with `claude --resume`**.
4. The resume replays into the in-flight tool call → Claude Code writes `[Request interrupted by user for tool use]` → the pane gets borrowed again → recreated again. Endless loop, no progress.

Evidence: all 9 affected tasks received the interrupt within **62ms** of each other, and the `joinTmuxPanes: join-pane succeeded` timestamps in `ui.log` matched the staggered `claude --resume` respawns exactly.

## The fix

- `acquireTUILock()` takes `LOCK_EX|LOCK_NB` on `tui.lock` (next to the DB, so isolated `WORKTREE_DB_PATH` instances — e.g. QA harnesses — don't contend) and holds it for the TUI's lifetime.
- A second TUI prints a clear message and exits cleanly instead of corrupting running sessions.
- flock releases automatically on process exit → a crashed TUI never leaves a stale lock (unlike a pidfile).
- A short bounded retry keeps `ty restart` from spuriously failing during the outgoing→incoming TUI handoff.
- Daemon, desktop app, and web viewer are unaffected — they don't borrow panes.

## Test

`TestAcquireTUILock` verifies the second acquire is refused while the first is held, and succeeds again after release.

Build, `go vet`, `gofmt`, and `golangci-lint` v2.8.0 all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)