### PR TITLE
Draw task model choices dynamically from the Claude CLI

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -120,6 +120,15 @@ func Open(path string) (*DB, error) {
 // "auto" denotes Claude Code's real auto mode.
 const permModeAutoMigrationKey = "migration:auto_means_accept_edits_v1"
 
+// modelClaudeSlugMigrationKey guards the one-time repair of tasks whose model
+// override is the literal "claude". That value is the executor slug, never a
+// valid Claude model alias: an early version of the model column shipped with
+// `DEFAULT 'claude'` (removed in a later release) and CreateTask did not write
+// the column for months, so every task inserted in that window fell through to
+// that default. Left in place it launches `claude --model claude`, which the CLI
+// rejects. Rewrite those rows to "" (no override / Claude's global default).
+const modelClaudeSlugMigrationKey = "migration:clear_model_claude_slug_v1"
+
 // migrate runs database migrations.
 func (db *DB) migrate() error {
 	migrations := []string{
@@ -331,6 +340,15 @@ func (db *DB) migrate() error {
 		db.Exec(`UPDATE tasks SET permission_mode = 'accept-edits' WHERE permission_mode = 'auto'`)
 		db.Exec(`UPDATE projects SET default_permission_mode = 'accept-edits' WHERE default_permission_mode = 'auto'`)
 		db.SetSetting(permModeAutoMigrationKey, "done")
+	}
+
+	// One-time: clear the invalid "claude" model override left by an early
+	// `DEFAULT 'claude'` on the model column (see modelClaudeSlugMigrationKey).
+	// "claude" is the executor slug, not a model alias, so no task should carry
+	// it; rewriting to "" restores Claude's global default.
+	if done, _ := db.GetSetting(modelClaudeSlugMigrationKey); done == "" {
+		db.Exec(`UPDATE tasks SET model = '' WHERE model = 'claude'`)
+		db.SetSetting(modelClaudeSlugMigrationKey, "done")
 	}
 
 	// Ensure 'personal' project exists

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -248,16 +248,18 @@ func IsValidEffortLevel(s string) bool {
 // the Claude CLI's --model flag; a full model name (e.g. "claude-opus-4-8") is
 // also valid and passed through unchanged.
 const (
+	ModelFable  = "fable"
 	ModelOpus   = "opus"
 	ModelSonnet = "sonnet"
 	ModelHaiku  = "haiku"
 )
 
-// ModelOptions returns the suggested per-task model override values offered in
-// the UI, most-capable first. The Claude CLI also accepts full model names, so
-// this list is a convenience, not an exhaustive set.
+// ModelOptions returns the per-task model override aliases offered in the UI.
+// The Claude CLI also accepts full model names, so this is a convenience list,
+// not an exhaustive set. Keep it in sync with the aliases the Claude CLI supports
+// as new models ship (e.g. "fable" was added alongside opus/sonnet/haiku).
 func ModelOptions() []string {
-	return []string{ModelOpus, ModelSonnet, ModelHaiku}
+	return []string{ModelOpus, ModelSonnet, ModelHaiku, ModelFable}
 }
 
 // IsValidModel reports whether s is an acceptable per-task model override. The

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -1701,6 +1701,56 @@ func TestModelPersistence(t *testing.T) {
 	}
 }
 
+// TestClearModelClaudeSlugMigration verifies the one-time repair that clears the
+// invalid "claude" model override (the executor slug an early DEFAULT baked into
+// every row) while leaving real overrides untouched, and only running once.
+func TestClearModelClaudeSlugMigration(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	database, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+	defer os.Remove(dbPath)
+
+	bad := &Task{Title: "bad", Status: StatusBacklog, Type: TypeCode, Project: "personal"}
+	good := &Task{Title: "good", Status: StatusBacklog, Type: TypeCode, Project: "personal", Model: ModelOpus}
+	if err := database.CreateTask(bad); err != nil {
+		t.Fatalf("create bad task: %v", err)
+	}
+	if err := database.CreateTask(good); err != nil {
+		t.Fatalf("create good task: %v", err)
+	}
+
+	// Simulate the legacy backfill: model set to the "claude" slug, guard cleared
+	// so the one-time migration runs on the next migrate().
+	database.Exec(`UPDATE tasks SET model = 'claude' WHERE id = ?`, bad.ID)
+	database.SetSetting(modelClaudeSlugMigrationKey, "")
+
+	if err := database.migrate(); err != nil {
+		t.Fatalf("re-run migrate: %v", err)
+	}
+
+	if got, _ := database.GetTask(bad.ID); got.Model != "" {
+		t.Errorf("expected invalid 'claude' model cleared to empty, got %q", got.Model)
+	}
+	if got, _ := database.GetTask(good.ID); got.Model != ModelOpus {
+		t.Errorf("expected real override %q preserved, got %q", ModelOpus, got.Model)
+	}
+
+	// Guard: a task legitimately set to "claude" AFTER the migration must not be
+	// rewritten on a later boot (the slug is invalid, but the guard makes it a
+	// one-time repair, not a permanent filter).
+	database.Exec(`UPDATE tasks SET model = 'claude' WHERE id = ?`, good.ID)
+	if err := database.migrate(); err != nil {
+		t.Fatalf("re-run migrate (guarded): %v", err)
+	}
+	if got, _ := database.GetTask(good.ID); got.Model != "claude" {
+		t.Errorf("guard should not re-run the repair, got %q", got.Model)
+	}
+}
+
 func TestUpdateTaskPRInfo(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")


### PR DESCRIPTION
## Problem

The task form's model selector hardcoded `opus`, `sonnet`, and `haiku`. The current Claude Code CLI advertises **Fable** too, but it never showed up because the list was static (`db.ModelOptions()`).

## Change

Draw the model choices from the installed Claude CLI so the picker stays current as new models ship.

- **New `internal/claudecli` package** — parses the model aliases the CLI advertises in its `--model` flag description (`claude --help`) and unions them with a static fallback superset. This means:
  - newly shipped aliases like `fable` appear **without a code change**,
  - a locally-known alias the CLI stops advertising (e.g. `haiku`) is **never dropped**, and
  - offline / CLI-missing use falls back to `db.ModelOptions()`.
- Discovery runs **once and is cached** for the process lifetime (one `claude --help`, 5s timeout).
- The task form (`internal/ui/form.go`) and `ty create --model` shell completion now source choices from `claudecli.AvailableModels()`.
- `db.ModelOptions()` remains the fallback and gains the `fable` alias.

On a machine with the current CLI, discovery returns `[fable opus sonnet haiku]`, so the form now offers: **default, fable, opus, sonnet, haiku**.

## Why parse `--help`?

The CLI exposes no machine-readable model list (`--model <bad>` returns a generic error with no enumeration). Its `--help` text is the authoritative advertised source. The parser is defensive — it only reads the aliases before "full name", skips full model IDs, and returns nothing (falling back) if the sentence isn't found.

## Tests

- `internal/claudecli/models_test.go` — parser (real wrapped help, single-line, empty, missing sentence, full-name exclusion), union/dedup/fallback, and discovery via an injected help func (no shell-out).
- Updated `TestModelFieldCycleAndPersist` to assert against the actual first discovered model instead of a hardcoded `opus`.
- `go build ./...`, `golangci-lint run` (v2.8.0, matches CI), and `gofmt` all clean.

## Follow-ups

- None required. If the CLI ever ships a structured `models` command, `claudecli.discoverModels` is the single spot to switch the source.