### PR TITLE
feat(timeline): agent activity timeline panel for a task

### DIFF
--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -1,5 +1,7 @@
 package db
 
+import "encoding/json"
+
 // EventEmitter is an interface for emitting task events.
 // This allows the DB to emit events without depending on the events package.
 type EventEmitter interface {
@@ -17,11 +19,36 @@ type EventEmitter interface {
 // reads MAX(id) to detect that the board changed), so it runs on every task
 // mutation regardless of whether a hook emitter is configured.
 func (db *DB) recordEvent(eventType string, taskID int64, message string) {
+	db.recordEventMeta(eventType, taskID, message, "{}")
+}
+
+// recordEventMeta is like recordEvent but persists a JSON metadata blob
+// alongside the event. The metadata is what the activity timeline reads to
+// render rich labels (e.g. a status transition's old/new values). An empty
+// string is normalized to "{}" so the column always holds valid JSON.
+func (db *DB) recordEventMeta(eventType string, taskID int64, message, metadata string) {
+	if metadata == "" {
+		metadata = "{}"
+	}
 	// Best-effort: a failed event write must never fail the mutation itself.
 	_, _ = db.Exec(`
 		INSERT INTO event_log (event_type, task_id, message, metadata)
-		VALUES (?, ?, ?, '')
-	`, eventType, taskID, message)
+		VALUES (?, ?, ?, ?)
+	`, eventType, taskID, message, metadata)
+}
+
+// marshalEventMetadata serializes a changes map for storage in event_log. It
+// never returns an error: on failure it falls back to "{}" so event recording
+// (which is best-effort) is never blocked by a bad value.
+func marshalEventMetadata(changes map[string]interface{}) string {
+	if len(changes) == 0 {
+		return "{}"
+	}
+	b, err := json.Marshal(changes)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
 }
 
 // SetEventEmitter sets the event emitter for this database.
@@ -40,7 +67,7 @@ func (db *DB) emitTaskCreated(task *Task) {
 
 // emitTaskUpdated emits a task updated event if an emitter is configured.
 func (db *DB) emitTaskUpdated(task *Task, changes map[string]interface{}) {
-	db.recordEvent("task.updated", task.ID, task.Title)
+	db.recordEventMeta("task.updated", task.ID, task.Title, marshalEventMetadata(changes))
 	if db.eventEmitter != nil {
 		db.eventEmitter.EmitTaskUpdated(task, changes)
 	}

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -1022,6 +1022,10 @@ func (db *DB) RetryTask(id int64, feedback string) error {
 		// The executor will still handle duplicates via name-based cleanup
 	}
 
+	// Record a distinct retry event so the activity timeline can show it
+	// separately from an ordinary re-queue transition.
+	db.recordEvent("task.retry", id, feedback)
+
 	// Re-queue the task
 	return db.UpdateTaskStatus(id, StatusQueued)
 }

--- a/internal/db/timeline.go
+++ b/internal/db/timeline.go
@@ -54,6 +54,13 @@ func (db *DB) GetTaskTimeline(taskID int64, limit int) ([]TaskTimelineEntry, err
 		if err := rows.Scan(&id, &eventType, &message, &metadata, &createdAt); err != nil {
 			return nil, fmt.Errorf("scan timeline row: %w", err)
 		}
+		// The blocked/completed lifecycle events are emitted alongside the
+		// status-transition task.updated row (e.g. "processing → done"), so
+		// surfacing both would double every block/finish at the same second.
+		// Drop the redundant lifecycle row and keep the richer transition.
+		if isRedundantLifecycleEvent(eventType, message) {
+			continue
+		}
 		label, detail := timelineLabel(eventType, message, metadata)
 		entries = append(entries, TaskTimelineEntry{
 			ID:        id,
@@ -67,6 +74,21 @@ func (db *DB) GetTaskTimeline(taskID int64, limit int) ([]TaskTimelineEntry, err
 		return nil, fmt.Errorf("iterate timeline rows: %w", err)
 	}
 	return entries, nil
+}
+
+// isRedundantLifecycleEvent reports whether an event is a bare lifecycle marker
+// that duplicates a status-transition task.updated row. task.completed is always
+// redundant with a "… → done" transition; task.blocked is redundant only when it
+// carries the generic "status change" reason (a real reason is kept).
+func isRedundantLifecycleEvent(eventType, message string) bool {
+	switch eventType {
+	case "task.completed":
+		return true
+	case "task.blocked":
+		return message == "" || message == "status change"
+	default:
+		return false
+	}
 }
 
 // timelineLabel maps a raw event_log row into a short label and optional detail

--- a/internal/db/timeline.go
+++ b/internal/db/timeline.go
@@ -1,0 +1,157 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TaskTimelineEntry is a single chronological entry in a task's activity
+// timeline, derived from a row in the event_log table. It carries a short,
+// human-readable Label (e.g. "queued → processing") plus the raw event type
+// and timestamp so callers can render a compact lifecycle view.
+type TaskTimelineEntry struct {
+	ID        int64     `json:"id"`
+	EventType string    `json:"event_type"`
+	Label     string    `json:"label"`
+	Detail    string    `json:"detail,omitempty"`
+	CreatedAt LocalTime `json:"created_at"`
+}
+
+// GetTaskTimeline returns a task's activity timeline in chronological order
+// (oldest first), built from the event_log. limit caps the number of rows; a
+// non-positive limit defaults to 200. The newest `limit` events are selected
+// but returned oldest-first so the timeline reads top-to-bottom.
+func (db *DB) GetTaskTimeline(taskID int64, limit int) ([]TaskTimelineEntry, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+
+	rows, err := db.Query(`
+		SELECT id, event_type, COALESCE(message, ''), COALESCE(metadata, '{}'), created_at
+		FROM (
+			SELECT id, event_type, message, metadata, created_at
+			FROM event_log
+			WHERE task_id = ?
+			ORDER BY created_at DESC, id DESC
+			LIMIT ?
+		)
+		ORDER BY created_at ASC, id ASC
+	`, taskID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query task timeline: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []TaskTimelineEntry
+	for rows.Next() {
+		var (
+			id        int64
+			eventType string
+			message   string
+			metadata  string
+			createdAt LocalTime
+		)
+		if err := rows.Scan(&id, &eventType, &message, &metadata, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan timeline row: %w", err)
+		}
+		label, detail := timelineLabel(eventType, message, metadata)
+		entries = append(entries, TaskTimelineEntry{
+			ID:        id,
+			EventType: eventType,
+			Label:     label,
+			Detail:    detail,
+			CreatedAt: createdAt,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate timeline rows: %w", err)
+	}
+	return entries, nil
+}
+
+// timelineLabel maps a raw event_log row into a short label and optional detail
+// suitable for the activity timeline. It understands the status-transition
+// metadata that emitTaskUpdated records so a re-queue/processing/blocked/done
+// change renders as e.g. "queued → processing".
+func timelineLabel(eventType, message, metadata string) (label, detail string) {
+	switch eventType {
+	case "task.created":
+		return "Created", message
+	case "task.completed":
+		return "Completed", ""
+	case "task.blocked":
+		// reason is carried in the message; "status change" is the generic
+		// transition reason and adds nothing, so suppress it as detail.
+		if message != "" && message != "status change" {
+			return "Blocked", message
+		}
+		return "Blocked", ""
+	case "task.retry":
+		return "Retried", message
+	case "task.deleted":
+		return "Deleted", ""
+	case "task.updated":
+		if from, to, ok := statusTransition(metadata); ok {
+			return fmt.Sprintf("%s → %s", from, to), ""
+		}
+		// A non-status update (title/body/etc). Name the changed fields if we
+		// can so the entry is meaningful rather than a bare "Updated".
+		if fields := changedFields(metadata); fields != "" {
+			return "Updated", fields
+		}
+		return "Updated", ""
+	default:
+		// Unknown event type: fall back to the raw type as the label.
+		return eventType, message
+	}
+}
+
+// statusTransition extracts old/new status values from an event_log metadata
+// blob of the form {"status":{"old":"queued","new":"processing"}}.
+func statusTransition(metadata string) (from, to string, ok bool) {
+	if metadata == "" || metadata == "{}" {
+		return "", "", false
+	}
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(metadata), &parsed); err != nil {
+		return "", "", false
+	}
+	raw, exists := parsed["status"]
+	if !exists {
+		return "", "", false
+	}
+	var change struct {
+		Old string `json:"old"`
+		New string `json:"new"`
+	}
+	if err := json.Unmarshal(raw, &change); err != nil {
+		return "", "", false
+	}
+	if change.Old == "" && change.New == "" {
+		return "", "", false
+	}
+	return change.Old, change.New, true
+}
+
+// changedFields returns a comma-separated list of the top-level keys present in
+// a changes metadata blob (excluding status, which is handled separately).
+func changedFields(metadata string) string {
+	if metadata == "" || metadata == "{}" {
+		return ""
+	}
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(metadata), &parsed); err != nil {
+		return ""
+	}
+	var fields string
+	for k := range parsed {
+		if k == "status" {
+			continue
+		}
+		if fields != "" {
+			fields += ", "
+		}
+		fields += k
+	}
+	return fields
+}

--- a/internal/db/timeline_test.go
+++ b/internal/db/timeline_test.go
@@ -65,15 +65,91 @@ func TestGetTaskTimelineChronological(t *testing.T) {
 		t.Errorf("expected a 'queued → processing' transition entry; got %+v", labels(entries))
 	}
 
-	// The terminal completion must be present.
-	var sawCompleted bool
+	// The terminal completion is represented by the "processing → done"
+	// transition; the redundant bare task.completed/task.blocked lifecycle rows
+	// are suppressed so each finish/block appears once.
+	var sawDoneTransition bool
 	for _, e := range entries {
-		if e.EventType == "task.completed" {
-			sawCompleted = true
+		if e.Label == "blocked → done" {
+			sawDoneTransition = true
+		}
+		if e.EventType == "task.completed" || e.EventType == "task.blocked" {
+			t.Errorf("redundant lifecycle event %s should be suppressed", e.EventType)
 		}
 	}
-	if !sawCompleted {
-		t.Errorf("expected a task.completed entry; got %+v", labels(entries))
+	if !sawDoneTransition {
+		t.Errorf("expected a 'blocked → done' transition entry; got %+v", labels(entries))
+	}
+}
+
+func TestGetTaskTimelineSuppressesRedundantLifecycle(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	task := &Task{Title: "Lifecycle Task", Status: StatusProcessing, Project: "personal"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	// processing -> blocked emits task.updated + task.blocked; blocked -> done
+	// emits task.updated + task.completed. Only the transitions should survive.
+	if err := database.UpdateTaskStatus(task.ID, StatusBlocked); err != nil {
+		t.Fatalf("block: %v", err)
+	}
+	if err := database.UpdateTaskStatus(task.ID, StatusDone); err != nil {
+		t.Fatalf("done: %v", err)
+	}
+
+	entries, err := database.GetTaskTimeline(task.ID, 0)
+	if err != nil {
+		t.Fatalf("get timeline: %v", err)
+	}
+
+	counts := map[string]int{}
+	for _, e := range entries {
+		counts[e.EventType]++
+	}
+	if counts["task.blocked"] != 0 {
+		t.Errorf("expected task.blocked to be suppressed, found %d", counts["task.blocked"])
+	}
+	if counts["task.completed"] != 0 {
+		t.Errorf("expected task.completed to be suppressed, found %d", counts["task.completed"])
+	}
+
+	var sawBlockedTransition, sawDoneTransition bool
+	for _, e := range entries {
+		switch e.Label {
+		case "processing → blocked":
+			sawBlockedTransition = true
+		case "blocked → done":
+			sawDoneTransition = true
+		}
+	}
+	if !sawBlockedTransition {
+		t.Errorf("expected 'processing → blocked' transition; got %+v", labels(entries))
+	}
+	if !sawDoneTransition {
+		t.Errorf("expected 'blocked → done' transition; got %+v", labels(entries))
+	}
+}
+
+func TestIsRedundantLifecycleEvent(t *testing.T) {
+	cases := []struct {
+		eventType string
+		message   string
+		want      bool
+	}{
+		{"task.completed", "anything", true},
+		{"task.blocked", "status change", true},
+		{"task.blocked", "", true},
+		{"task.blocked", "needs human input", false},
+		{"task.updated", "", false},
+		{"task.created", "", false},
+		{"task.retry", "", false},
+	}
+	for _, tc := range cases {
+		if got := isRedundantLifecycleEvent(tc.eventType, tc.message); got != tc.want {
+			t.Errorf("isRedundantLifecycleEvent(%q,%q)=%v want %v", tc.eventType, tc.message, got, tc.want)
+		}
 	}
 }
 

--- a/internal/db/timeline_test.go
+++ b/internal/db/timeline_test.go
@@ -1,0 +1,205 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestGetTaskTimelineChronological(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	task := &Task{
+		Title:   "Timeline Task",
+		Body:    "body",
+		Status:  StatusBacklog,
+		Project: "personal",
+	}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	// Drive a realistic lifecycle: queued -> processing -> blocked -> done.
+	transitions := []string{StatusQueued, StatusProcessing, StatusBlocked, StatusDone}
+	for _, s := range transitions {
+		if err := database.UpdateTaskStatus(task.ID, s); err != nil {
+			t.Fatalf("update status %s: %v", s, err)
+		}
+	}
+
+	entries, err := database.GetTaskTimeline(task.ID, 0)
+	if err != nil {
+		t.Fatalf("get timeline: %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatal("expected timeline entries, got none")
+	}
+
+	// First entry must be the creation event.
+	if entries[0].EventType != "task.created" {
+		t.Errorf("expected first entry task.created, got %s", entries[0].EventType)
+	}
+	if entries[0].Label != "Created" {
+		t.Errorf("expected first label 'Created', got %q", entries[0].Label)
+	}
+
+	// Entries must be chronologically non-decreasing.
+	for i := 1; i < len(entries); i++ {
+		if entries[i].CreatedAt.Time.Before(entries[i-1].CreatedAt.Time) {
+			t.Errorf("entries out of order at %d: %v before %v",
+				i, entries[i].CreatedAt.Time, entries[i-1].CreatedAt.Time)
+		}
+		if entries[i].CreatedAt.Time.IsZero() {
+			t.Errorf("entry %d has zero timestamp", i)
+		}
+	}
+
+	// A status transition entry must carry an arrow label.
+	var sawTransition bool
+	for _, e := range entries {
+		if e.Label == "queued → processing" {
+			sawTransition = true
+		}
+	}
+	if !sawTransition {
+		t.Errorf("expected a 'queued → processing' transition entry; got %+v", labels(entries))
+	}
+
+	// The terminal completion must be present.
+	var sawCompleted bool
+	for _, e := range entries {
+		if e.EventType == "task.completed" {
+			sawCompleted = true
+		}
+	}
+	if !sawCompleted {
+		t.Errorf("expected a task.completed entry; got %+v", labels(entries))
+	}
+}
+
+func TestGetTaskTimelineRetry(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	task := &Task{Title: "Retry Task", Status: StatusBlocked, Project: "personal"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	if err := database.RetryTask(task.ID, "try again differently"); err != nil {
+		t.Fatalf("retry task: %v", err)
+	}
+
+	entries, err := database.GetTaskTimeline(task.ID, 0)
+	if err != nil {
+		t.Fatalf("get timeline: %v", err)
+	}
+
+	var retry *TaskTimelineEntry
+	for i := range entries {
+		if entries[i].EventType == "task.retry" {
+			retry = &entries[i]
+		}
+	}
+	if retry == nil {
+		t.Fatalf("expected a task.retry entry; got %+v", labels(entries))
+	}
+	if retry.Label != "Retried" {
+		t.Errorf("expected label 'Retried', got %q", retry.Label)
+	}
+	if retry.Detail != "try again differently" {
+		t.Errorf("expected retry feedback in detail, got %q", retry.Detail)
+	}
+}
+
+func TestGetTaskTimelineLimit(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	task := &Task{Title: "Limit Task", Status: StatusBacklog, Project: "personal"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	// Generate several status flips to produce many events.
+	flips := []string{StatusQueued, StatusBacklog, StatusQueued, StatusBacklog, StatusQueued}
+	for _, s := range flips {
+		if err := database.UpdateTaskStatus(task.ID, s); err != nil {
+			t.Fatalf("update status: %v", err)
+		}
+	}
+
+	entries, err := database.GetTaskTimeline(task.ID, 2)
+	if err != nil {
+		t.Fatalf("get timeline: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries with limit=2, got %d", len(entries))
+	}
+	// With a limit, we keep the newest events but still return them oldest-first.
+	if entries[0].CreatedAt.Time.After(entries[1].CreatedAt.Time) {
+		t.Errorf("limited entries not in chronological order")
+	}
+}
+
+func TestGetTaskTimelineEmpty(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	entries, err := database.GetTaskTimeline(99999, 0)
+	if err != nil {
+		t.Fatalf("get timeline for missing task: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected no entries for unknown task, got %d", len(entries))
+	}
+}
+
+func TestTimelineLabel(t *testing.T) {
+	cases := []struct {
+		name       string
+		eventType  string
+		message    string
+		metadata   string
+		wantLabel  string
+		wantDetail string
+	}{
+		{"created", "task.created", "My Task", "{}", "Created", "My Task"},
+		{"completed", "task.completed", "My Task", "{}", "Completed", ""},
+		{"blocked generic", "task.blocked", "status change", "{}", "Blocked", ""},
+		{"blocked reason", "task.blocked", "needs input", "{}", "Blocked", "needs input"},
+		{"retry", "task.retry", "do over", "{}", "Retried", "do over"},
+		{
+			"status transition",
+			"task.updated", "My Task",
+			`{"status":{"old":"queued","new":"processing"}}`,
+			"queued → processing", "",
+		},
+		{
+			"field update",
+			"task.updated", "My Task",
+			`{"title":{"old":"a","new":"b"}}`,
+			"Updated", "title",
+		},
+		{"bare update", "task.updated", "My Task", "{}", "Updated", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			label, detail := timelineLabel(tc.eventType, tc.message, tc.metadata)
+			if label != tc.wantLabel {
+				t.Errorf("label: got %q want %q", label, tc.wantLabel)
+			}
+			if detail != tc.wantDetail {
+				t.Errorf("detail: got %q want %q", detail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func labels(entries []TaskTimelineEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Label
+	}
+	return out
+}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -141,12 +141,18 @@ type DetailModel struct {
 	glamourRendererUnfocused *glamour.TermRenderer
 	glamourWidth             int // Width the renderers were created for
 
+	// Activity timeline (task lifecycle events from the event_log), refreshed
+	// on the periodic Refresh() tick so it updates live as new events land.
+	timeline         []db.TaskTimelineEntry
+	lastTimelineHash uint64
+
 	// Content caching to avoid unnecessary re-renders
-	lastRenderedBody    string
-	lastRenderedSummary string
-	lastRenderedLogHash uint64
-	lastRenderedFocused bool
-	cachedContent       string
+	lastRenderedBody         string
+	lastRenderedSummary      string
+	lastRenderedLogHash      uint64
+	lastRenderedTimelineHash uint64
+	lastRenderedFocused      bool
+	cachedContent            string
 
 	// View render cache. View() runs on every Bubble Tea update while the detail
 	// view is open (focus ticks, polls, pane events), but its pixels only change
@@ -465,6 +471,19 @@ func (m *DetailModel) Refresh() tea.Cmd {
 		}
 	}
 
+	// Refresh the activity timeline. The query is small (bounded, indexed by
+	// task_id), so we reload it here and only re-render when it actually changed
+	// — this is what makes the timeline update live as new events land.
+	if timeline, tlErr := m.database.GetTaskTimeline(m.task.ID, 100); tlErr == nil {
+		if h := timelineHash(timeline); h != m.lastTimelineHash {
+			m.timeline = timeline
+			m.lastTimelineHash = h
+			if m.ready {
+				m.setViewportContent()
+			}
+		}
+	}
+
 	// Check log count first to avoid loading all logs if unchanged.
 	// Load logs asynchronously to avoid blocking the UI event loop.
 	var cmd tea.Cmd
@@ -580,6 +599,13 @@ func NewDetailModel(t *db.Task, database *db.DB, exec *executor.Executor, width,
 	// Load logs
 	logs, _ := database.GetTaskLogs(t.ID, 100)
 	m.logs = logs
+
+	// Load the activity timeline so it paints immediately; later events arrive
+	// via the periodic Refresh() tick.
+	if timeline, err := database.GetTaskTimeline(t.ID, 100); err == nil {
+		m.timeline = timeline
+		m.lastTimelineHash = timelineHash(timeline)
+	}
 
 	m.initViewport()
 
@@ -2804,10 +2830,12 @@ func (m *DetailModel) renderContent() string {
 	// Check if we can use cached content
 	// Note: We don't cache when related tasks are loading/changing
 	logHash := m.computeLogHash()
+	tlHash := m.lastTimelineHash
 	if m.cachedContent != "" &&
 		m.lastRenderedBody == t.Body &&
 		m.lastRenderedSummary == t.Summary &&
 		m.lastRenderedLogHash == logHash &&
+		m.lastRenderedTimelineHash == tlHash &&
 		m.lastRenderedFocused == m.focused &&
 		!m.relatedTasksLoading {
 		return m.cachedContent
@@ -2963,6 +2991,14 @@ func (m *DetailModel) renderContent() string {
 		}
 	}
 
+	// Activity timeline (task lifecycle from the event_log)
+	if len(m.timeline) > 0 {
+		b.WriteString("\n")
+		b.WriteString(Bold.Render("Activity Timeline"))
+		b.WriteString("\n\n")
+		b.WriteString(m.renderTimeline(dimmedStyle))
+	}
+
 	// Execution logs
 	if len(m.logs) > 0 {
 		b.WriteString("\n")
@@ -3018,10 +3054,66 @@ func (m *DetailModel) renderContent() string {
 	m.lastRenderedBody = t.Body
 	m.lastRenderedSummary = t.Summary
 	m.lastRenderedLogHash = logHash
+	m.lastRenderedTimelineHash = tlHash
 	m.lastRenderedFocused = m.focused
 	m.cachedContent = content
 
 	return content
+}
+
+// timelineEventIcon maps an event type to a small glyph for the timeline.
+func timelineEventIcon(eventType string) string {
+	switch eventType {
+	case "task.created":
+		return "✨"
+	case "task.completed":
+		return "✅"
+	case "task.blocked":
+		return "⛔"
+	case "task.retry":
+		return "🔁"
+	case "task.deleted":
+		return "🗑️"
+	default: // task.updated and anything else
+		return "•"
+	}
+}
+
+// renderTimeline renders the activity timeline entries as a compact, chronological
+// list with real timestamps and short labels.
+func (m *DetailModel) renderTimeline(dimmedStyle lipgloss.Style) string {
+	var b strings.Builder
+	for _, e := range m.timeline {
+		icon := timelineEventIcon(e.EventType)
+		ts := e.CreatedAt.Time.Format("Jan 2 15:04:05")
+		label := e.Label
+		if e.Detail != "" {
+			label = fmt.Sprintf("%s — %s", label, e.Detail)
+		}
+		var line string
+		if m.focused {
+			line = fmt.Sprintf("%s %s %s", Dim.Render(ts), icon, label)
+		} else {
+			line = fmt.Sprintf("%s %s %s", dimmedStyle.Render(ts), icon, dimmedStyle.Render(label))
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// timelineHash is a fast change-detection proxy for the activity timeline: the
+// entry count combined with the newest entry's id. New events always increase
+// the id, so any change flips the hash and triggers a re-render. The count is
+// multiplied by a prime before mixing so it can't cancel the id (for a single
+// task the ids are sequential and a plain XOR would collide to zero).
+func timelineHash(entries []db.TaskTimelineEntry) uint64 {
+	if len(entries) == 0 {
+		return 0
+	}
+	hash := uint64(len(entries)) * 1000003
+	hash ^= uint64(entries[len(entries)-1].ID)
+	return hash
 }
 
 func (m *DetailModel) renderHelp() string {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -3061,9 +3061,11 @@ func (m *DetailModel) renderContent() string {
 	return content
 }
 
-// timelineEventIcon maps an event type to a small glyph for the timeline.
-func timelineEventIcon(eventType string) string {
-	switch eventType {
+// timelineEntryIcon maps a timeline entry to a small glyph. Status transitions
+// (task.updated rows labeled "old → new") are keyed off their target status so a
+// finish shows ✅, a block ⛔, etc; other events key off their type.
+func timelineEntryIcon(e db.TaskTimelineEntry) string {
+	switch e.EventType {
 	case "task.created":
 		return "✨"
 	case "task.completed":
@@ -3074,7 +3076,24 @@ func timelineEventIcon(eventType string) string {
 		return "🔁"
 	case "task.deleted":
 		return "🗑️"
-	default: // task.updated and anything else
+	case "task.updated":
+		// Pick an icon from the transition target, e.g. "queued → processing".
+		if idx := strings.LastIndex(e.Label, "→ "); idx >= 0 {
+			switch strings.TrimSpace(e.Label[idx+len("→ "):]) {
+			case db.StatusDone, db.StatusArchived:
+				return "✅"
+			case db.StatusBlocked:
+				return "⛔"
+			case db.StatusProcessing:
+				return "⚙️"
+			case db.StatusQueued:
+				return "⏳"
+			case db.StatusBacklog:
+				return "📋"
+			}
+		}
+		return "•"
+	default:
 		return "•"
 	}
 }
@@ -3084,7 +3103,7 @@ func timelineEventIcon(eventType string) string {
 func (m *DetailModel) renderTimeline(dimmedStyle lipgloss.Style) string {
 	var b strings.Builder
 	for _, e := range m.timeline {
-		icon := timelineEventIcon(e.EventType)
+		icon := timelineEntryIcon(e)
 		ts := e.CreatedAt.Time.Format("Jan 2 15:04:05")
 		label := e.Label
 		if e.Detail != "" {

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -580,3 +580,48 @@ func TestContainsSourceFiles(t *testing.T) {
 		})
 	}
 }
+
+// TestDetailTimelineRendersAndUpdatesLive verifies the Activity Timeline section
+// appears in the detail content with real lifecycle entries, and that new events
+// landing in the event_log are picked up live on Refresh().
+func TestDetailTimelineRendersAndUpdatesLive(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "timeline.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	task := &db.Task{Title: "Timeline UI Task", Status: db.StatusBacklog, Body: "body"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := database.UpdateTaskStatus(task.ID, db.StatusQueued); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	m, _ := NewDetailModel(task, database, nil, 160, 50, false)
+
+	content := m.renderContent()
+	if !strings.Contains(content, "Activity Timeline") {
+		t.Fatalf("expected Activity Timeline section in detail content:\n%s", content)
+	}
+	if !strings.Contains(content, "Created") {
+		t.Error("expected a 'Created' timeline entry")
+	}
+	if !strings.Contains(content, "queued") {
+		t.Error("expected the queued transition to appear in the timeline")
+	}
+
+	// A new lifecycle event should be reflected after Refresh().
+	beforeHash := m.lastTimelineHash
+	if err := database.UpdateTaskStatus(task.ID, db.StatusProcessing); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+	m.Refresh()
+	if m.lastTimelineHash == beforeHash {
+		t.Error("expected timeline hash to change after a new event landed")
+	}
+	if !strings.Contains(m.renderContent(), "processing") {
+		t.Error("expected the processing transition to appear after live refresh")
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -1003,6 +1003,58 @@ func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, events)
 }
 
+// --- Timeline ---
+
+// timelineEntryJSON is the wire form of a db.TaskTimelineEntry, with the
+// timestamp rendered as a real UTC RFC3339 string (matching the rest of the API).
+type timelineEntryJSON struct {
+	ID        int64  `json:"id"`
+	EventType string `json:"event_type"`
+	Label     string `json:"label"`
+	Detail    string `json:"detail,omitempty"`
+	CreatedAt string `json:"created_at"`
+}
+
+func toTimelineJSON(e db.TaskTimelineEntry) timelineEntryJSON {
+	return timelineEntryJSON{
+		ID:        e.ID,
+		EventType: e.EventType,
+		Label:     e.Label,
+		Detail:    e.Detail,
+		CreatedAt: apiTime(e.CreatedAt.Time),
+	}
+}
+
+// handleTaskTimeline returns a task's chronological activity timeline, built
+// from the event_log: state transitions, retries, blocks, and completion with
+// real timestamps and short labels.
+func (s *Server) handleTaskTimeline(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		jsonErr(w, "invalid task id", http.StatusBadRequest)
+		return
+	}
+
+	limit := 0 // GetTaskTimeline applies its own default
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	entries, err := s.db.GetTaskTimeline(id, limit)
+	if err != nil {
+		jsonErr(w, "failed to query timeline", http.StatusInternalServerError)
+		return
+	}
+
+	out := make([]timelineEntryJSON, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, toTimelineJSON(e))
+	}
+	jsonOK(w, out)
+}
+
 // --- Status ---
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -99,6 +99,7 @@ func New(cfg Config) *Server {
 
 	// Task logs, streaming, executor output & terminal
 	mux.HandleFunc("GET /api/tasks/{id}/logs", s.handleTaskLogs)
+	mux.HandleFunc("GET /api/tasks/{id}/timeline", s.handleTaskTimeline)
 	mux.HandleFunc("GET /api/tasks/{id}/stream", s.handleTaskStream)
 	mux.HandleFunc("GET /api/tasks/{id}/output", s.handleTaskOutput)
 	mux.HandleFunc("GET /api/tasks/{id}/terminal", s.handleTerminal)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bborn/workflow/internal/db"
 )
@@ -596,6 +598,73 @@ func TestHandleListEvents(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandleTaskTimeline(t *testing.T) {
+	srv, database, _ := setupServer(t)
+
+	task := &db.Task{Title: "Timeline Web Task", Status: db.StatusBacklog, Project: "personal"}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := database.UpdateTaskStatus(task.ID, db.StatusQueued); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+	if err := database.UpdateTaskStatus(task.ID, db.StatusProcessing); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/tasks/1/timeline", nil)
+	req.SetPathValue("id", strconv.FormatInt(task.ID, 10))
+	w := httptest.NewRecorder()
+	srv.handleTaskTimeline(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var entries []timelineEntryJSON
+	if err := json.NewDecoder(w.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected timeline entries, got none")
+	}
+	if entries[0].EventType != "task.created" {
+		t.Errorf("expected first entry task.created, got %s", entries[0].EventType)
+	}
+	// Every entry must carry a real, parseable UTC timestamp.
+	for i, e := range entries {
+		if e.CreatedAt == "" {
+			t.Errorf("entry %d missing created_at", i)
+		}
+		if _, err := time.Parse(time.RFC3339, e.CreatedAt); err != nil {
+			t.Errorf("entry %d created_at not RFC3339: %q", i, e.CreatedAt)
+		}
+	}
+	// The queued→processing transition should be present.
+	var sawTransition bool
+	for _, e := range entries {
+		if e.Label == "queued → processing" {
+			sawTransition = true
+		}
+	}
+	if !sawTransition {
+		t.Error("expected a 'queued → processing' entry in web timeline")
+	}
+}
+
+func TestHandleTaskTimeline_InvalidID(t *testing.T) {
+	srv, _, _ := setupServer(t)
+
+	req := httptest.NewRequest("GET", "/api/tasks/abc/timeline", nil)
+	req.SetPathValue("id", "abc")
+	w := httptest.NewRecorder()
+	srv.handleTaskTimeline(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }
 

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -42,6 +42,14 @@ func (s *Server) handleTaskStream(w http.ResponseWriter, r *http.Request) {
 	heartbeat := time.NewTicker(15 * time.Second)
 	defer heartbeat.Stop()
 
+	// Track the newest activity-timeline event we've already streamed so we only
+	// push new lifecycle events. Clients fetch the initial timeline via the REST
+	// endpoint, so we start from the current max and stream forward from there.
+	var lastTimelineID int64
+	if entries, err := s.db.GetTaskTimeline(id, 1); err == nil && len(entries) > 0 {
+		lastTimelineID = entries[len(entries)-1].ID
+	}
+
 	ctx := r.Context()
 	for {
 		select {
@@ -71,8 +79,34 @@ func (s *Server) handleTaskStream(w http.ResponseWriter, r *http.Request) {
 			if len(logs) > 0 {
 				flusher.Flush()
 			}
+
+			// Stream any new activity-timeline events.
+			lastTimelineID = s.streamTimelineSince(w, flusher, id, lastTimelineID)
 		}
 	}
+}
+
+// streamTimelineSince writes any timeline entries newer than lastID as SSE
+// "timeline" events and returns the new high-water mark.
+func (s *Server) streamTimelineSince(w http.ResponseWriter, flusher http.Flusher, taskID, lastID int64) int64 {
+	entries, err := s.db.GetTaskTimeline(taskID, 200)
+	if err != nil {
+		return lastID
+	}
+	var wrote bool
+	for _, e := range entries {
+		if e.ID <= lastID {
+			continue
+		}
+		data, _ := json.Marshal(toTimelineJSON(e))
+		fmt.Fprintf(w, "event: timeline\ndata: %s\n\n", data)
+		lastID = e.ID
+		wrote = true
+	}
+	if wrote {
+		flusher.Flush()
+	}
+	return lastID
 }
 
 // handleBoardStream sends SSE events when the board changes.


### PR DESCRIPTION
## Summary

Gives a task a compact, chronological **activity timeline** of its lifecycle, built from the `event_log` and updating live via the existing SSE feed. Borrows the "agent state timeline" idea from herdr-insight.

A task now shows an accurate, ordered event timeline with real timestamps — state transitions (`queued → processing → blocked → done`), retries, blocks, and completion — that updates live as new events land.

## Changes

**`internal/db`**
- New `GetTaskTimeline(taskID, limit)` builds chronological (oldest-first) `TaskTimelineEntry` values from `event_log`, mapping each row to a short label (`Created`, `Completed`, `Blocked`, `Retried`, and `queued → processing` style transitions).
- Status changes now persist their `{old,new}` values in the `event_log` metadata column (`recordEventMeta` / `marshalEventMetadata`), so transition labels are accurate.
- `RetryTask` records a distinct `task.retry` event so retries are visible on the timeline.

**`internal/ui` (TUI detail view)**
- New **Activity Timeline** section in the detail view, each entry showing a real timestamp, an icon, and a short label.
- Reloaded on the periodic `Refresh()` tick and folded into the render cache key, so it updates live as events land (no manual reopen).

**`internal/web`**
- `GET /api/tasks/{id}/timeline` returns the timeline as JSON with real UTC timestamps.
- The existing per-task SSE stream now also emits `timeline` events as new lifecycle events occur, so the web detail page can update live.

## Tests
- `internal/db`: timeline builder (chronological order, transitions, retry, limit, empty) + label mapping table.
- `internal/web`: timeline endpoint (shape, RFC3339 timestamps, transition label) + invalid-id.
- `internal/ui`: timeline renders in detail content and updates live after a new event on `Refresh()`.

`go build ./...`, `go test` for the three touched packages, and `golangci-lint run` (v2.8.0) all pass.

## Follow-ups
- The web SPA (`internal/web/ui/dist`, built out-of-repo behind the `ui` build tag) needs a small frontend change to render the new endpoint/SSE `timeline` events; the backend API + stream are ready for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)