### PR TITLE
Tag-based scoping: TASK_TAGS in hook env + delimiter-safe ty list --tag filter

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -803,6 +803,7 @@ Examples:
 			status, _ := cmd.Flags().GetString("status")
 			project, _ := cmd.Flags().GetString("project")
 			taskType, _ := cmd.Flags().GetString("type")
+			tag, _ := cmd.Flags().GetString("tag")
 			all, _ := cmd.Flags().GetBool("all")
 			limit, _ := cmd.Flags().GetInt("limit")
 			outputJSON, _ := cmd.Flags().GetBool("json")
@@ -821,6 +822,7 @@ Examples:
 				Status:        status,
 				Project:       project,
 				Type:          taskType,
+				Tag:           tag,
 				Limit:         limit,
 				IncludeClosed: all,
 			}
@@ -959,6 +961,7 @@ Examples:
 	listCmd.Flags().StringP("status", "s", "", "Filter by status: backlog, queued, processing, blocked, done")
 	listCmd.Flags().StringP("project", "p", "", "Filter by project")
 	listCmd.Flags().StringP("type", "t", "", "Filter by type: code, writing, thinking")
+	listCmd.Flags().String("tag", "", "Filter by tag (exact match, e.g. gm:cortex)")
 	listCmd.Flags().BoolP("all", "a", false, "Include completed tasks")
 	listCmd.Flags().IntP("limit", "n", 50, "Maximum number of tasks to return")
 	listCmd.Flags().Bool("json", false, "Output in JSON format")

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -430,8 +430,14 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 		// Tags are stored comma-separated (e.g. "a,gm:cortex,b"). A naive
 		// LIKE '%gm:cortex%' would false-match "gm:cortex-2", so normalize the
 		// stored value to ",a,gm:cortex,b," and match the delimited ",tag,".
-		query += " AND (',' || REPLACE(COALESCE(tags, ''), ' ', '') || ',') LIKE ?"
-		args = append(args, "%,"+strings.ReplaceAll(opts.Tag, " ", "")+",%")
+		// Escape LIKE metacharacters (\, %, _) in the needle so a tag value
+		// containing them matches literally rather than as a wildcard pattern.
+		needle := strings.ReplaceAll(opts.Tag, " ", "")
+		needle = strings.ReplaceAll(needle, `\`, `\\`)
+		needle = strings.ReplaceAll(needle, "%", `\%`)
+		needle = strings.ReplaceAll(needle, "_", `\_`)
+		query += ` AND (',' || REPLACE(COALESCE(tags, ''), ' ', '') || ',') LIKE ? ESCAPE '\'`
+		args = append(args, "%,"+needle+",%")
 	}
 
 	// Exclude done and archived by default unless specifically querying for them or includeClosed is set

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -384,6 +384,7 @@ type ListTasksOptions struct {
 	Status         string
 	Type           string
 	Project        string
+	Tag            string // Filter to tasks carrying this exact tag (delimiter-safe; "gm:cortex" does not match "gm:cortex-2")
 	Limit          int
 	Offset         int
 	IncludeClosed  bool // Include closed tasks even when Status is empty
@@ -424,6 +425,13 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 		}
 		query += " AND project = ?"
 		args = append(args, projectName)
+	}
+	if opts.Tag != "" {
+		// Tags are stored comma-separated (e.g. "a,gm:cortex,b"). A naive
+		// LIKE '%gm:cortex%' would false-match "gm:cortex-2", so normalize the
+		// stored value to ",a,gm:cortex,b," and match the delimited ",tag,".
+		query += " AND (',' || REPLACE(COALESCE(tags, ''), ' ', '') || ',') LIKE ?"
+		args = append(args, "%,"+strings.ReplaceAll(opts.Tag, " ", "")+",%")
 	}
 
 	// Exclude done and archived by default unless specifically querying for them or includeClosed is set

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -2670,3 +2670,49 @@ func TestListTasksTagFilterDelimiterSafe(t *testing.T) {
 		t.Errorf("expected exactly 2 matching tasks, got %d", len(tasks))
 	}
 }
+
+func TestListTasksTagFilterEscapesLikeWildcards(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	database, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer database.Close()
+	defer os.Remove(dbPath)
+
+	if err := database.CreateProject(&Project{Name: "test", Path: tmpDir}); err != nil {
+		t.Fatalf("failed to create test project: %v", err)
+	}
+
+	// A tag value containing LIKE metacharacters must match literally, never
+	// as a wildcard. Without ESCAPE, "%" matches any run and "_" matches any
+	// single char, so the decoys below would false-match.
+	pct := &Task{Title: "pct", Status: StatusBacklog, Type: TypeCode, Project: "test", Tags: "gm:c%x"}
+	pctDecoy := &Task{Title: "pctDecoy", Status: StatusBacklog, Type: TypeCode, Project: "test", Tags: "gm:cZZZx"}
+	und := &Task{Title: "und", Status: StatusBacklog, Type: TypeCode, Project: "test", Tags: "gm:a_b"}
+	undDecoy := &Task{Title: "undDecoy", Status: StatusBacklog, Type: TypeCode, Project: "test", Tags: "gm:aXb"}
+
+	for _, tk := range []*Task{pct, pctDecoy, und, undDecoy} {
+		if err := database.CreateTask(tk); err != nil {
+			t.Fatalf("failed to create task %q: %v", tk.Title, err)
+		}
+	}
+
+	pctTasks, err := database.ListTasks(ListTasksOptions{Tag: "gm:c%x"})
+	if err != nil {
+		t.Fatalf("ListTasks with '%%' tag filter failed: %v", err)
+	}
+	if len(pctTasks) != 1 || pctTasks[0].ID != pct.ID {
+		t.Errorf("tag filter %q must match only the literal tag, got %d tasks", "gm:c%x", len(pctTasks))
+	}
+
+	undTasks, err := database.ListTasks(ListTasksOptions{Tag: "gm:a_b"})
+	if err != nil {
+		t.Fatalf("ListTasks with '_' tag filter failed: %v", err)
+	}
+	if len(undTasks) != 1 || undTasks[0].ID != und.ID {
+		t.Errorf("tag filter %q must match only the literal tag, got %d tasks", "gm:a_b", len(undTasks))
+	}
+}

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -2619,3 +2619,54 @@ func TestPRAutoCompletedMarker(t *testing.T) {
 		}
 	}
 }
+
+func TestListTasksTagFilterDelimiterSafe(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	database, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer database.Close()
+	defer os.Remove(dbPath)
+
+	if err := database.CreateProject(&Project{Name: "test", Path: tmpDir}); err != nil {
+		t.Fatalf("failed to create test project: %v", err)
+	}
+
+	// Three tasks with overlapping tag prefixes. The filter for "gm:cortex"
+	// must match only the exact tag, never the longer "gm:cortex-2".
+	cortex := &Task{Title: "cortex task", Status: StatusBacklog, Type: TypeCode, Project: "test", Tags: "gm:cortex"}
+	cortex2 := &Task{Title: "cortex-2 task", Status: StatusBacklog, Type: TypeCode, Project: "test", Tags: "gm:cortex-2"}
+	multi := &Task{Title: "multi-tag task", Status: StatusBacklog, Type: TypeCode, Project: "test", Tags: "urgent,gm:cortex,backend"}
+
+	for _, tk := range []*Task{cortex, cortex2, multi} {
+		if err := database.CreateTask(tk); err != nil {
+			t.Fatalf("failed to create task %q: %v", tk.Title, err)
+		}
+	}
+
+	tasks, err := database.ListTasks(ListTasksOptions{Tag: "gm:cortex"})
+	if err != nil {
+		t.Fatalf("ListTasks with tag filter failed: %v", err)
+	}
+
+	got := map[int64]bool{}
+	for _, tk := range tasks {
+		got[tk.ID] = true
+	}
+
+	if !got[cortex.ID] {
+		t.Errorf("expected task with exact tag gm:cortex to match, but it did not")
+	}
+	if !got[multi.ID] {
+		t.Errorf("expected task with gm:cortex among multiple tags to match, but it did not")
+	}
+	if got[cortex2.ID] {
+		t.Errorf("tag filter gm:cortex must NOT match gm:cortex-2 (delimiter-unsafe substring match)")
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected exactly 2 matching tasks, got %d", len(tasks))
+	}
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -96,6 +96,7 @@ func (e *Emitter) runHook(event Event) {
 			fmt.Sprintf("TASK_TITLE=%s", event.Task.Title),
 			fmt.Sprintf("TASK_STATUS=%s", event.Task.Status),
 			fmt.Sprintf("TASK_PROJECT=%s", event.Task.Project),
+			fmt.Sprintf("TASK_TAGS=%s", event.Task.Tags),
 		)
 		if event.Task.WorktreePath != "" {
 			env = append(env,


### PR DESCRIPTION
> Per Bruno's redirect on #561 — generalize on the existing free-form `tags` column instead of baking a GM-specific `assigned_gm` column into ty's core schema. **#561 to be closed in favor of this.** ty stays a neutral task substrate; ty-os owns the GM concept and scopes its work with a `gm:<slug>` tag convention.

## What
Two small, generic changes (no new schema — reuses the existing `tags` column):

1. **`TASK_TAGS` in the hook env** (`internal/events/events.go`). Hook scripts now receive the task's comma-separated tag list alongside `TASK_PROJECT` — lets a consumer filter its hook / notification stream by tag entirely client-side. Highest-leverage change.
2. **`ty list --tag` filter.** Adds `Tag` to `db.ListTasksOptions`, a delimiter-safe `AND ... LIKE ?` clause in `ListTasks`, and a `--tag` flag on `ty list` (`cmd/task/main.go`).

## Why
- `tags` is already a free-form column; a consumer scopes its work with a tag convention (e.g. `gm:cortex`) — no migration, and every future tagging need benefits.
- `project` (`ty list -p`, `TASK_PROJECT`, `project` in notifications) already covers the common "my tasks / my events" case; tags add a second, fully generic scoping axis without committing ty to any GM-specific concept.
- Consciously dropped vs. #561: the crisp old→new "reassigned away from me" delta a dedicated field gave. Acceptable trade — re-assignment between owners is rare and project scoping covers the common case.

## How tested
`go build ./... && go vet ./... && go test ./...` — all green. Two tests in `internal/db/tasks_test.go`:
- **`TestListTasksTagFilterDelimiterSafe`** — `--tag gm:cortex` matches `gm:cortex` (standalone) and `urgent,gm:cortex,backend` (mid-list) but **not** `gm:cortex-2`. Done by normalizing the stored value to `,a,b,` form and matching the delimited `,gm:cortex,` rather than a naïve `LIKE '%gm:cortex%'`.
- **`TestListTasksTagFilterEscapesLikeWildcards`** — the `--tag` needle is escaped for `LIKE` metacharacters (`%` / `_`) with `ESCAPE '\'`, so `--tag "gm:c%x"` can't wildcard-match `gm:cZZZx`.

## Follow-up (not in this PR)
- **TUI tags support** — tags input on create/edit + board display + filter. Net-new and generally useful (not GM-specific); tracked separately to keep this PR small.
