### PR TITLE
Allow choosing the Claude model when executing a task

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -600,6 +600,7 @@ Examples:
 			project, _ := cmd.Flags().GetString("project")
 			taskExecutor, _ := cmd.Flags().GetString("executor")
 			effortLevel, _ := cmd.Flags().GetString("effort")
+			modelOverride, _ := cmd.Flags().GetString("model")
 			execute, _ := cmd.Flags().GetBool("execute")
 			createDangerous, _ := cmd.Flags().GetBool("dangerous")
 			permissionModeFlag, _ := cmd.Flags().GetString("permission-mode")
@@ -674,6 +675,10 @@ Examples:
 				os.Exit(1)
 			}
 
+			// Normalize model override (empty = use Claude's global default). Any
+			// non-empty value is accepted; the Claude CLI validates the model name.
+			modelOverride = strings.TrimSpace(modelOverride)
+
 			// If project not specified, try to detect from cwd
 			if project == "" {
 				if cwd, err := os.Getwd(); err == nil {
@@ -730,6 +735,7 @@ Examples:
 				Project:        project,
 				Executor:       taskExecutor,
 				EffortLevel:    effortLevel,
+				Model:          modelOverride,
 				Tags:           tags,
 				Pinned:         pinned,
 				SourceBranch:   branch,
@@ -757,6 +763,9 @@ Examples:
 				if task.EffortLevel != "" {
 					output["effort_level"] = task.EffortLevel
 				}
+				if task.Model != "" {
+					output["model"] = task.Model
+				}
 				jsonBytes, _ := json.Marshal(output)
 				fmt.Println(string(jsonBytes))
 			} else {
@@ -780,6 +789,7 @@ Examples:
 	createCmd.Flags().StringP("project", "p", "", "Project name (auto-detected from cwd if not specified)")
 	createCmd.Flags().StringP("executor", "e", "", "Task executor: claude, codex, gemini, pi, opencode, openclaw (default: claude)")
 	createCmd.Flags().String("effort", "", "Per-task Claude effort override: low, medium, high, xhigh, max (default: Claude's global default)")
+	createCmd.Flags().String("model", "", "Per-task Claude model override: opus, sonnet, haiku, or a full model name (default: Claude's global default)")
 	createCmd.Flags().BoolP("execute", "x", false, "Queue task for immediate execution")
 	createCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (alias for --permission-mode dangerous)")
 	createCmd.Flags().String("permission-mode", "", "Permission mode: default (prompt), accept-edits (auto-accept file edits), auto (Claude Code auto mode: auto-approve safe actions, block risky ones), dangerous (skip all). Defaults to the project's setting")
@@ -793,6 +803,9 @@ Examples:
 	createCmd.RegisterFlagCompletionFunc("executor", completeFlagExecutors)
 	createCmd.RegisterFlagCompletionFunc("effort", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return db.EffortLevels(), cobra.ShellCompDirectiveNoFileComp
+	})
+	createCmd.RegisterFlagCompletionFunc("model", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return db.ModelOptions(), cobra.ShellCompDirectiveNoFileComp
 	})
 	rootCmd.AddCommand(createCmd)
 

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -297,6 +297,9 @@ func (db *DB) migrate() error {
 		`ALTER TABLE tasks ADD COLUMN effort_level TEXT DEFAULT ''`,
 
 		`ALTER TABLE tasks ADD COLUMN remote_control INTEGER DEFAULT 0`, // Whether to launch claude with --remote-control
+
+		// Per-task Claude model override ("" = use global/Claude default, otherwise an alias like opus/sonnet/haiku or a full model name)
+		`ALTER TABLE tasks ADD COLUMN model TEXT DEFAULT ''`,
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -20,6 +20,7 @@ type Task struct {
 	Project         string
 	Executor        string // Task executor: "claude" (default), "codex", "gemini"
 	EffortLevel     string // Per-task Claude effort override ("" = use global/Claude default; otherwise low/medium/high/xhigh/max)
+	Model           string // Per-task Claude model override ("" = use global/Claude default; otherwise an alias like opus/sonnet/haiku or a full model name)
 	WorktreePath    string
 	BranchName      string
 	Port            int    // Unique port for running the application in this task's worktree
@@ -241,6 +242,32 @@ func IsValidEffortLevel(s string) bool {
 	}
 }
 
+// Model overrides are per-task selections for Claude's model (claude --model).
+// An empty value means "no override" — the task uses Claude's global default,
+// leaving the user's global setting untouched. The aliases below are accepted by
+// the Claude CLI's --model flag; a full model name (e.g. "claude-opus-4-8") is
+// also valid and passed through unchanged.
+const (
+	ModelOpus   = "opus"
+	ModelSonnet = "sonnet"
+	ModelHaiku  = "haiku"
+)
+
+// ModelOptions returns the suggested per-task model override values offered in
+// the UI, most-capable first. The Claude CLI also accepts full model names, so
+// this list is a convenience, not an exhaustive set.
+func ModelOptions() []string {
+	return []string{ModelOpus, ModelSonnet, ModelHaiku}
+}
+
+// IsValidModel reports whether s is an acceptable per-task model override. The
+// empty string is valid and means "use the global/Claude default" (no per-task
+// override). Any non-empty value is accepted because the Claude CLI validates
+// the model name itself and supports both aliases and full model IDs.
+func IsValidModel(s string) bool {
+	return true
+}
+
 // Port allocation constants
 const (
 	PortRangeStart = 3100 // First port in the allocation range
@@ -298,9 +325,9 @@ func (db *DB) CreateTask(t *Task) error {
 	t.DangerousMode = t.PermissionMode == PermissionModeDangerous
 
 	result, err := db.Exec(`
-		INSERT INTO tasks (title, body, status, type, project, executor, pinned, tags, source_branch, dangerous_mode, permission_mode, remote_control, effort_level)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor, t.Pinned, t.Tags, t.SourceBranch, t.DangerousMode, t.PermissionMode, t.RemoteControl, t.EffortLevel)
+		INSERT INTO tasks (title, body, status, type, project, executor, pinned, tags, source_branch, dangerous_mode, permission_mode, remote_control, effort_level, model)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor, t.Pinned, t.Tags, t.SourceBranch, t.DangerousMode, t.PermissionMode, t.RemoteControl, t.EffortLevel, t.Model)
 	if err != nil {
 		return fmt.Errorf("insert task: %w", err)
 	}
@@ -326,6 +353,7 @@ func (db *DB) CreateTask(t *Task) error {
 	// ("default") so switching back to the default sticks.
 	if t.Project != "" {
 		db.SetLastEffortForProject(t.Project, t.EffortLevel)
+		db.SetLastModelForProject(t.Project, t.Model)
 		db.SetLastPermissionForProject(t.Project, t.PermissionMode)
 	}
 
@@ -353,7 +381,7 @@ func (db *DB) GetTask(id int64) (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''), COALESCE(model, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -365,7 +393,7 @@ func (db *DB) GetTask(id int64) (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary, &t.EffortLevel,
+		&t.SourceBranch, &t.Summary, &t.EffortLevel, &t.Model,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -400,7 +428,7 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''), COALESCE(model, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -482,7 +510,7 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary, &t.EffortLevel,
+			&t.SourceBranch, &t.Summary, &t.EffortLevel, &t.Model,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -507,7 +535,7 @@ func (db *DB) GetMostRecentlyCreatedTask() (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''), COALESCE(model, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -521,7 +549,7 @@ func (db *DB) GetMostRecentlyCreatedTask() (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary, &t.EffortLevel,
+		&t.SourceBranch, &t.Summary, &t.EffortLevel, &t.Model,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -550,7 +578,7 @@ func (db *DB) SearchTasks(query string, limit int) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''), COALESCE(model, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -583,7 +611,7 @@ func (db *DB) SearchTasks(query string, limit int) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary, &t.EffortLevel,
+			&t.SourceBranch, &t.Summary, &t.EffortLevel, &t.Model,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -685,13 +713,13 @@ func (db *DB) UpdateTask(t *Task) error {
 			title = ?, body = ?, status = ?, type = ?, project = ?, executor = ?,
 			worktree_path = ?, branch_name = ?, port = ?, claude_session_id = ?,
 			daemon_session = ?, pr_url = ?, pr_number = ?, pr_info_json = ?, dangerous_mode = ?, permission_mode = ?, remote_control = ?,
-			pinned = ?, tags = ?, source_branch = ?, effort_level = ?,
+			pinned = ?, tags = ?, source_branch = ?, effort_level = ?, model = ?,
 			updated_at = CURRENT_TIMESTAMP
 		WHERE id = ?
 	`, t.Title, t.Body, t.Status, t.Type, t.Project, t.Executor,
 		t.WorktreePath, t.BranchName, t.Port, t.ClaudeSessionID,
 		t.DaemonSession, t.PRURL, t.PRNumber, t.PRInfoJSON, t.DangerousMode, t.PermissionMode, t.RemoteControl,
-		t.Pinned, t.Tags, t.SourceBranch, t.EffortLevel, t.ID)
+		t.Pinned, t.Tags, t.SourceBranch, t.EffortLevel, t.Model, t.ID)
 	if err != nil {
 		return fmt.Errorf("update task: %w", err)
 	}
@@ -1065,7 +1093,7 @@ func (db *DB) GetNextQueuedTask() (*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''), COALESCE(model, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -1080,7 +1108,7 @@ func (db *DB) GetNextQueuedTask() (*Task, error) {
 		&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 		&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 		&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-		&t.SourceBranch, &t.Summary, &t.EffortLevel,
+		&t.SourceBranch, &t.Summary, &t.EffortLevel, &t.Model,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 		&t.LastDistilledAt, &t.LastAccessedAt,
 		&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -1103,7 +1131,7 @@ func (db *DB) GetQueuedTasks() ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''), COALESCE(model, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -1126,7 +1154,7 @@ func (db *DB) GetQueuedTasks() ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary, &t.EffortLevel,
+			&t.SourceBranch, &t.Summary, &t.EffortLevel, &t.Model,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,
@@ -1718,6 +1746,18 @@ func (db *DB) SetLastEffortForProject(project, effort string) error {
 	return db.SetSetting("last_effort_"+project, effort)
 }
 
+// GetLastModelForProject returns the last used Claude model override for a
+// project ("" means the global/Claude default was used).
+func (db *DB) GetLastModelForProject(project string) (string, error) {
+	return db.GetSetting("last_model_" + project)
+}
+
+// SetLastModelForProject saves the last used Claude model override for a project
+// so the next task in it defaults to the same choice.
+func (db *DB) SetLastModelForProject(project, model string) error {
+	return db.SetSetting("last_model_"+project, model)
+}
+
 // GetLastPermissionForProject returns the last used permission mode for a
 // project ("" means none recorded yet).
 func (db *DB) GetLastPermissionForProject(project string) (string, error) {
@@ -2069,7 +2109,7 @@ func (db *DB) GetStaleWorktreeTasks(maxAge time.Duration) ([]*Task, error) {
 		       COALESCE(claude_pane_id, ''), COALESCE(shell_pane_id, ''),
 		       COALESCE(pr_url, ''), COALESCE(pr_number, 0), COALESCE(pr_info_json, ''),
 		       COALESCE(dangerous_mode, 0), COALESCE(permission_mode, ''), COALESCE(remote_control, 0), COALESCE(pinned, 0), COALESCE(tags, ''),
-		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''),
+		       COALESCE(source_branch, ''), COALESCE(summary, ''), COALESCE(effort_level, ''), COALESCE(model, ''),
 		       created_at, updated_at, started_at, completed_at,
 		       last_distilled_at, last_accessed_at,
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
@@ -2096,7 +2136,7 @@ func (db *DB) GetStaleWorktreeTasks(maxAge time.Duration) ([]*Task, error) {
 			&t.DaemonSession, &t.TmuxWindowID, &t.ClaudePaneID, &t.ShellPaneID,
 			&t.PRURL, &t.PRNumber, &t.PRInfoJSON,
 			&t.DangerousMode, &t.PermissionMode, &t.RemoteControl, &t.Pinned, &t.Tags,
-			&t.SourceBranch, &t.Summary, &t.EffortLevel,
+			&t.SourceBranch, &t.Summary, &t.EffortLevel, &t.Model,
 			&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 			&t.LastDistilledAt, &t.LastAccessedAt,
 			&t.ArchiveRef, &t.ArchiveCommit, &t.ArchiveWorktreePath, &t.ArchiveBranchName,

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -1629,6 +1629,78 @@ func TestIsValidEffortLevel(t *testing.T) {
 	}
 }
 
+func TestModelPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+	defer os.Remove(dbPath)
+
+	// Create a task without a model override (empty = global/Claude default)
+	task := &Task{
+		Title:   "Default model task",
+		Status:  StatusBacklog,
+		Type:    TypeCode,
+		Project: "personal",
+	}
+	if err := db.CreateTask(task); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	retrieved, err := db.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+	if retrieved.Model != "" {
+		t.Errorf("expected empty model by default, got %q", retrieved.Model)
+	}
+
+	// Create a task with a per-task model override
+	override := &Task{
+		Title:   "Opus task",
+		Status:  StatusBacklog,
+		Type:    TypeCode,
+		Project: "personal",
+		Model:   ModelOpus,
+	}
+	if err := db.CreateTask(override); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+	retrieved, err = db.GetTask(override.ID)
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+	if retrieved.Model != ModelOpus {
+		t.Errorf("expected model %q, got %q", ModelOpus, retrieved.Model)
+	}
+
+	// Update the model via UpdateTask (including a full model name)
+	retrieved.Model = "claude-opus-4-8"
+	if err := db.UpdateTask(retrieved); err != nil {
+		t.Fatalf("failed to update task: %v", err)
+	}
+	updated, err := db.GetTask(override.ID)
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+	if updated.Model != "claude-opus-4-8" {
+		t.Errorf("expected model %q after update, got %q", "claude-opus-4-8", updated.Model)
+	}
+
+	// The last-used model is stored per project for stickiness.
+	last, err := db.GetLastModelForProject("personal")
+	if err != nil {
+		t.Fatalf("failed to get last model: %v", err)
+	}
+	if last != ModelOpus {
+		t.Errorf("expected last model %q, got %q", ModelOpus, last)
+	}
+}
+
 func TestUpdateTaskPRInfo(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")

--- a/internal/executor/claude_executor.go
+++ b/internal/executor/claude_executor.go
@@ -81,6 +81,19 @@ func effortFlag(level string) string {
 	return fmt.Sprintf("--effort %s ", level)
 }
 
+// modelFlag returns the `--model <name> ` CLI flag (with a trailing space) for a
+// per-task model override, or an empty string when no override is set. An empty
+// override means the task uses Claude's global default, leaving the user's global
+// model setting untouched. The model name is shell-single-quoted because the
+// returned flag is concatenated into a script run via `sh -c` and may be an
+// arbitrary full model ID supplied via the CLI/MCP.
+func modelFlag(model string) string {
+	if model == "" {
+		return ""
+	}
+	return fmt.Sprintf("--model %s ", shellSingleQuote(model))
+}
+
 // rcFlag returns the `--remote-control <name> ` CLI flag (with a trailing
 // space) for a task that has Remote Control enabled, or an empty string
 // otherwise. The session name is the task title, falling back to `task-<id>`
@@ -162,6 +175,9 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 	// Build per-task effort override flag (empty = use Claude's global default)
 	effort := effortFlag(task.EffortLevel)
 
+	// Build per-task model override flag (empty = use Claude's global default)
+	model := modelFlag(task.Model)
+
 	// Get session ID for environment
 	worktreeSessionID := os.Getenv("WORKTREE_SESSION_ID")
 	if worktreeSessionID == "" {
@@ -177,8 +193,8 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 
 	// Build command - resume if we have a session ID, otherwise start fresh
 	if sessionID != "" {
-		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s--resume %s`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort, sessionID)
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s--resume %s`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort, model, sessionID)
 	}
 
 	// Start fresh - if prompt is provided, write to temp file and pass it
@@ -187,18 +203,18 @@ func (c *ClaudeExecutor) BuildCommand(task *db.Task, sessionID, prompt string) s
 		promptFile, err := os.CreateTemp("", "task-prompt-*.txt")
 		if err != nil {
 			c.logger.Error("BuildCommand: failed to create temp file", "error", err)
-			return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s`,
-				task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort)
+			return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s`,
+				task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort, model)
 		}
 		promptFile.WriteString(prompt)
 		promptFile.Close()
 
-		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s"$(cat %q)"; rm -f %q`,
-			task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort, promptFile.Name(), promptFile.Name())
+		return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s"$(cat %q)"; rm -f %q`,
+			task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort, model, promptFile.Name(), promptFile.Name())
 	}
 
-	return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s`,
-		task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort)
+	return fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath, configPrefix, dangerousFlag, effort, model)
 }
 
 // configDirPrefix returns the `CLAUDE_CONFIG_DIR=<dir> ` shell prefix for the task's

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2550,6 +2550,8 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 	rcFlag := rcFlag(task)
 	// Build per-task effort override flag (empty = use Claude's global default)
 	effort := effortFlag(task.EffortLevel)
+	// Build per-task model override flag (empty = use Claude's global default)
+	model := modelFlag(task.Model)
 	// Build trailing prompt arg - suppressed for Remote Control so claude starts with a blank session
 	promptArg := fmt.Sprintf(`"$(cat %q)"`, promptFile.Name())
 	if task.RemoteControl {
@@ -2564,8 +2566,8 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 	envPrefix := claudeEnvPrefix(paths.configDir)
 	if existingSessionID != "" && ClaudeSessionExists(existingSessionID, workDir, paths.configDir) {
 		e.logLine(task.ID, "system", fmt.Sprintf("Resuming existing session %s", existingSessionID))
-		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s--resume %s %s`,
-			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, rcFlag, effort, existingSessionID, promptArg)
+		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s%s--resume %s %s`,
+			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, rcFlag, effort, model, existingSessionID, promptArg)
 	} else {
 		if existingSessionID != "" {
 			e.logLine(task.ID, "system", fmt.Sprintf("Session %s no longer exists, starting fresh", existingSessionID))
@@ -2574,8 +2576,8 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 				e.logger.Warn("failed to clear stale session ID", "task", task.ID, "error", err)
 			}
 		}
-		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s%s`,
-			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, rcFlag, effort, promptArg)
+		script = fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s%s%s`,
+			task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, rcFlag, effort, model, promptArg)
 	}
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
@@ -2713,6 +2715,8 @@ func (e *Executor) runClaudeResume(ctx context.Context, task *db.Task, workDir, 
 	rcFlag := rcFlag(task)
 	// Build per-task effort override flag (empty = use Claude's global default)
 	effort := effortFlag(task.EffortLevel)
+	// Build per-task model override flag (empty = use Claude's global default)
+	model := modelFlag(task.Model)
 	// Build trailing prompt arg - suppressed for Remote Control so claude starts with a blank session
 	promptArg := fmt.Sprintf(`"$(cat %q)"`, feedbackFile.Name())
 	if task.RemoteControl {
@@ -2720,8 +2724,8 @@ func (e *Executor) runClaudeResume(ctx context.Context, task *db.Task, workDir, 
 	}
 
 	envPrefix := claudeEnvPrefix(paths.configDir)
-	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s--resume %s %s`,
-		task.ID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, rcFlag, effort, claudeSessionID, promptArg)
+	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sclaude %s%s%s%s--resume %s %s`,
+		task.ID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, rcFlag, effort, model, claudeSessionID, promptArg)
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
 	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))

--- a/internal/executor/model_test.go
+++ b/internal/executor/model_test.go
@@ -1,0 +1,62 @@
+package executor
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+// TestModelFlag verifies the modelFlag helper produces the expected CLI flag.
+func TestModelFlag(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{"", ""},
+		{db.ModelOpus, "--model 'opus' "},
+		{db.ModelSonnet, "--model 'sonnet' "},
+		{db.ModelHaiku, "--model 'haiku' "},
+		{"claude-opus-4-8", "--model 'claude-opus-4-8' "},
+	}
+	for _, tt := range tests {
+		if got := modelFlag(tt.model); got != tt.want {
+			t.Errorf("modelFlag(%q) = %q, want %q", tt.model, got, tt.want)
+		}
+	}
+}
+
+// TestBuildCommandModel verifies BuildCommand includes the --model flag only
+// when a per-task override is set, leaving the default (empty) untouched.
+func TestBuildCommandModel(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	exec := New(database, &config.Config{})
+	claude := exec.executorFactory.Get(db.ExecutorClaude)
+
+	// No override: command must not contain --model.
+	task := &db.Task{ID: 1, Port: 8080, WorktreePath: "/tmp/test-worktree"}
+	if cmd := claude.BuildCommand(task, "", ""); strings.Contains(cmd, "--model") {
+		t.Errorf("BuildCommand() with no model override should not contain --model, got %q", cmd)
+	}
+
+	// Override set: command must contain --model <name>.
+	task.Model = db.ModelOpus
+	cmd := claude.BuildCommand(task, "", "")
+	if !strings.Contains(cmd, "--model 'opus'") {
+		t.Errorf("BuildCommand() with opus model should contain %q, got %q", "--model 'opus'", cmd)
+	}
+}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -30,6 +30,7 @@ const (
 	FieldType
 	FieldExecutor
 	FieldEffort
+	FieldModel
 	FieldPermission
 	FieldCount
 )
@@ -71,6 +72,10 @@ type FormModel struct {
 	effortIdx          int
 	effortLevels       []string // Selectable effort values; "" (first) means "default"
 	effortTouched      bool     // user picked an effort explicitly; stop following project default
+	model              string   // Per-task Claude model override ("" = use global/Claude default)
+	modelIdx           int
+	models             []string // Selectable model values; "" (first) means "default"
+	modelTouched       bool     // user picked a model explicitly; stop following project default
 	permissionMode     string   // Per-task permission mode ("default"/"auto"/"dangerous")
 	permissionIdx      int
 	permissionModes    []string // Selectable permission modes
@@ -168,6 +173,24 @@ func effortIndexFor(options []string, level string) int {
 	return 0
 }
 
+// modelOptions returns the selectable model values for the form. The first entry
+// is the empty string, which represents "default" (no per-task override — uses
+// Claude's global default).
+func modelOptions() []string {
+	return append([]string{""}, db.ModelOptions()...)
+}
+
+// modelIndexFor returns the index of the given model in the options list,
+// defaulting to 0 ("default") when not found.
+func modelIndexFor(options []string, model string) int {
+	for i, m := range options {
+		if m == model {
+			return i
+		}
+	}
+	return 0
+}
+
 // permissionModeOptions returns the selectable permission modes for the form, in
 // display order. "default" (prompt for each permission) comes first, then the
 // less-restrictive modes.
@@ -257,6 +280,10 @@ func NewEditFormModel(database *db.DB, task *db.Task, width, height int, availab
 		effortLevels:        effortLevelOptions(),
 		effortIdx:           effortIndexFor(effortLevelOptions(), task.EffortLevel),
 		effortTouched:       true, // editing: keep the task's existing effort unless changed
+		model:               task.Model,
+		models:              modelOptions(),
+		modelIdx:            modelIndexFor(modelOptions(), task.Model),
+		modelTouched:        true, // editing: keep the task's existing model unless changed
 		permissionMode:      task.EffectivePermissionMode(),
 		permissionModes:     permissionModeOptions(),
 		permissionIdx:       permissionIndexFor(permissionModeOptions(), task.EffectivePermissionMode()),
@@ -382,6 +409,7 @@ func NewFormModel(database *db.DB, width, height int, workingDir string, availab
 		taskRefAutocomplete: NewTaskRefAutocompleteModel(database, width-24),
 		attachmentCursor:    -1,
 		effortLevels:        effortLevelOptions(), // Defaults to "" (Claude's global default)
+		models:              modelOptions(),       // Defaults to "" (Claude's global default)
 		permissionModes:     permissionModeOptions(),
 		showAdvanced:        showAdvanced, // Load from user preference
 	}
@@ -460,6 +488,7 @@ func NewFormModel(database *db.DB, width, height int, workingDir string, availab
 	// previous task in that project.
 	m.refreshPermissionDefaultForProject()
 	m.refreshEffortDefaultForProject()
+	m.refreshModelDefaultForProject()
 
 	// Title input
 	m.titleInput = textinput.New()
@@ -806,6 +835,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.loadLastExecutorForProject()
 				m.refreshPermissionDefaultForProject()
 				m.refreshEffortDefaultForProject()
+				m.refreshModelDefaultForProject()
 				return m, nil
 			}
 			if m.focused == FieldType {
@@ -822,6 +852,12 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.effortIdx = (m.effortIdx - 1 + len(m.effortLevels)) % len(m.effortLevels)
 				m.effortLevel = m.effortLevels[m.effortIdx]
 				m.effortTouched = true
+				return m, nil
+			}
+			if m.focused == FieldModel && len(m.models) > 0 {
+				m.modelIdx = (m.modelIdx - 1 + len(m.models)) % len(m.models)
+				m.model = m.models[m.modelIdx]
+				m.modelTouched = true
 				return m, nil
 			}
 			if m.focused == FieldPermission && len(m.permissionModes) > 0 {
@@ -843,6 +879,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.loadLastExecutorForProject()
 				m.refreshPermissionDefaultForProject()
 				m.refreshEffortDefaultForProject()
+				m.refreshModelDefaultForProject()
 				return m, nil
 			}
 			if m.focused == FieldType {
@@ -859,6 +896,12 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.effortIdx = (m.effortIdx + 1) % len(m.effortLevels)
 				m.effortLevel = m.effortLevels[m.effortIdx]
 				m.effortTouched = true
+				return m, nil
+			}
+			if m.focused == FieldModel && len(m.models) > 0 {
+				m.modelIdx = (m.modelIdx + 1) % len(m.models)
+				m.model = m.models[m.modelIdx]
+				m.modelTouched = true
 				return m, nil
 			}
 			if m.focused == FieldPermission && len(m.permissionModes) > 0 {
@@ -920,7 +963,7 @@ func (m *FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			// Type-to-select for other selector fields
-			if m.focused == FieldType || m.focused == FieldExecutor || m.focused == FieldEffort || m.focused == FieldPermission {
+			if m.focused == FieldType || m.focused == FieldExecutor || m.focused == FieldEffort || m.focused == FieldModel || m.focused == FieldPermission {
 				key := msg.String()
 				if len(key) == 1 && unicode.IsLetter(rune(key[0])) {
 					m.selectByPrefix(strings.ToLower(key))
@@ -1128,6 +1171,7 @@ func (m *FormModel) selectProjectFromSearch() {
 	m.loadLastExecutorForProject()
 	m.refreshPermissionDefaultForProject()
 	m.refreshEffortDefaultForProject()
+	m.refreshModelDefaultForProject()
 }
 
 // filterProjects updates the filtered project list based on the search query.
@@ -1199,6 +1243,19 @@ func (m *FormModel) selectByPrefix(prefix string) {
 				m.effortIdx = i
 				m.effortLevel = l
 				m.effortTouched = true
+				return
+			}
+		}
+	case FieldModel:
+		for i, l := range m.models {
+			label := l
+			if label == "" {
+				label = "default"
+			}
+			if strings.HasPrefix(strings.ToLower(label), prefix) {
+				m.modelIdx = i
+				m.model = l
+				m.modelTouched = true
 				return
 			}
 		}
@@ -1320,6 +1377,29 @@ func (m *FormModel) refreshEffortDefaultForProject() {
 	m.effortIdx = effortIndexFor(m.effortLevels, m.effortLevel)
 }
 
+// defaultModelForProject returns the model override a new task should start with
+// for the given project: the last model used in it (stickiness), or "" (the
+// global/Claude default) when none was recorded.
+func (m *FormModel) defaultModelForProject(project string) string {
+	if m.db != nil && project != "" {
+		if last, err := m.db.GetLastModelForProject(project); err == nil && db.IsValidModel(last) {
+			return last
+		}
+	}
+	return ""
+}
+
+// refreshModelDefaultForProject re-seeds the model selector from the current
+// project's last-used model, unless the user has explicitly chosen one. Called
+// when the selected project changes so the default follows the project.
+func (m *FormModel) refreshModelDefaultForProject() {
+	if m.modelTouched {
+		return
+	}
+	m.model = m.defaultModelForProject(m.project)
+	m.modelIdx = modelIndexFor(m.models, m.model)
+}
+
 // rebuildExecutorListForProject rebuilds the executor list sorted by usage for the current project.
 // This should be called when the project changes to re-sort executors by usage count.
 func (m *FormModel) rebuildExecutorListForProject() {
@@ -1358,9 +1438,9 @@ func (m *FormModel) rebuildExecutorListForProject() {
 // isFieldVisible returns whether a field should be shown in the current view.
 // When showAdvanced is false, only Title and Body are visible.
 func (m *FormModel) isFieldVisible(field FormField) bool {
-	if field == FieldEffort {
-		// Effort is a Claude-specific override (claude --effort), only shown in
-		// advanced mode and only when the Claude executor is selected.
+	if field == FieldEffort || field == FieldModel {
+		// Effort and model are Claude-specific overrides (claude --effort/--model),
+		// only shown in advanced mode and only when the Claude executor is selected.
 		return m.showAdvanced && m.executor == db.ExecutorClaude
 	}
 	if m.showAdvanced {
@@ -1918,6 +1998,25 @@ func (m *FormModel) View() string {
 			b.WriteString("\n")
 		}
 
+		// Model selector (Claude-specific; only shown for the Claude executor)
+		if m.isFieldVisible(FieldModel) {
+			cursor = " "
+			if m.focused == FieldModel {
+				cursor = cursorStyle.Render("▸")
+			}
+			// Build model labels (replace "" with "default")
+			modelLabels := make([]string, len(m.models))
+			for i, l := range m.models {
+				if l == "" {
+					modelLabels[i] = "default"
+				} else {
+					modelLabels[i] = l
+				}
+			}
+			b.WriteString(cursor + " " + labelStyle.Render("Model") + m.renderSelector(modelLabels, m.modelIdx, m.focused == FieldModel, selectedStyle, optionStyle, dimStyle))
+			b.WriteString("\n")
+		}
+
 		// Permission selector
 		if m.isFieldVisible(FieldPermission) {
 			cursor = " "
@@ -2073,6 +2172,13 @@ func (m *FormModel) ApplyTo(task *db.Task) {
 		task.EffortLevel = m.effortLevel
 	} else {
 		task.EffortLevel = ""
+	}
+
+	// Model is a Claude-specific override; only carry it for the Claude executor.
+	if m.executor == db.ExecutorClaude {
+		task.Model = m.model
+	} else {
+		task.Model = ""
 	}
 
 	// Permission mode is now an editable field on the form, so carry it onto the

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -1345,6 +1345,60 @@ func TestEffortFieldHiddenForNonClaude(t *testing.T) {
 	}
 }
 
+func TestModelFieldDefaultsToGlobal(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", []string{db.ExecutorClaude})
+
+	// Model options start with "" (the global/Claude default).
+	if len(m.models) == 0 || m.models[0] != "" {
+		t.Fatalf("expected first model option to be the empty default, got %v", m.models)
+	}
+	if m.model != "" {
+		t.Errorf("expected default model to be empty, got %q", m.model)
+	}
+
+	// GetDBTask should not set an override when the user leaves the default.
+	if got := m.GetDBTask().Model; got != "" {
+		t.Errorf("expected GetDBTask to leave model empty by default, got %q", got)
+	}
+}
+
+func TestModelFieldCycleAndPersist(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", []string{db.ExecutorClaude})
+	m.showAdvanced = true
+	m.focused = FieldModel
+
+	// Cycling right from the default lands on the first real model.
+	m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if m.model != db.ModelOpus {
+		t.Errorf("expected model to be %q after one right press, got %q", db.ModelOpus, m.model)
+	}
+
+	if got := m.GetDBTask().Model; got != db.ModelOpus {
+		t.Errorf("expected GetDBTask to carry model %q, got %q", db.ModelOpus, got)
+	}
+
+	// Cycling left returns to the default (empty) override.
+	m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if m.model != "" {
+		t.Errorf("expected model to return to default, got %q", m.model)
+	}
+}
+
+func TestModelFieldHiddenForNonClaude(t *testing.T) {
+	m := NewFormModel(nil, 100, 50, "", []string{db.ExecutorClaude})
+	m.showAdvanced = true
+
+	m.executor = db.ExecutorClaude
+	if !m.isFieldVisible(FieldModel) {
+		t.Error("expected model field to be visible for the Claude executor")
+	}
+
+	m.executor = db.ExecutorCodex
+	if m.isFieldVisible(FieldModel) {
+		t.Error("expected model field to be hidden for non-Claude executors")
+	}
+}
+
 func TestPermissionFieldDefaultsToProjectDefault(t *testing.T) {
 	m := NewFormModel(nil, 100, 50, "", []string{db.ExecutorClaude})
 

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -216,6 +216,7 @@ type updateTaskRequest struct {
 	Pinned         *bool   `json:"pinned"`
 	PermissionMode *string `json:"permission_mode"`
 	EffortLevel    *string `json:"effort_level"`
+	Model          *string `json:"model"`
 }
 
 func (s *Server) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
@@ -260,6 +261,9 @@ func (s *Server) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.EffortLevel != nil {
 		task.EffortLevel = *req.EffortLevel
+	}
+	if req.Model != nil {
+		task.Model = *req.Model
 	}
 
 	if err := s.db.UpdateTask(task); err != nil {
@@ -1043,6 +1047,7 @@ type taskJSON struct {
 	WorktreePath   string        `json:"worktree_path,omitempty"`
 	HasExecutor    bool          `json:"has_executor"`
 	EffortLevel    string        `json:"effort_level,omitempty"`
+	Model          string        `json:"model,omitempty"`
 	SourceBranch   string        `json:"source_branch,omitempty"`
 	DaemonSession  string        `json:"daemon_session,omitempty"`
 	TmuxWindowID   string        `json:"tmux_window_id,omitempty"`
@@ -1096,6 +1101,7 @@ func toTaskJSON(t *db.Task) *taskJSON {
 		WorktreePath:   t.WorktreePath,
 		HasExecutor:    t.ClaudePaneID != "",
 		EffortLevel:    t.EffortLevel,
+		Model:          t.Model,
 		SourceBranch:   t.SourceBranch,
 		DaemonSession:  t.DaemonSession,
 		TmuxWindowID:   t.TmuxWindowID,


### PR DESCRIPTION
## Summary

Adds a per-task **Model** override alongside the existing **Executor** and **Effort** settings, so a task can run on a specific Claude model (e.g. `opus`, `sonnet`, `haiku`, or a full model id) without touching the user's global Claude default.

Empty (`default`) leaves Claude's global model untouched. The override is Claude-specific (only shown/carried for the `claude` executor), exactly like effort.

## Changes

- **db** — new `tasks.model` column + idempotent migration; `Task.Model` field; `ModelOptions()` / `IsValidModel()` helpers; wired through `CreateTask`/`UpdateTask` and every task scan; per-project last-used stickiness via `Get/SetLastModelForProject`.
- **executor** — `modelFlag()` emits a shell-quoted `--model <name>` flag, wired into `ClaudeExecutor.BuildCommand` and both daemon launch + resume command builders (kept in sync, per the two-command-builder gotcha).
- **form UI** — new **Model** selector field (advanced mode, Claude-only) with arrow cycling, type-to-select, project stickiness, and `ApplyTo` carry. Mirrors the Effort field.
- **CLI** — `ty create --model <name>` flag with shell completion and JSON output.
- **web** — `model` on the update request + task JSON payload.

## Tests

- `internal/db`: `TestModelPersistence` (create/update round-trip + per-project stickiness)
- `internal/executor`: `TestModelFlag`, `TestBuildCommandModel`
- `internal/ui`: `TestModelFieldDefaultsToGlobal`, `TestModelFieldCycleAndPersist`, `TestModelFieldHiddenForNonClaude`

`go build ./...`, `go vet`, `gofmt`, and `golangci-lint run` (v2.8.0, matching CI) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)