### PR TITLE
docs(marketing): positioning teardown + draft 'TaskYou vs X' compare pages

### DIFF
--- a/docs/compare/compare.css
+++ b/docs/compare/compare.css
@@ -1,0 +1,117 @@
+/* TaskYou /compare — shared styles, extracted from index.html so the
+   comparison section matches the landing page exactly. */
+:root{
+  --bg:#0e0b16; --panel:#15111f; --panel2:#1b1628; --line:#241e38; --line2:#2e2746;
+  --text:#f3eaff; --muted:#9b93bd; --dim:#6f6790;
+  --orange:#ff7a3c; --orange-d:#c9432a; --green:#7cf6b0; --yellow:#ffd23f; --red:#ff5f57;
+}
+*{box-sizing:border-box; margin:0; padding:0;}
+html{scroll-behavior:smooth;}
+body{
+  font-family:'Space Grotesk',system-ui,-apple-system,sans-serif; background:var(--bg); color:var(--text);
+  line-height:1.6; -webkit-font-smoothing:antialiased; overflow-x:hidden;
+}
+/* CRT scanlines */
+body::before{
+  content:""; position:fixed; inset:0; pointer-events:none; z-index:9999; opacity:.5;
+  background:repeating-linear-gradient(0deg, rgba(255,255,255,.022) 0 1px, transparent 1px 3px);
+}
+.grid-bg{
+  position:fixed; inset:0; z-index:-1; pointer-events:none;
+  background-image:linear-gradient(rgba(255,255,255,.025) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.025) 1px,transparent 1px);
+  background-size:26px 26px;
+  -webkit-mask-image:radial-gradient(120% 90% at 50% 0%, #000 0%, transparent 75%);
+          mask-image:radial-gradient(120% 90% at 50% 0%, #000 0%, transparent 75%);
+}
+.wrap{max-width:1080px; margin:0 auto; padding:0 1.5rem;}
+.prose{max-width:820px;}
+a{color:inherit; text-decoration:none;}
+.mono{font-family:'JetBrains Mono',monospace;}
+
+/* NAV */
+nav{position:sticky; top:0; z-index:100; backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px); background:rgba(14,11,22,.72); border-bottom:1px solid var(--line);}
+nav .wrap{display:flex; align-items:center; justify-content:space-between; height:60px;}
+.brand{display:flex; align-items:center; gap:.55rem; font-weight:700; font-size:1.05rem;}
+.brand img{height:26px; width:auto; image-rendering:pixelated;}
+.navlinks{display:flex; align-items:center; gap:1.4rem; font-family:'JetBrains Mono',monospace; font-size:.8rem; color:var(--muted);}
+.navlinks a:hover{color:var(--text);}
+.navlinks a.active{color:var(--orange);}
+.navlinks .desktop-only{display:inline;}
+@media(max-width:640px){.navlinks .desktop-only{display:none;}}
+.btn{display:inline-flex; align-items:center; gap:.5rem; font-family:'JetBrains Mono',monospace; font-weight:700; font-size:.8rem; padding:.5rem .9rem; border-radius:8px; transition:transform .12s ease;}
+.btn:hover{transform:translateY(-1px);}
+.btn-primary{background:var(--orange); color:#1a1320; box-shadow:0 4px 0 var(--orange-d);}
+.btn-primary:active{transform:translateY(3px); box-shadow:0 1px 0 var(--orange-d);}
+
+/* HERO / PAGE HEAD */
+header.phead{padding:3.5rem 0 1.5rem; position:relative;}
+.eyebrow{font-family:'JetBrains Mono',monospace; font-size:.72rem; letter-spacing:.14em; text-transform:uppercase; color:var(--orange); margin-bottom:.8rem;}
+h1.headline{font-weight:700; font-size:clamp(2.1rem,4.6vw,3.1rem); line-height:1.04; letter-spacing:-.02em; margin-bottom:.8rem;}
+h1.headline .t{color:var(--orange);}
+.oneline{font-family:'JetBrains Mono',monospace; font-size:1rem; color:var(--green); line-height:1.55; max-width:70ch; border-left:2px solid var(--line2); padding-left:1rem;}
+.oneline b{color:var(--text); font-weight:600;}
+
+/* CONTENT */
+section.body{padding:2rem 0 3rem;}
+.body h2{font-weight:700; font-size:clamp(1.4rem,2.6vw,1.8rem); letter-spacing:-.01em; margin:2.4rem 0 .9rem;}
+.body h3{font-weight:600; font-size:1.12rem; margin:1.6rem 0 .5rem; color:var(--text);}
+.body p{color:var(--muted); margin:.7rem 0; max-width:78ch;}
+.body p strong, .body li strong{color:var(--text); font-weight:600;}
+.body em{color:var(--text); font-style:italic;}
+.body a{color:var(--green); text-decoration:none; border-bottom:1px solid rgba(124,246,176,.3);}
+.body a:hover{border-bottom-color:var(--green);}
+.body ul, .body ol{color:var(--muted); margin:.7rem 0 .7rem 1.2rem; max-width:78ch;}
+.body li{margin:.4rem 0;}
+.body code{font-family:'JetBrains Mono',monospace; font-size:.85em; background:#0a0812; border:1px solid var(--line2); border-radius:5px; padding:.08rem .35rem; color:var(--green);}
+.body pre{font-family:'JetBrains Mono',monospace; font-size:.8rem; background:#0a0812; border:1px solid var(--line2); border-radius:10px; padding:1rem 1.1rem; overflow-x:auto; margin:1rem 0; color:var(--muted); line-height:1.5;}
+.body pre code{background:none; border:none; padding:0; color:inherit;}
+.body blockquote{border-left:3px solid var(--orange); background:var(--panel); border-radius:0 10px 10px 0; padding:.9rem 1.2rem; margin:1.2rem 0; color:var(--text);}
+.body blockquote p{color:var(--text); margin:.3rem 0;}
+.body hr{border:none; border-top:1px solid var(--line); margin:2.5rem 0;}
+.note{font-size:.86rem; color:var(--dim); font-style:italic; margin-top:2rem;}
+
+/* TABLES */
+.tablewrap{overflow-x:auto; margin:1.3rem 0; border:1px solid var(--line2); border-radius:12px;}
+table{border-collapse:collapse; width:100%; font-size:.9rem; min-width:520px;}
+thead th{background:#181426; color:var(--text); font-weight:600; text-align:left; padding:.7rem .9rem; border-bottom:1px solid var(--line2); font-family:'JetBrains Mono',monospace; font-size:.78rem;}
+tbody td{padding:.7rem .9rem; border-bottom:1px solid var(--line); color:var(--muted); vertical-align:middle;}
+tbody td:first-child{vertical-align:middle;}
+tbody tr:last-child td{border-bottom:none;}
+tbody tr:nth-child(even){background:rgba(255,255,255,.012);}
+td.c, th.c{text-align:center;}
+td strong, td b{color:var(--text);}
+/* status marks — crisp monospace glyphs, theme-colored, never OS emoji */
+.mark{font-family:'JetBrains Mono',monospace; font-size:1rem; font-weight:700; line-height:1; font-variant-emoji:text;}
+.yes{color:var(--green);}
+.no{color:var(--dim);}
+.partial{color:var(--yellow);}
+/* value cells: centered glyph, annotation as a small caption beneath it so
+   glyphs line up in a tidy grid regardless of annotation length */
+td.val{text-align:center; vertical-align:middle;}
+td.val .mark{display:block; font-size:1.05rem;}
+td.val .anno{display:block; max-width:24ch; margin:.22rem auto 0; font-size:.78rem; line-height:1.35; color:var(--muted);}
+td.val .anno.plain{margin:0; font-size:.88rem;}
+td.val .anno code{font-size:.76rem;}
+.legend{font-family:'JetBrains Mono',monospace; font-size:.74rem; color:var(--dim); margin-top:.7rem;}
+
+/* CARD GRID (compare index) */
+.cards{display:grid; grid-template-columns:1fr 1fr; gap:1rem; margin:1.5rem 0;}
+@media(max-width:680px){.cards{grid-template-columns:1fr;}}
+.card{background:var(--panel); border:1px solid var(--line); border-radius:14px; padding:1.3rem; transition:border-color .15s ease, transform .15s ease; display:block;}
+.card:hover{border-color:var(--orange); transform:translateY(-2px);}
+.card h3{font-size:1.1rem; margin-bottom:.3rem; color:var(--text); border:none;}
+.card p{color:var(--muted); font-size:.9rem; margin:.3rem 0 0;}
+.card .arrow{color:var(--orange); font-family:'JetBrains Mono',monospace; font-size:.78rem; margin-top:.8rem; display:inline-block;}
+
+/* back / pager */
+.pager{display:flex; flex-wrap:wrap; gap:.8rem; margin-top:2.5rem; padding-top:1.5rem; border-top:1px solid var(--line);}
+.pager a{font-family:'JetBrains Mono',monospace; font-size:.8rem; color:var(--muted); border:1px solid var(--line2); border-radius:8px; padding:.5rem .8rem;}
+.pager a:hover{border-color:var(--orange); color:var(--text);}
+
+/* FOOTER */
+footer{border-top:1px solid var(--line); padding:2.5rem 0 3.5rem; color:var(--dim); margin-top:2rem;}
+footer .wrap{display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:1rem;}
+footer .fbrand{display:flex; align-items:center; gap:.5rem; color:var(--muted); font-weight:600;}
+footer .fbrand img{height:22px; width:auto; image-rendering:pixelated;}
+footer .flinks{display:flex; gap:1.3rem; font-family:'JetBrains Mono',monospace; font-size:.78rem;}
+footer .flinks a:hover{color:var(--text);}

--- a/docs/compare/index.html
+++ b/docs/compare/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Compare — TaskYou</title>
+<meta name="description" content="TaskYou is an autonomy-first task orchestrator for coding agents.">
+<link rel="icon" href="../images/logo.webp">
+<meta property="og:title" content="Compare — TaskYou">
+<meta property="og:description" content="TaskYou is an autonomy-first task orchestrator for coding agents.">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="compare.css">
+</head>
+<body>
+<div class="grid-bg"></div>
+<nav>
+  <div class="wrap">
+    <a class="brand" href="/"><img src="../images/logo.webp" alt="">taskyou</a>
+    <div class="navlinks">
+      <a class="desktop-only" href="/#how">How it works</a>
+      <a class="desktop-only" href="/#features">Features</a>
+      <a class="active" href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="/#install" class="btn btn-primary">Install ↓</a>
+    </div>
+  </div>
+</nav>
+<section class="body">
+  <div class="wrap prose">
+<h1 class="headline">TaskYou vs everything else</h1>
+<p><strong>TaskYou is an autonomy-first task orchestrator for coding agents.</strong> You drop a task on a board, an agent picks it up and works in its own isolated git worktree in the background, and the card tracks all the way to a merged PR. One agent per task. A worktree per agent.</p>
+<p>That's a different job from a terminal multiplexer, a process dashboard, or a worktree-diff tool. This page lays the whole landscape on one grid, then links to a detailed page for each contender. We try to be fair: where a tool genuinely beats us at <em>its</em> job, we say so.</p>
+<blockquote><p><strong>The short version:</strong> most of these tools help you <em>watch and drive</em> agents you launch by</p><p>hand. TaskYou helps you <em>queue outcomes and walk away.</em> If your mental model is "panes I'm</p><p>babysitting," you want a multiplexer. If it's "a backlog that clears itself," you want TaskYou.</p></blockquote>
+<hr>
+<h2>Capability matrix</h2>
+<div class="tablewrap"><table><thead><tr><th>Capability</th><th class="c"><strong>TaskYou</strong></th><th class="c">tmux / Zellij</th><th class="c">cmux / Warp</th><th class="c">Conductor / Emdash / Superset</th></tr></thead><tbody><tr><td>Unit of work is a <strong>task / outcome</strong> (not a pane)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark yes">✓︎</span></td></tr><tr><td><strong>Queue + background execution</strong> (stack work, walk away)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td><strong>Kanban board</strong> (Backlog / In Progress / Blocked / Done)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td><strong>Worktree-per-task isolation</strong>, automatic</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark partial">◐︎</span></td><td class="val"><span class="mark yes">✓︎</span></td></tr><tr><td><strong>PR-aware completion</strong> (task state follows the PR to merge)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td><strong>Pluggable executors</strong> (Claude, Codex, Gemini, Pi, OpenClaw, OpenCode)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="anno plain">n/a</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td><strong>Routines</strong> — scheduled unattended runs that feed the queue</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td><strong>Live executor panes</strong> to watch/drive an agent</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td>Runs over <strong>SSH</strong> (board from anywhere)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td><strong>Web UI</strong> (same board in a browser)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td><strong>Desktop app</strong> (macOS / Linux)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark yes">✓︎</span></td></tr><tr><td><strong>Email control</strong> (create + unblock tasks from your phone)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td><strong>Fully scriptable CLI / agent API</strong></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark partial">◐︎</span></td><td class="val"><span class="mark partial">◐︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td>Open source</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">MIT</span></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark partial">◐︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr></tbody></table></div>
+<p><span class="mark yes">✓︎</span> first-class · <span class="mark partial">◐︎</span> partial / possible-but-not-the-point · <span class="mark no">✕︎</span> no · n/a not applicable <em>(<code><span class="mark partial">◐︎</span></code> and <code><span class="mark no">✕︎</span></code> for other tools reflect their stated positioning as of mid-2026; correct us with a PR if a tool has shipped past this.)</em></p>
+<hr>
+<h2>Pick your comparison</h2>
+<ul><li><strong><a href="taskyou-vs-tmux.html">TaskYou vs tmux / Zellij</a></strong> — TaskYou <em>runs on</em> tmux; here's what it adds on top.</li><li><strong><a href="taskyou-vs-conductor-emdash-superset.html">TaskYou vs Conductor / Emdash / Superset</a></strong> — the other worktree-orchestrator camp.</li><li><strong><a href="taskyou-vs-cmux-warp.html">TaskYou vs cmux / Warp</a></strong> — desktop agent apps vs a board that runs anywhere.</li></ul>
+<hr>
+<h2>One-liners</h2>
+<ul><li><strong>vs tmux / Zellij:</strong> tmux multiplexes terminals; TaskYou multiplexes <em>tasks</em> — and it's built on tmux, so you get the panes anyway.</li><li><strong>vs Conductor / Emdash / Superset:</strong> they isolate a worktree per branch and help you review the diff; TaskYou does that <em>and</em> runs the work in the background on a queue, across six executors, on whatever surface you're holding.</li><li><strong>vs cmux / Warp:</strong> they're polished Mac apps for agents; TaskYou is the same board in your terminal, your browser, your desktop, your inbox, and over SSH.</li></ul>
+<div class="pager"><a href="/compare/">← All comparisons</a></div>
+  </div>
+</section>
+<footer>
+  <div class="wrap">
+    <span class="fbrand"><img src="../images/logo.webp" alt="">taskyou</span>
+    <span class="flinks">
+      <a href="/">Home</a>
+      <a href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="https://github.com/bborn/taskyou#readme">Docs</a>
+    </span>
+  </div>
+</footer>
+</body>
+</html>

--- a/docs/compare/taskyou-vs-cmux-warp.html
+++ b/docs/compare/taskyou-vs-cmux-warp.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TaskYou vs cmux / Warp — TaskYou</title>
+<meta name="description" content="cmux and Warp are polished apps for running agents on your machine; TaskYou is the">
+<link rel="icon" href="../images/logo.webp">
+<meta property="og:title" content="TaskYou vs cmux / Warp — TaskYou">
+<meta property="og:description" content="cmux and Warp are polished apps for running agents on your machine; TaskYou is the">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="compare.css">
+</head>
+<body>
+<div class="grid-bg"></div>
+<nav>
+  <div class="wrap">
+    <a class="brand" href="/"><img src="../images/logo.webp" alt="">taskyou</a>
+    <div class="navlinks">
+      <a class="desktop-only" href="/#how">How it works</a>
+      <a class="desktop-only" href="/#features">Features</a>
+      <a class="active" href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="/#install" class="btn btn-primary">Install ↓</a>
+    </div>
+  </div>
+</nav>
+<section class="body">
+  <div class="wrap prose">
+<h1 class="headline">TaskYou vs cmux / Warp</h1>
+<p><strong>One line:</strong> cmux and Warp are polished apps for running agents on your machine; TaskYou is the same job as a board that runs <em>anywhere</em> — terminal, browser, desktop, email, and over SSH — and is built to queue work and walk away.</p>
+<p>cmux (a Mac terminal app for agents) and Warp (an agentic development platform / terminal) both bet on a beautiful, local, GUI-forward experience. TaskYou bets on <strong>autonomy and reach</strong>: file an outcome, let an agent run it in the background in an isolated worktree, and pick up the result from whatever device you have.</p>
+<hr>
+<h2>What cmux / Warp are good at</h2>
+<ul><li><strong>Polished, native UX.</strong> Warp in particular is a gorgeous terminal with first-class agent</li></ul>
+<p>features; cmux is a focused Mac app for driving agents. If you want a beautiful local cockpit, this is the camp.</p>
+<ul><li><strong>Low friction on your own machine.</strong> Install the app, open it, go. No daemon mental model, no</li></ul>
+<p>SSH server to think about.</p>
+<ul><li><strong>Rich interactive features</strong> baked into the app — completions, blocks, agent panes, and so on.</li></ul>
+<p>If you primarily work on one Mac and want the most polished local agent experience, these are strong, and TaskYou doesn't try to out-pretty them.</p>
+<h2>Where TaskYou is different</h2>
+<div class="tablewrap"><table><thead><tr><th></th><th class="c"><strong>TaskYou</strong></th><th class="c">cmux / Warp</th></tr></thead><tbody><tr><td>Center of gravity</td><td class="val"><span class="anno plain">A <strong>task board</strong> + queue</span></td><td class="val"><span class="anno plain">A polished terminal/app you drive</span></td></tr><tr><td>Queue + background execution</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">stack work, walk away</span></td><td class="val"><span class="mark no">✕︎</span><span class="anno">you drive sessions live</span></td></tr><tr><td>Worktree-per-task isolation</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">automatic</span></td><td class="val"><span class="mark partial">◐︎</span><span class="anno">varies</span></td></tr><tr><td>PR-aware completion</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td>Pluggable executors (6)</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">per task</span></td><td class="val"><span class="mark partial">◐︎</span><span class="anno">tied to the app's agent(s)</span></td></tr><tr><td>Routines (scheduled unattended runs)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td>Runs on a <strong>headless server / over SSH</strong></td><td class="val"><span class="mark yes">✓︎</span><span class="anno"><code>taskd</code></span></td><td class="val"><span class="mark no">✕︎</span><span class="anno">desktop-bound (cmux); <span class="mark partial">◐︎</span> (Warp)</span></td></tr><tr><td>Same board on <strong>web + email + Chrome</strong></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td>Open source</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">MIT</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr></tbody></table></div>
+<p>Two differences matter most:</p>
+<ol><li><strong>Autonomy.</strong> cmux and Warp are places you <em>drive</em> agents. TaskYou is a place you <em>hand off</em></li></ol>
+<p>work: queue a column, walk away, come back to diffs. The board, the worktrees, and the PR-aware lifecycle exist so you don't have to sit in the loop.</p>
+<ol><li><strong>Reach beyond the desktop.</strong> A desktop app lives on the desktop. TaskYou runs the same board</li></ol>
+<p>in your <strong>terminal</strong>, your <strong>browser</strong> (<code>ty serve</code>), a <strong>desktop app</strong>, over <strong>SSH</strong> (<code>taskd</code>, so it can live on a remote box or a cloud VM), via <strong>email</strong> (create and unblock tasks from your phone with the <code>ty-email</code> extension), and through a <strong>Chrome extension</strong> for annotate-and-fix loops. You can kick off work from a VM you SSH into and review it from your phone.</p>
+<hr>
+<h2>When to pick which</h2>
+<p><strong>Pick cmux / Warp when:</strong></p>
+<ul><li>You want the most polished <strong>local, GUI</strong> agent experience and you live on one machine.</li><li>You're driving agents hands-on and don't need a queue, a scheduler, or remote surfaces.</li><li>Native app niceties (blocks, completions, design) are what you're optimizing for.</li></ul>
+<p><strong>Pick TaskYou when:</strong></p>
+<ul><li>You want to <strong>queue outcomes and walk away</strong>, not drive every session by hand.</li><li>You want <strong>worktree isolation + PR-aware tracking</strong> as defaults.</li><li>You need to run agents on a <strong>remote/cloud box</strong> and triage them from <strong>any device</strong> —</li></ul>
+<p>including your <strong>phone</strong>, by email.</p>
+<ul><li>You want <strong>multiple executors</strong> and <strong>scheduled routines</strong> on one open-source (MIT) board.</li></ul>
+<p><strong>They can coexist:</strong> TaskYou can run on a server and own the queue and worktrees while you use a slick local terminal (Warp, cmux, or anything else) as the place you drop in to take the wheel on a single task.</p>
+<hr>
+<p class="note"><em>Accuracy note: TaskYou capabilities are documented in the <a href="https://github.com/bborn/taskyou#readme">README</a> and the <code>extensions/ty-*</code> READMEs. cmux/Warp entries reflect their general positioning as desktop/terminal agent apps; <code><span class="mark partial">◐︎</span></code> marks places their scope varies or we haven't individually verified a feature. This is a category comparison, not a feature audit. PRs welcome to correct anything.</em></p>
+<div class="pager"><a href="/compare/">← All comparisons</a><a href="/">taskyou.dev →</a></div>
+  </div>
+</section>
+<footer>
+  <div class="wrap">
+    <span class="fbrand"><img src="../images/logo.webp" alt="">taskyou</span>
+    <span class="flinks">
+      <a href="/">Home</a>
+      <a href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="https://github.com/bborn/taskyou#readme">Docs</a>
+    </span>
+  </div>
+</footer>
+</body>
+</html>

--- a/docs/compare/taskyou-vs-conductor-emdash-superset.html
+++ b/docs/compare/taskyou-vs-conductor-emdash-superset.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TaskYou vs Conductor / Emdash / Superset — TaskYou</title>
+<meta name="description" content="Conductor, Emdash, and Superset isolate a worktree per branch and help you review">
+<link rel="icon" href="../images/logo.webp">
+<meta property="og:title" content="TaskYou vs Conductor / Emdash / Superset — TaskYou">
+<meta property="og:description" content="Conductor, Emdash, and Superset isolate a worktree per branch and help you review">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="compare.css">
+</head>
+<body>
+<div class="grid-bg"></div>
+<nav>
+  <div class="wrap">
+    <a class="brand" href="/"><img src="../images/logo.webp" alt="">taskyou</a>
+    <div class="navlinks">
+      <a class="desktop-only" href="/#how">How it works</a>
+      <a class="desktop-only" href="/#features">Features</a>
+      <a class="active" href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="/#install" class="btn btn-primary">Install ↓</a>
+    </div>
+  </div>
+</nav>
+<section class="body">
+  <div class="wrap prose">
+<h1 class="headline">TaskYou vs Conductor / Emdash / Superset</h1>
+<p><strong>One line:</strong> Conductor, Emdash, and Superset isolate a worktree per branch and help you review the diff; TaskYou does that <em>and</em> runs the work in the background on a queue, across six executors, on whatever surface you happen to be holding.</p>
+<p>This is the comparison closest to TaskYou's own job. These tools share TaskYou's core insight — <strong>give every agent its own isolated git worktree</strong> — so the differences are about everything <em>around</em> the worktree: the queue, the lifecycle, the executor choice, and where you can drive it from.</p>
+<hr>
+<h2>What they share with TaskYou</h2>
+<p>Conductor, Emdash, and Superset are worktree-orchestration tools for coding agents. Like TaskYou, they:</p>
+<ul><li>Run each agent in an <strong>isolated git worktree</strong> so parallel work doesn't collide.</li><li>Center the workflow on <strong>diffs and pull requests</strong> rather than raw terminal panes.</li><li>Aim to let you run <strong>multiple agents in parallel</strong> on the same repo.</li></ul>
+<p>If the terminal-multiplexer tools are one camp, this is the "worktree orchestrator" camp — and TaskYou lives here too. So we'll be precise about the differences instead of hand-waving.</p>
+<h2>What TaskYou does differently</h2>
+<div class="tablewrap"><table><thead><tr><th></th><th class="c"><strong>TaskYou</strong></th><th class="c">Conductor / Emdash / Superset</th></tr></thead><tbody><tr><td>Worktree-per-task isolation</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark yes">✓︎</span><span class="anno">(the shared idea)</span></td></tr><tr><td>Diff / PR review flow</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">+ PR-aware completion lifecycle</span></td><td class="val"><span class="mark yes">✓︎</span></td></tr><tr><td><strong>Kanban board</strong> as the home surface</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">Backlog / In Progress / Blocked / Done</span></td><td class="val"><span class="mark partial">◐︎</span><span class="anno">varies; often a list or per-agent view</span></td></tr><tr><td><strong>Queue + background execution</strong></td><td class="val"><span class="mark yes">✓︎</span><span class="anno">stack a column, walk away</span></td><td class="val"><span class="mark partial">◐︎</span><span class="anno">varies by tool</span></td></tr><tr><td><strong>Pluggable executors</strong></td><td class="val"><span class="mark yes">✓︎</span><span class="anno">Claude, Codex, Gemini, Pi, OpenClaw, OpenCode — per task</span></td><td class="val"><span class="mark partial">◐︎</span><span class="anno">usually one or two</span></td></tr><tr><td><strong>Routines</strong> — scheduled unattended runs feeding the queue</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td><strong>PR-aware completion</strong> (task auto-<code>done</code> on merge/close)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td><strong>Multi-surface</strong> (TUI · web · desktop · email · SSH · Chrome)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark partial">◐︎</span><span class="anno">usually one app (often desktop or web)</span></td></tr><tr><td><strong>Fully scriptable CLI + MCP</strong> for agents to drive the queue</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark partial">◐︎</span></td></tr><tr><td>Open source</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">MIT</span></td><td class="val"><span class="mark partial">◐︎</span><span class="anno">varies</span></td></tr></tbody></table></div>
+<p>The pattern: this camp tends to ship <strong>one polished surface</strong> (a desktop app or a web app), <strong>one or two agents</strong>, and a <strong>worktree-plus-diff</strong> flow. TaskYou matches the worktree-plus-diff flow, then adds the things that make it an <em>orchestrator</em> rather than a launcher:</p>
+<ol><li><strong>A real queue.</strong> Drop ten tasks and walk away. The board works the column down in the</li></ol>
+<p>background — you're not launching agents one at a time.</p>
+<ol><li><strong>Executor choice per task.</strong> Claude Code for the gnarly refactor, Codex for the boilerplate,</li></ol>
+<p>Gemini or Pi or OpenClaw or OpenCode for whatever fits — on the same board.</p>
+<ol><li><strong>PR-aware completion.</strong> A task that opens a PR goes to <code>blocked</code> for human review, then is</li></ol>
+<p>promoted to <code>done</code> automatically when the PR merges or closes. The board mirrors your repo.</p>
+<ol><li><strong>Routines.</strong> Named, unattended agent runs — scouts and monitors — that wake on a schedule and</li></ol>
+<p><em>file tasks into your queue</em>. Your backlog can fill itself.</p>
+<ol><li><strong>Surface independence.</strong> The same board in a terminal, a browser, a desktop app, your email,</li></ol>
+<p>and over SSH. Most tools in this camp are a single app.</p>
+<hr>
+<h2>When to pick which</h2>
+<p><strong>Pick Conductor / Emdash / Superset when:</strong></p>
+<ul><li>You want a single, polished, opinionated app and that app's chosen agent fits your workflow.</li><li>A focused worktree-and-diff experience is exactly the scope you want — no queue, no scheduler,</li></ul>
+<p>no extra surfaces.</p>
+<ul><li>Their specific UX or integrations match how your team already works.</li></ul>
+<p><strong>Pick TaskYou when:</strong></p>
+<ul><li>You want the worktree-and-diff flow <strong>plus a queue you can stack and walk away from.</strong></li><li>You want to <strong>mix executors</strong> across tasks instead of being locked to one agent.</li><li>You want <strong>routines</strong> that feed your backlog on a schedule, unattended.</li><li>You want to <strong>drive from anywhere</strong> — terminal, browser, desktop, phone (email), or SSH.</li><li>You want it <strong>open source (MIT)</strong> and scriptable to the last command.</li></ul>
+<hr>
+<p class="note"><em>Accuracy note: TaskYou capabilities are documented in the <a href="https://github.com/bborn/taskyou#readme">README</a> and the <code>extensions/ty-*</code> READMEs. The competitor column is deliberately marked <code><span class="mark partial">◐︎</span></code> where these tools differ in scope or have shipped features we haven't individually verified — this page describes the <strong>category</strong> difference (launcher vs orchestrator), not a feature-by-feature audit of each product. Corrections welcome via PR.</em></p>
+<div class="pager"><a href="/compare/">← All comparisons</a><a href="/">taskyou.dev →</a></div>
+  </div>
+</section>
+<footer>
+  <div class="wrap">
+    <span class="fbrand"><img src="../images/logo.webp" alt="">taskyou</span>
+    <span class="flinks">
+      <a href="/">Home</a>
+      <a href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="https://github.com/bborn/taskyou#readme">Docs</a>
+    </span>
+  </div>
+</footer>
+</body>
+</html>

--- a/docs/compare/taskyou-vs-tmux.html
+++ b/docs/compare/taskyou-vs-tmux.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TaskYou vs tmux / Zellij — TaskYou</title>
+<meta name="description" content="tmux and Zellij multiplex terminals; TaskYou multiplexes tasks — and since">
+<link rel="icon" href="../images/logo.webp">
+<meta property="og:title" content="TaskYou vs tmux / Zellij — TaskYou">
+<meta property="og:description" content="tmux and Zellij multiplex terminals; TaskYou multiplexes tasks — and since">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="compare.css">
+</head>
+<body>
+<div class="grid-bg"></div>
+<nav>
+  <div class="wrap">
+    <a class="brand" href="/"><img src="../images/logo.webp" alt="">taskyou</a>
+    <div class="navlinks">
+      <a class="desktop-only" href="/#how">How it works</a>
+      <a class="desktop-only" href="/#features">Features</a>
+      <a class="active" href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="/#install" class="btn btn-primary">Install ↓</a>
+    </div>
+  </div>
+</nav>
+<section class="body">
+  <div class="wrap prose">
+<h1 class="headline">TaskYou vs tmux / Zellij</h1>
+<p><strong>One line:</strong> tmux and Zellij multiplex <em>terminals</em>; TaskYou multiplexes <em>tasks</em> — and since TaskYou is built on tmux under the hood, you get the panes anyway.</p>
+<p>This is the friendliest comparison on the list, because it isn't really a competition. tmux and Zellij are terminal multiplexers — they keep sessions alive and tile panes. TaskYou is an autonomy-first task orchestrator that <em>uses</em> a multiplexer as plumbing. The question isn't "which one" — it's "what sits on top."</p>
+<hr>
+<h2>What TaskYou is</h2>
+<p>A Kanban board for coding agents. You drop a task in a column, an agent picks it up in its own isolated git worktree, runs in the background, and the card tracks itself to a merged PR. One agent per task, a worktree per agent.</p>
+<p>Under the hood, each executor runs in a <strong>tmux window</strong> inside a daemon session:</p>
+<pre><code>task-daemon-{PID}              (tmux session)
+├── _placeholder               (keeps the session alive)
+├── task-123                   (window for task 123)
+│   ├── pane 0: executor       (Claude / Codex / … output)
+│   └── pane 1: shell          (workdir access)
+├── task-124                   (window for task 124)
+└── ...</code></pre>
+<p>So TaskYou doesn't replace tmux — it <em>programs</em> it. The difference is everything that wraps those panes: a board, a queue, worktree isolation, PR tracking, and a database that remembers what every task is doing.</p>
+<h2>What tmux / Zellij give you</h2>
+<ul><li><strong>Persistent sessions</strong> — your work survives a disconnect; reattach later.</li><li><strong>Panes and windows</strong> — tile, split, and navigate terminals by hand.</li><li><strong>Scriptability</strong> — tmux especially is automatable (TaskYou leans on exactly this).</li><li><strong>Zellij extras</strong> — a modern, discoverable UX with layouts, a status bar, and plugins.</li></ul>
+<p>What they <em>don't</em> do — by design, because they're general-purpose terminal tools — is understand your work. A pane is a pane. tmux doesn't know that window 3 is an agent, that it's blocked waiting on you, that it's working in an isolated worktree, or that it just opened a PR.</p>
+<hr>
+<h2>What TaskYou adds on top of the multiplexer</h2>
+<div class="tablewrap"><table><thead><tr><th></th><th class="c"><strong>TaskYou</strong></th><th class="c"><strong>tmux / Zellij</strong></th></tr></thead><tbody><tr><td>Persistent sessions</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">(via the daemon)</span></td><td class="val"><span class="mark yes">✓︎</span></td></tr><tr><td>Tiled panes</td><td class="val"><span class="mark yes">✓︎</span><span class="anno">(executor + shell per task)</span></td><td class="val"><span class="mark yes">✓︎</span></td></tr><tr><td><strong>Knows a pane is an agent</strong></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td><strong>Kanban board</strong> of work</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td><strong>Queue + background execution</strong></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span><span class="anno">— you launch every process by hand</span></td></tr><tr><td><strong>Worktree-per-task isolation</strong></td><td class="val"><span class="mark yes">✓︎</span><span class="anno">automatic</span></td><td class="val"><span class="mark no">✕︎</span><span class="anno">— you <code>git worktree add</code> yourself</span></td></tr><tr><td><strong>PR-aware completion</strong></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td><strong>Pluggable AI executors</strong></td><td class="val"><span class="mark yes">✓︎</span><span class="anno">6 of them</span></td><td class="val"><span class="mark no">✕︎</span><span class="anno">— not its job</span></td></tr><tr><td><strong>Task database + history</strong></td><td class="val"><span class="mark yes">✓︎</span><span class="anno">SQLite</span></td><td class="val"><span class="mark no">✕︎</span><span class="anno">— panes are ephemeral state</span></td></tr><tr><td><strong>Routines</strong> (scheduled unattended runs)</td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="mark no">✕︎</span></td></tr><tr><td><strong>Web / desktop / email / SSH surfaces</strong></td><td class="val"><span class="mark yes">✓︎</span></td><td class="val"><span class="anno plain">terminal only</span></td></tr></tbody></table></div>
+<p>The honest way to say it: <strong>you <em>could</em> build a poor man's TaskYou out of tmux</strong> — a session per task, a <code>git worktree add</code> for each, a shell loop to launch agents, and a wall of sticky notes to track which is which. TaskYou is what you get when someone builds that properly and adds a board, a queue, worktree lifecycle, PR tracking, and a database so nothing gets lost.</p>
+<hr>
+<h2>When to pick which</h2>
+<p><strong>Reach for tmux / Zellij when:</strong></p>
+<ul><li>You want a general-purpose multiplexer for <em>any</em> terminal work, not just agents.</li><li>You want to hand-manage panes and sessions yourself.</li><li>You're composing your own tooling and want the lowest-level, most scriptable substrate.</li></ul>
+<p><strong>Reach for TaskYou when:</strong></p>
+<ul><li>Your terminals are mostly <strong>coding agents</strong> and you want to manage them as <em>work</em>, not panes.</li><li>You want <strong>queue + background execution + worktree isolation + PR tracking</strong> without scripting</li></ul>
+<p>it together yourself.</p>
+<ul><li>You want the same board on the <strong>web, a desktop app, email, and over SSH</strong> — not just in a</li></ul>
+<p>terminal.</p>
+<p><strong>You're already using both.</strong> TaskYou runs on tmux. If you live in tmux today, TaskYou is the task layer that sits on top of it — and you can still <code>tmux attach</code> to the daemon session and poke at any task's panes by hand whenever you want to take the wheel.</p>
+<hr>
+<p class="note"><em>Accuracy note: the tmux architecture shown above is TaskYou's actual executor model, documented in the <a href="https://github.com/bborn/taskyou#readme">README</a> under "How Task Executors Work." Zellij/tmux capabilities are their standard documented features.</em></p>
+<div class="pager"><a href="/compare/">← All comparisons</a><a href="/">taskyou.dev →</a></div>
+  </div>
+</section>
+<footer>
+  <div class="wrap">
+    <span class="fbrand"><img src="../images/logo.webp" alt="">taskyou</span>
+    <span class="flinks">
+      <a href="/">Home</a>
+      <a href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="https://github.com/bborn/taskyou#readme">Docs</a>
+    </span>
+  </div>
+</footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,6 +165,7 @@
     <div class="navlinks">
       <a class="desktop-only" href="#how">How it works</a>
       <a class="desktop-only" href="#features">Features</a>
+      <a href="/compare/">Compare</a>
       <a href="https://github.com/bborn/taskyou">GitHub</a>
       <a href="#install" class="btn btn-primary">Install ↓</a>
     </div>

--- a/docs/marketing/README.md
+++ b/docs/marketing/README.md
@@ -1,0 +1,33 @@
+# Marketing & positioning drafts
+
+Working drafts for TaskYou's competitive positioning and "TaskYou vs X" comparison content,
+prompted by a teardown of the sharpest public surfaces in the coding-agent space — whose
+positioning and `/compare` pages are currently tighter than ours.
+
+**These are drafts for review, not published copy.** The live marketing site is the hand-written
+[`docs/index.html`](../index.html) (served at taskyou.dev). Intended destination once approved: a
+`/compare` section on taskyou.dev (rendered HTML drafted under [`docs/compare/`](../compare/)).
+See the memo for the open question on where the public-site content should ultimately live.
+
+## Contents
+
+- **[positioning-memo.md](positioning-memo.md)** — the teardown + recommendations. Start here.
+  Covers where our marketing lives, what the best-positioned competitors do well, where we
+  honestly beat them, and a concrete sharpening of the hero/tagline.
+- **[compare/](compare/)** — "TaskYou vs X" comparison drafts, leading with what TaskYou *is*
+  (an autonomy-first task orchestrator):
+  - [compare/index.md](compare/index.md) — capability matrix across the whole landscape
+  - [compare/taskyou-vs-tmux.md](compare/taskyou-vs-tmux.md) (tmux / Zellij)
+  - [compare/taskyou-vs-conductor-emdash-superset.md](compare/taskyou-vs-conductor-emdash-superset.md)
+  - [compare/taskyou-vs-cmux-warp.md](compare/taskyou-vs-cmux-warp.md)
+- **[../compare/](../compare/)** — the same pages rendered as styled HTML for the live site.
+
+## Ground rules these drafts follow
+
+- **Lead with what TaskYou is, not what it isn't.** Category claim: *autonomy-first task
+  orchestrator for coding agents.*
+- **Every capability claim maps to a shipped feature** documented in the
+  [README](../../README.md) or an `extensions/ty-*` README. No vaporware. Partial / executor-specific
+  features are flagged.
+- **Be fair.** Each page names where the competitor genuinely wins at its own job. Comparison
+  content that only flatters us reads as spin and ages badly.

--- a/docs/marketing/compare/index.md
+++ b/docs/marketing/compare/index.md
@@ -1,0 +1,53 @@
+# TaskYou vs everything else
+
+**TaskYou is an autonomy-first task orchestrator for coding agents.** You drop a task on a
+board, an agent picks it up and works in its own isolated git worktree in the background, and
+the card tracks all the way to a merged PR. One agent per task. A worktree per agent.
+
+That's a different job from a terminal multiplexer, a process dashboard, or a worktree-diff
+tool. This page lays the whole landscape on one grid, then links to a detailed page for each
+contender. We try to be fair: where a tool genuinely beats us at *its* job, we say so.
+
+> **The short version:** most of these tools help you *watch and drive* agents you launch by
+> hand. TaskYou helps you *queue outcomes and walk away.* If your mental model is "panes I'm
+> babysitting," you want a multiplexer. If it's "a backlog that clears itself," you want TaskYou.
+
+---
+
+## Capability matrix
+
+| Capability | **TaskYou** | tmux / Zellij | cmux / Warp | Conductor / Emdash / Superset |
+|---|:--:|:--:|:--:|:--:|
+| Unit of work is a **task / outcome** (not a pane) | ✅ | ❌ | ❌ | ✅ |
+| **Queue + background execution** (stack work, walk away) | ✅ | ❌ | ❌ | ◐ |
+| **Kanban board** (Backlog / In Progress / Blocked / Done) | ✅ | ❌ | ❌ | ◐ |
+| **Worktree-per-task isolation**, automatic | ✅ | ❌ | ◐ | ✅ |
+| **PR-aware completion** (task state follows the PR to merge) | ✅ | ❌ | ❌ | ◐ |
+| **Pluggable executors** (Claude, Codex, Gemini, Pi, OpenClaw, OpenCode) | ✅ | n/a | ❌ | ◐ |
+| **Routines** — scheduled unattended runs that feed the queue | ✅ | ❌ | ❌ | ❌ |
+| **Live executor panes** to watch/drive an agent | ✅ | ✅ | ✅ | ◐ |
+| Runs over **SSH** (board from anywhere) | ✅ | ✅ | ❌ | ❌ |
+| **Web UI** (same board in a browser) | ✅ | ❌ | ❌ | ◐ |
+| **Desktop app** (macOS / Linux) | ✅ | ❌ | ✅ | ✅ |
+| **Email control** (create + unblock tasks from your phone) | ✅ | ❌ | ❌ | ❌ |
+| **Fully scriptable CLI / agent API** | ✅ | ◐ | ◐ | ◐ |
+| Open source | ✅ MIT | ✅ | ◐ | ◐ |
+
+✅ first-class · ◐ partial / possible-but-not-the-point · ❌ no · n/a not applicable
+*(`◐` and `❌` for other tools reflect their stated positioning as of mid-2026; correct us with a PR if a tool has shipped past this.)*
+
+---
+
+## Pick your comparison
+
+- **[TaskYou vs tmux / Zellij](taskyou-vs-tmux.md)** — TaskYou *runs on* tmux; here's what it adds on top.
+- **[TaskYou vs Conductor / Emdash / Superset](taskyou-vs-conductor-emdash-superset.md)** — the other worktree-orchestrator camp.
+- **[TaskYou vs cmux / Warp](taskyou-vs-cmux-warp.md)** — desktop agent apps vs a board that runs anywhere.
+
+---
+
+## One-liners
+
+- **vs tmux / Zellij:** tmux multiplexes terminals; TaskYou multiplexes *tasks* — and it's built on tmux, so you get the panes anyway.
+- **vs Conductor / Emdash / Superset:** they isolate a worktree per branch and help you review the diff; TaskYou does that *and* runs the work in the background on a queue, across six executors, on whatever surface you're holding.
+- **vs cmux / Warp:** they're polished Mac apps for agents; TaskYou is the same board in your terminal, your browser, your desktop, your inbox, and over SSH.

--- a/docs/marketing/compare/taskyou-vs-cmux-warp.md
+++ b/docs/marketing/compare/taskyou-vs-cmux-warp.md
@@ -1,0 +1,80 @@
+# TaskYou vs cmux / Warp
+
+**One line:** cmux and Warp are polished apps for running agents on your machine; TaskYou is the
+same job as a board that runs *anywhere* — terminal, browser, desktop, email, and over SSH —
+and is built to queue work and walk away.
+
+cmux (a Mac terminal app for agents) and Warp (an agentic development platform / terminal) both
+bet on a beautiful, local, GUI-forward experience. TaskYou bets on **autonomy and reach**: file
+an outcome, let an agent run it in the background in an isolated worktree, and pick up the result
+from whatever device you have.
+
+---
+
+## What cmux / Warp are good at
+
+- **Polished, native UX.** Warp in particular is a gorgeous terminal with first-class agent
+  features; cmux is a focused Mac app for driving agents. If you want a beautiful local cockpit,
+  this is the camp.
+- **Low friction on your own machine.** Install the app, open it, go. No daemon mental model, no
+  SSH server to think about.
+- **Rich interactive features** baked into the app — completions, blocks, agent panes, and so on.
+
+If you primarily work on one Mac and want the most polished local agent experience, these are
+strong, and TaskYou doesn't try to out-pretty them.
+
+## Where TaskYou is different
+
+| | **TaskYou** | cmux / Warp |
+|---|---|---|
+| Center of gravity | A **task board** + queue | A polished terminal/app you drive |
+| Queue + background execution | ✅ stack work, walk away | ❌ you drive sessions live |
+| Worktree-per-task isolation | ✅ automatic | ◐ varies |
+| PR-aware completion | ✅ | ❌ |
+| Pluggable executors (6) | ✅ per task | ◐ tied to the app's agent(s) |
+| Routines (scheduled unattended runs) | ✅ | ❌ |
+| Runs on a **headless server / over SSH** | ✅ `taskd` | ❌ desktop-bound (cmux); ◐ (Warp) |
+| Same board on **web + email + Chrome** | ✅ | ❌ |
+| Open source | ✅ MIT | ◐ |
+
+Two differences matter most:
+
+1. **Autonomy.** cmux and Warp are places you *drive* agents. TaskYou is a place you *hand off*
+   work: queue a column, walk away, come back to diffs. The board, the worktrees, and the
+   PR-aware lifecycle exist so you don't have to sit in the loop.
+
+2. **Reach beyond the desktop.** A desktop app lives on the desktop. TaskYou runs the same board
+   in your **terminal**, your **browser** (`ty serve`), a **desktop app**, over **SSH** (`taskd`,
+   so it can live on a remote box or a cloud VM), via **email** (create and unblock tasks from
+   your phone with the `ty-email` extension), and through a **Chrome extension** for
+   annotate-and-fix loops. You can kick off work from a VM you SSH into and review it from your
+   phone.
+
+---
+
+## When to pick which
+
+**Pick cmux / Warp when:**
+
+- You want the most polished **local, GUI** agent experience and you live on one machine.
+- You're driving agents hands-on and don't need a queue, a scheduler, or remote surfaces.
+- Native app niceties (blocks, completions, design) are what you're optimizing for.
+
+**Pick TaskYou when:**
+
+- You want to **queue outcomes and walk away**, not drive every session by hand.
+- You want **worktree isolation + PR-aware tracking** as defaults.
+- You need to run agents on a **remote/cloud box** and triage them from **any device** —
+  including your **phone**, by email.
+- You want **multiple executors** and **scheduled routines** on one open-source (MIT) board.
+
+**They can coexist:** TaskYou can run on a server and own the queue and worktrees while you use a
+slick local terminal (Warp, cmux, or anything else) as the place you drop in to take the wheel on
+a single task.
+
+---
+
+*Accuracy note: TaskYou capabilities are documented in the [README](../../../README.md) and the
+`extensions/ty-*` READMEs. cmux/Warp entries reflect their general positioning as desktop/terminal
+agent apps; `◐` marks places their scope varies or we haven't individually verified a feature.
+This is a category comparison, not a feature audit. PRs welcome to correct anything.*

--- a/docs/marketing/compare/taskyou-vs-conductor-emdash-superset.md
+++ b/docs/marketing/compare/taskyou-vs-conductor-emdash-superset.md
@@ -1,0 +1,81 @@
+# TaskYou vs Conductor / Emdash / Superset
+
+**One line:** Conductor, Emdash, and Superset isolate a worktree per branch and help you review
+the diff; TaskYou does that *and* runs the work in the background on a queue, across six
+executors, on whatever surface you happen to be holding.
+
+This is the comparison closest to TaskYou's own job. These tools share TaskYou's core insight —
+**give every agent its own isolated git worktree** — so the differences are about everything
+*around* the worktree: the queue, the lifecycle, the executor choice, and where you can drive it
+from.
+
+---
+
+## What they share with TaskYou
+
+Conductor, Emdash, and Superset are worktree-orchestration tools for coding agents. Like TaskYou,
+they:
+
+- Run each agent in an **isolated git worktree** so parallel work doesn't collide.
+- Center the workflow on **diffs and pull requests** rather than raw terminal panes.
+- Aim to let you run **multiple agents in parallel** on the same repo.
+
+If the terminal-multiplexer tools are one camp, this is the "worktree orchestrator" camp — and TaskYou lives
+here too. So we'll be precise about the differences instead of hand-waving.
+
+## What TaskYou does differently
+
+| | **TaskYou** | Conductor / Emdash / Superset |
+|---|---|---|
+| Worktree-per-task isolation | ✅ | ✅ (the shared idea) |
+| Diff / PR review flow | ✅ + PR-aware completion lifecycle | ✅ |
+| **Kanban board** as the home surface | ✅ Backlog / In Progress / Blocked / Done | ◐ varies; often a list or per-agent view |
+| **Queue + background execution** | ✅ stack a column, walk away | ◐ varies by tool |
+| **Pluggable executors** | ✅ Claude, Codex, Gemini, Pi, OpenClaw, OpenCode — per task | ◐ usually one or two |
+| **Routines** — scheduled unattended runs feeding the queue | ✅ | ❌ |
+| **PR-aware completion** (task auto-`done` on merge/close) | ✅ | ◐ |
+| **Multi-surface** (TUI · web · desktop · email · SSH · Chrome) | ✅ | ◐ usually one app (often desktop or web) |
+| **Fully scriptable CLI + MCP** for agents to drive the queue | ✅ | ◐ |
+| Open source | ✅ MIT | ◐ varies |
+
+The pattern: this camp tends to ship **one polished surface** (a desktop app or a web app), **one
+or two agents**, and a **worktree-plus-diff** flow. TaskYou matches the worktree-plus-diff flow,
+then adds the things that make it an *orchestrator* rather than a launcher:
+
+1. **A real queue.** Drop ten tasks and walk away. The board works the column down in the
+   background — you're not launching agents one at a time.
+2. **Executor choice per task.** Claude Code for the gnarly refactor, Codex for the boilerplate,
+   Gemini or Pi or OpenClaw or OpenCode for whatever fits — on the same board.
+3. **PR-aware completion.** A task that opens a PR goes to `blocked` for human review, then is
+   promoted to `done` automatically when the PR merges or closes. The board mirrors your repo.
+4. **Routines.** Named, unattended agent runs — scouts and monitors — that wake on a schedule and
+   *file tasks into your queue*. Your backlog can fill itself.
+5. **Surface independence.** The same board in a terminal, a browser, a desktop app, your email,
+   and over SSH. Most tools in this camp are a single app.
+
+---
+
+## When to pick which
+
+**Pick Conductor / Emdash / Superset when:**
+
+- You want a single, polished, opinionated app and that app's chosen agent fits your workflow.
+- A focused worktree-and-diff experience is exactly the scope you want — no queue, no scheduler,
+  no extra surfaces.
+- Their specific UX or integrations match how your team already works.
+
+**Pick TaskYou when:**
+
+- You want the worktree-and-diff flow **plus a queue you can stack and walk away from.**
+- You want to **mix executors** across tasks instead of being locked to one agent.
+- You want **routines** that feed your backlog on a schedule, unattended.
+- You want to **drive from anywhere** — terminal, browser, desktop, phone (email), or SSH.
+- You want it **open source (MIT)** and scriptable to the last command.
+
+---
+
+*Accuracy note: TaskYou capabilities are documented in the [README](../../../README.md) and the
+`extensions/ty-*` READMEs. The competitor column is deliberately marked `◐` where these tools
+differ in scope or have shipped features we haven't individually verified — this page describes
+the **category** difference (launcher vs orchestrator), not a feature-by-feature audit of each
+product. Corrections welcome via PR.*

--- a/docs/marketing/compare/taskyou-vs-tmux.md
+++ b/docs/marketing/compare/taskyou-vs-tmux.md
@@ -1,0 +1,95 @@
+# TaskYou vs tmux / Zellij
+
+**One line:** tmux and Zellij multiplex *terminals*; TaskYou multiplexes *tasks* — and since
+TaskYou is built on tmux under the hood, you get the panes anyway.
+
+This is the friendliest comparison on the list, because it isn't really a competition. tmux and
+Zellij are terminal multiplexers — they keep sessions alive and tile panes. TaskYou is an
+autonomy-first task orchestrator that *uses* a multiplexer as plumbing. The question isn't
+"which one" — it's "what sits on top."
+
+---
+
+## What TaskYou is
+
+A Kanban board for coding agents. You drop a task in a column, an agent picks it up in its own
+isolated git worktree, runs in the background, and the card tracks itself to a merged PR. One
+agent per task, a worktree per agent.
+
+Under the hood, each executor runs in a **tmux window** inside a daemon session:
+
+```
+task-daemon-{PID}              (tmux session)
+├── _placeholder               (keeps the session alive)
+├── task-123                   (window for task 123)
+│   ├── pane 0: executor       (Claude / Codex / … output)
+│   └── pane 1: shell          (workdir access)
+├── task-124                   (window for task 124)
+└── ...
+```
+
+So TaskYou doesn't replace tmux — it *programs* it. The difference is everything that wraps
+those panes: a board, a queue, worktree isolation, PR tracking, and a database that remembers
+what every task is doing.
+
+## What tmux / Zellij give you
+
+- **Persistent sessions** — your work survives a disconnect; reattach later.
+- **Panes and windows** — tile, split, and navigate terminals by hand.
+- **Scriptability** — tmux especially is automatable (TaskYou leans on exactly this).
+- **Zellij extras** — a modern, discoverable UX with layouts, a status bar, and plugins.
+
+What they *don't* do — by design, because they're general-purpose terminal tools — is
+understand your work. A pane is a pane. tmux doesn't know that window 3 is an agent, that it's
+blocked waiting on you, that it's working in an isolated worktree, or that it just opened a PR.
+
+---
+
+## What TaskYou adds on top of the multiplexer
+
+| | **TaskYou** | **tmux / Zellij** |
+|---|---|---|
+| Persistent sessions | ✅ (via the daemon) | ✅ |
+| Tiled panes | ✅ (executor + shell per task) | ✅ |
+| **Knows a pane is an agent** | ✅ | ❌ |
+| **Kanban board** of work | ✅ | ❌ |
+| **Queue + background execution** | ✅ | ❌ — you launch every process by hand |
+| **Worktree-per-task isolation** | ✅ automatic | ❌ — you `git worktree add` yourself |
+| **PR-aware completion** | ✅ | ❌ |
+| **Pluggable AI executors** | ✅ 6 of them | ❌ — not its job |
+| **Task database + history** | ✅ SQLite | ❌ — panes are ephemeral state |
+| **Routines** (scheduled unattended runs) | ✅ | ❌ |
+| **Web / desktop / email / SSH surfaces** | ✅ | terminal only |
+
+The honest way to say it: **you *could* build a poor man's TaskYou out of tmux** — a session
+per task, a `git worktree add` for each, a shell loop to launch agents, and a wall of sticky
+notes to track which is which. TaskYou is what you get when someone builds that properly and
+adds a board, a queue, worktree lifecycle, PR tracking, and a database so nothing gets lost.
+
+---
+
+## When to pick which
+
+**Reach for tmux / Zellij when:**
+
+- You want a general-purpose multiplexer for *any* terminal work, not just agents.
+- You want to hand-manage panes and sessions yourself.
+- You're composing your own tooling and want the lowest-level, most scriptable substrate.
+
+**Reach for TaskYou when:**
+
+- Your terminals are mostly **coding agents** and you want to manage them as *work*, not panes.
+- You want **queue + background execution + worktree isolation + PR tracking** without scripting
+  it together yourself.
+- You want the same board on the **web, a desktop app, email, and over SSH** — not just in a
+  terminal.
+
+**You're already using both.** TaskYou runs on tmux. If you live in tmux today, TaskYou is the
+task layer that sits on top of it — and you can still `tmux attach` to the daemon session and
+poke at any task's panes by hand whenever you want to take the wheel.
+
+---
+
+*Accuracy note: the tmux architecture shown above is TaskYou's actual executor model, documented
+in the [README](../../../README.md) under "How Task Executors Work." Zellij/tmux capabilities are
+their standard documented features.*

--- a/docs/marketing/positioning-memo.md
+++ b/docs/marketing/positioning-memo.md
@@ -1,0 +1,161 @@
+# Positioning memo: sharpening TaskYou + a "vs X" comparison section
+
+**Status:** draft for review · **Audience:** Bruno + whoever owns taskyou.dev
+**Companion drafts:** [`compare/`](compare/) — "TaskYou vs X" pages
+
+---
+
+## TL;DR
+
+The sharpest tools in the coding-agent space are winning the *positioning* fight, not the
+*product* fight. The best-positioned competitors have a tighter one-liner, a clear **category
+claim**, and a clean `/compare` page that frames every rival on their own terms. TaskYou's
+surface ("Kanban for code agents") describes the **UI metaphor** instead of the **job**, and we
+have no comparison content at all — so anyone evaluating the space reads someone else's framing
+and never hears ours.
+
+The fix is cheap and doesn't require a single product change:
+
+1. **Lead with the job, not the widget.** TaskYou's job is *autonomy* — you describe an
+   outcome, an agent executes it in the background, and the board tracks it to a merged PR. Say
+   that first.
+2. **Claim a category.** TaskYou is an **"autonomy-first task orchestrator for coding agents."**
+   That's an honestly different category from a terminal multiplexer, a process dashboard, or a
+   worktree-diff tool.
+3. **Ship a `/compare` section.** Draft pages are in [`compare/`](compare/). They lead with what
+   TaskYou *is* and lay the landscape on one capability grid.
+
+Every claim in these drafts is checked against current code/features in the README and the
+shipped extensions. No vaporware. Anything aspirational is called out as such.
+
+---
+
+## 1. Where TaskYou's public marketing lives
+
+| Surface | Location | Canonical? |
+|---|---|---|
+| Landing page (taskyou.dev) | [`docs/index.html`](../index.html) in **this repo**, published via `docs/CNAME` → `taskyou.dev` | **Yes** — this is the live marketing site. Single page, no `/compare`, no `/docs` route. |
+| Product docs | [`README.md`](../../README.md) (long-form, 970+ lines) | Yes — doubles as the docs site (`taskyou.dev` "Docs" link points at the README). |
+| Extension docs | `extensions/ty-*/README.md` (email, chrome, web, qmd) | Yes, per-extension. |
+| Install scripts | `docs/install.sh`, `docs/install-macos.sh` | Yes. |
+
+**Note on the public-site repo.** The live site is the hand-written `docs/index.html` here,
+deployed straight from `docs/` (Cloudflare Pages style, given `docs/_headers` + `docs/CNAME`).
+There is no separate site-content repo in this checkout. **These drafts are authored as portable
+Markdown under `docs/marketing/`, with rendered HTML pages under `docs/compare/`** so they deploy
+to taskyou.dev as a `/compare` section in the same style as the landing page. Flagging so the
+final home is a deliberate choice.
+
+---
+
+## 2. Teardown: what the best-positioned competitors do well
+
+The strongest competitive positioning in this space shares a few traits worth stealing:
+
+- **A category claim, in one sentence.** The best tools tell you exactly what they are and what
+  mental slot they occupy before you finish reading — often by borrowing a familiar tool's
+  credibility ("X for agents"). TaskYou makes you infer the job from a UI metaphor.
+- **The analogy does the selling.** A familiar anchor instantly tells the reader *why they'd
+  care*. Our "Kanban for code agents" borrows Kanban's familiarity but not its **urgency** —
+  Kanban is a board you look at; the strongest analogies name a tool you *live in*.
+- **"Agent state at a glance."** The sharpest idea floating around the category: surface
+  *blocked / working / done / idle* as first-class, scannable state. It reframes "a wall of
+  terminal panes" into "a dashboard of agent status." TaskYou already has the raw material for
+  this (Kanban columns + the green-dot activity indicator) and should say so explicitly.
+- **A `/compare` page is a moat.** The tools that publish one — a capability matrix, a
+  positioning paragraph per rival, a one-line verdict for each — define the **axes** of
+  comparison. Whoever defines the axes wins. Right now we're absent from that conversation, so
+  the axes get set without us.
+- **Mouse-first / low-friction onboarding.** Lowering the learning curve widens the audience.
+
+**The uncomfortable part:** if a buyer reads a competitor's `/compare` and then looks at TaskYou,
+they'll slot us into whatever bucket that page already dismissed. We need to be in the
+conversation on our **own** axes — autonomy, lifecycle, and distribution — not theirs.
+
+## 3. Where we win — honestly
+
+A lot of tools in this space are **viewers and control layers**: they make already-running agents
+*persistent and visible*, but you still drive every agent yourself, pane by pane. That's the
+ceiling of that category.
+
+TaskYou is an **orchestrator**: the unit of work is a *task*, not a pane. You describe an outcome
+and walk away. That difference cashes out in features the viewer category structurally doesn't
+have:
+
+| Axis | TaskYou | Multiplexer / viewer tools |
+|---|---|---|
+| **Unit of work** | A task (an outcome you want) | A pane (an agent you're watching) |
+| **Queue + background execution** | Stack a column, walk away, come back to diffs | You attach and drive each agent live |
+| **Worktree-per-task** | Automatic, default substrate — every task isolated | Sometimes integrated; rarely the core metaphor |
+| **PR-aware completion** | Task → `blocked` on PR open, auto-promoted to `done` when the PR merges/closes | No PR lifecycle |
+| **Pluggable executors** | Claude Code, Codex, Gemini, Pi, OpenClaw, OpenCode — per task | Attaches to whatever agent you launched |
+| **Routines** | Named unattended runs (scouts/monitors) that feed the queue on a schedule | — |
+| **Distribution** | TUI **+ web UI + desktop app + email + SSH + Chrome extension** | Usually one surface |
+
+Two of these are worth leading with:
+
+- **Autonomy.** Queue, background execution, worktree-per-task, and PR-aware completion add up to
+  a loop the viewer category can't run: *task in → agent works unattended → PR out → board
+  reflects merge.* Those tools keep the human in the driver's seat of every pane. We let you
+  leave.
+- **Distribution / reach.** The common reach story is "SSH from any device that has a terminal."
+  Ours is genuinely multi-surface: the same board in a **terminal**, a **browser** (`ty serve`,
+  localhost:8484), a **desktop app** (macOS/Linux), over **SSH** (`taskd`), via **email** (create
+  tasks + reply to unblock from your phone, no terminal required), and a **Chrome extension** for
+  annotate-and-fix loops. You can triage your agents from a phone on the couch. A terminal-only
+  tool can't.
+
+**Be honest about what we don't lead on:** if what someone wants is a *live, mouse-first grid of
+interactive agent panes they drive by hand*, a purpose-built multiplexer is better at exactly
+that. TaskYou runs on tmux too and has live executor panes in the detail view — but our center of
+gravity is the **board and the queue**, not the pane grid. The compare pages say this out loud;
+pretending otherwise would make the whole `/compare` section read as spin.
+
+## 4. Sharpen the positioning / tagline
+
+Current hero (`docs/index.html`):
+
+> **Kanban for code agents.** Calm, cool, a little crazy. An agent for every task. A worktree for every agent.
+
+Keep the voice — "calm, cool, a little crazy" and the mug-in-sunglasses mascot are real brand
+equity and we should not sand them off. The problem is only the **top line**: it names the widget,
+not the job.
+
+**Recommended changes (smallest-diff-first):**
+
+1. **Add a category line above or beside the hero** — the thing we're missing:
+   > **An autonomy-first task orchestrator for coding agents.**
+   This is the sentence that wins the "what *is* this" race. "Kanban for code agents" can stay as
+   the friendly restatement right under it.
+
+2. **Promote the job-story line.** The site already contains the perfect line as a section header
+   further down: **"Drop a task. Walk away. Merge the diff."** That's a job in six words. Pull it
+   up near the hero.
+
+**Net hero proposal (illustrative — final copy is a separate task):**
+
+> ### An autonomy-first task orchestrator for coding agents.
+> **Drop a task. Walk away. Merge the diff.**
+> An agent for every task. A worktree for every agent.
+> *Calm, cool, a little crazy.*
+
+This keeps 100% of the existing personality and adds the one thing the page is missing: a claim
+about *what TaskYou is for*.
+
+---
+
+## 5. Recommended next steps
+
+1. **Approve / edit the `/compare` drafts** in [`compare/`](compare/) (vs tmux/Zellij, vs
+   Conductor/Emdash/Superset, vs cmux/Warp) + the [`compare/index.md`](compare/index.md)
+   capability matrix.
+2. **Decide the publish target** for `/compare` (static HTML on taskyou.dev — already drafted
+   under `docs/compare/` — vs a public-site repo) — see §1.
+3. **Land the hero tweak** (§4) — a ~10-line change to `docs/index.html`, separate PR.
+4. **Pick the canonical comparison axes** (capability matrix rows). Our matrix centers them on
+   autonomy, lifecycle, and distribution. Worth a deliberate sign-off because these become the
+   terms of every future comparison.
+
+*Every capability asserted in these drafts maps to a shipped feature documented in the README or
+an `extensions/ty-*` README. Where something is partial or executor-specific (e.g. session
+resumption is Claude/Pi/OpenClaw only), the drafts say so.*

--- a/scripts/gen-compare-pages.py
+++ b/scripts/gen-compare-pages.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Render docs/marketing/compare/*.md drafts into styled HTML under docs/compare/.
+
+Source of truth for copy is the Markdown under docs/marketing/compare/. This
+generator wraps each page in the taskyou.dev shell (nav/footer + compare.css)
+so the /compare section matches the landing page. Re-run after editing copy:
+
+    python3 scripts/gen-compare-pages.py
+"""
+import re, html, sys, pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SRC = ROOT / "docs/marketing/compare"
+OUT = ROOT / "docs/compare"
+OUT.mkdir(parents=True, exist_ok=True)
+
+PAGES = {
+    "index":                                ("Compare", "Compare"),
+    "taskyou-vs-tmux":                      ("TaskYou vs tmux / Zellij", "vs tmux"),
+    "taskyou-vs-conductor-emdash-superset": ("TaskYou vs Conductor / Emdash / Superset", "vs Conductor"),
+    "taskyou-vs-cmux-warp":                 ("TaskYou vs cmux / Warp", "vs cmux / Warp"),
+}
+
+
+def rewrite_link(href):
+    if "README.md" in href:
+        return "https://github.com/bborn/taskyou#readme"
+    if href == "../index.html":
+        return "/"
+    href = re.sub(r"\.md(#.*)?$", lambda m: ".html" + (m.group(1) or ""), href)
+    if href == "index.html":
+        return "./"
+    return href
+
+
+def inline(text):
+    spans = []
+
+    def stash(m):
+        spans.append(m.group(1))
+        return f"\x00{len(spans) - 1}\x00"
+
+    text = re.sub(r"`([^`]+)`", stash, text)
+    text = html.escape(text, quote=False)
+    text = re.sub(
+        r"\[([^\]]+)\]\(([^)]+)\)",
+        lambda m: f'<a href="{html.escape(rewrite_link(m.group(2)), quote=True)}">{m.group(1)}</a>',
+        text,
+    )
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"(?<![\w*])\*([^*]+)\*(?![\w*])", r"<em>\1</em>", text)
+    text = re.sub(r"\x00(\d+)\x00", lambda m: f"<code>{html.escape(spans[int(m.group(1))], quote=False)}</code>", text)
+    # Map status emoji to crisp text glyphs (U+FE0E forces text, not emoji,
+    # presentation) so they match the terminal aesthetic instead of bolting on
+    # OS color emoji. Applied globally so table cells AND the legend line agree.
+    text = text.replace("✅", '<span class="mark yes">✓︎</span>')
+    text = text.replace("◐", '<span class="mark partial">◐︎</span>')
+    text = text.replace("❌", '<span class="mark no">✕︎</span>')
+    return text
+
+
+def style_cell(cell):
+    return inline(cell.strip())
+
+
+def value_cell(cell):
+    """Format a comparison-column cell as a centered status glyph with the
+    annotation (if any) as a small caption beneath it. Keeps every glyph on a
+    consistent baseline so rows don't read ragged when annotations vary in
+    length. Cells with no leading glyph (prose like 'A task board + queue',
+    'n/a') render as a plain centered caption."""
+    h = inline(cell.strip())
+    m = re.match(r'^(<span class="mark [a-z]+">[^<]*</span>)\s*(.*)$', h)
+    if m:
+        mark, rest = m.group(1), m.group(2).strip()
+        return mark + (f'<span class="anno">{rest}</span>' if rest else "")
+    if not h:
+        return ""
+    return f'<span class="anno plain">{h}</span>'
+
+
+def convert(md):
+    lines = md.split("\n")
+    out, i, n = [], 0, len(md.split("\n"))
+    while i < n:
+        line = lines[i]
+        if line.startswith("```"):
+            buf = []
+            i += 1
+            while i < n and not lines[i].startswith("```"):
+                buf.append(html.escape(lines[i], quote=False))
+                i += 1
+            i += 1
+            out.append("<pre><code>" + "\n".join(buf) + "</code></pre>")
+            continue
+        if re.match(r"^---+\s*$", line):
+            out.append("<hr>")
+            i += 1
+            continue
+        m = re.match(r"^(#{1,4})\s+(.*)$", line)
+        if m:
+            lvl, txt = len(m.group(1)), inline(m.group(2).strip())
+            out.append(f'<h1 class="headline">{txt}</h1>' if lvl == 1 else f"<h{lvl}>{txt}</h{lvl}>")
+            i += 1
+            continue
+        if line.strip().startswith("|") and i + 1 < n and re.match(r"^\s*\|[\s:|-]+\|\s*$", lines[i + 1]):
+            header = line.strip().strip("|").split("|")
+            i += 2
+            rows = []
+            while i < n and lines[i].strip().startswith("|"):
+                rows.append(lines[i].strip().strip("|").split("|"))
+                i += 1
+            th = "".join(
+                (f'<th class="c">{inline(h.strip())}</th>' if k > 0 else f"<th>{inline(h.strip())}</th>")
+                for k, h in enumerate(header)
+            )
+            body = []
+            for r in rows:
+                tds = "".join(
+                    (f'<td class="val">{value_cell(cell)}</td>' if k > 0 else f"<td>{style_cell(cell)}</td>")
+                    for k, cell in enumerate(r)
+                )
+                body.append("<tr>" + tds + "</tr>")
+            out.append(
+                '<div class="tablewrap"><table><thead><tr>' + th + "</tr></thead><tbody>" + "".join(body) + "</tbody></table></div>"
+            )
+            continue
+        if line.startswith(">"):
+            buf = []
+            while i < n and lines[i].startswith(">"):
+                buf.append(lines[i][1:].strip())
+                i += 1
+            out.append("<blockquote>" + "".join(f"<p>{inline(b)}</p>" for b in buf if b) + "</blockquote>")
+            continue
+        if re.match(r"^\s*[-*]\s+", line):
+            buf = []
+            while i < n and re.match(r"^\s*[-*]\s+", lines[i]):
+                buf.append(inline(re.sub(r"^\s*[-*]\s+", "", lines[i])))
+                i += 1
+            out.append("<ul>" + "".join(f"<li>{b}</li>" for b in buf) + "</ul>")
+            continue
+        if re.match(r"^\s*\d+\.\s+", line):
+            buf = []
+            while i < n and re.match(r"^\s*\d+\.\s+", lines[i]):
+                buf.append(inline(re.sub(r"^\s*\d+\.\s+", "", lines[i])))
+                i += 1
+            out.append("<ol>" + "".join(f"<li>{b}</li>" for b in buf) + "</ol>")
+            continue
+        if not line.strip():
+            i += 1
+            continue
+        buf = [line]
+        i += 1
+        while (
+            i < n
+            and lines[i].strip()
+            and not re.match(r"^(#{1,4}\s|>|\s*[-*]\s|\s*\d+\.\s|```|---+\s*$)", lines[i])
+            and not lines[i].strip().startswith("|")
+        ):
+            buf.append(lines[i])
+            i += 1
+        para = inline(" ".join(b.strip() for b in buf))
+        cls = ' class="note"' if para.startswith("<em>Accuracy note") or para.startswith("<em>(") else ""
+        out.append(f"<p{cls}>{para}</p>")
+    return "\n".join(out)
+
+
+NAV = '''<nav>
+  <div class="wrap">
+    <a class="brand" href="/"><img src="../images/logo.webp" alt="">taskyou</a>
+    <div class="navlinks">
+      <a class="desktop-only" href="/#how">How it works</a>
+      <a class="desktop-only" href="/#features">Features</a>
+      <a class="active" href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="/#install" class="btn btn-primary">Install ↓</a>
+    </div>
+  </div>
+</nav>'''
+
+FOOTER = '''<footer>
+  <div class="wrap">
+    <span class="fbrand"><img src="../images/logo.webp" alt="">taskyou</span>
+    <span class="flinks">
+      <a href="/">Home</a>
+      <a href="/compare/">Compare</a>
+      <a href="https://github.com/bborn/taskyou">GitHub</a>
+      <a href="https://github.com/bborn/taskyou#readme">Docs</a>
+    </span>
+  </div>
+</footer>'''
+
+TEMPLATE = '''<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{title} — TaskYou</title>
+<meta name="description" content="{desc}">
+<link rel="icon" href="../images/logo.webp">
+<meta property="og:title" content="{title} — TaskYou">
+<meta property="og:description" content="{desc}">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="compare.css">
+</head>
+<body>
+<div class="grid-bg"></div>
+{nav}
+<section class="body">
+  <div class="wrap prose">
+{content}
+{pager}
+  </div>
+</section>
+{footer}
+</body>
+</html>
+'''
+
+
+def pager(slug):
+    links = ['<a href="/compare/">← All comparisons</a>']
+    if slug != "index":
+        links.append('<a href="/">taskyou.dev →</a>')
+    return '<div class="pager">' + "".join(links) + "</div>"
+
+
+def main():
+    for slug, (title, _short) in PAGES.items():
+        md = (SRC / f"{slug}.md").read_text()
+        dm = re.search(r"\*\*One line:\*\*\s*(.+)", md)
+        desc = re.sub(r"[*_`]", "", dm.group(1)).strip() if dm else "TaskYou is an autonomy-first task orchestrator for coding agents."
+        desc = html.escape(desc[:180], quote=True)
+        page = TEMPLATE.format(
+            title=html.escape(title), desc=desc, nav=NAV, content=convert(md), pager=pager(slug), footer=FOOTER
+        )
+        (OUT / f"{slug}.html").write_text(page)
+        print("wrote", (OUT / f"{slug}.html").relative_to(ROOT))
+    print("done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A competitive **positioning teardown** plus a drafted **/compare** section for taskyou.dev — Markdown source under `docs/marketing/`, rendered to styled HTML under `docs/compare/`. Docs/writing only; no product code changes.

## Live preview (Cloudflare Pages)

Deployed to a **standalone preview project** — production `taskyou.dev` is untouched:

**▶ https://taskyou-compare-preview.pages.dev/compare/**

- [Compare index + capability matrix](https://taskyou-compare-preview.pages.dev/compare/)
- [vs tmux / Zellij](https://taskyou-compare-preview.pages.dev/compare/taskyou-vs-tmux)
- [vs Conductor / Emdash / Superset](https://taskyou-compare-preview.pages.dev/compare/taskyou-vs-conductor-emdash-superset)
- [vs cmux / Warp](https://taskyou-compare-preview.pages.dev/compare/taskyou-vs-cmux-warp)

(The landing page is also on the preview root so you can see the new **Compare** nav link in context.)

## QA screenshots

Status marks are crisp monospace glyphs (`✓` / `✕` / `◐`) in the theme palette — not OS color emoji — and each value cell renders the glyph centered with its annotation as a small caption beneath, so glyphs line up in a tidy grid instead of drifting with annotation length.

![capability matrix — aligned glyph grid](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-06-25/617v3-index-fixed-layout.png)
![vs cmux / Warp detail](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-06-25/617v3-cmux-fixed-layout.png)

## Deliverables

- **`docs/marketing/positioning-memo.md`** — the teardown + recommendations: where our marketing lives, what the best-positioned tools in the category do well, where TaskYou honestly wins (**autonomy** — queue + background execution + worktree-per-task + PR-aware completion; plus **multi-surface distribution**: TUI · web · desktop · email · SSH · Chrome), and a sharpened category line — *"autonomy-first task orchestrator for coding agents."*
- **`docs/marketing/compare/*.md`** — comparison drafts (Markdown source of truth), each leading with what TaskYou **is** and fair about where a rival wins at its own job: capability matrix, vs tmux/Zellij, vs Conductor/Emdash/Superset, vs cmux/Warp.
- **`docs/compare/*.html` + `compare.css`** — the same pages rendered in the landing-page style; **Compare** link added to the nav. Generated by `scripts/gen-compare-pages.py` (re-run after editing the Markdown).

## Accuracy

Every TaskYou capability asserted maps to a shipped feature in `README.md` or an `extensions/ty-*` README. Executor-specific caveats (e.g. session resumption is Claude/Pi/OpenClaw only) are flagged. Each page also names where a competitor genuinely wins at its own job.

## Open questions for review

1. **Publish target** — these render under `docs/compare/` so they ship to taskyou.dev as-is, or move to a separate public-site repo if one exists.
2. **Sign-off on the comparison axes** (capability-matrix rows) — these become the terms of every future comparison.
3. The hero/tagline tweak (memo §4) is intentionally a **separate** ~10-line change to `docs/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
