### PR TITLE
fix(workflow): close three reliability gaps that stall pipelines

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4610,15 +4610,22 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 		// Claude finished its turn and is waiting for user input
 		// This is the key transition: processing → blocked (needs input)
 		if task.Status == db.StatusProcessing {
-			// A workflow step is instructed to call taskyou_complete when done. If
-			// the agent ends its turn without it but has committed AND pushed its
-			// work (clean worktree, HEAD == upstream), parking it in 'blocked' would
-			// stall the whole DAG for a step that actually finished. Auto-complete it
-			// so the workflow advances. A step that stopped to ask a question or left
-			// work uncommitted/unpushed hasn't finished — block as before.
+			// A workflow step signals completion by committing AND pushing its work —
+			// the push is the handoff, ty advances the DAG on its own (there is no tool
+			// to call). If the agent ends its turn with a clean worktree and HEAD pushed
+			// to the shared branch, the step finished: the terminal step (which opened
+			// the PR) parks in 'blocked' for a human to merge, every other step goes
+			// 'done' so its dependents auto-queue. A step that stopped to ask a question
+			// or left work uncommitted/unpushed hasn't finished — block as before, and
+			// the daemon's sweep is the backstop for a Stop hook that fires mid-push.
 			if pipeline.IsWorkflowTask(task) && workflowStepFinished(task) {
-				database.UpdateTaskStatus(taskID, db.StatusDone)
-				database.AppendTaskLog(taskID, "system", "Workflow step pushed its work but didn't call taskyou_complete — auto-completed to advance the workflow")
+				if pipeline.IsTerminalStep(database, task) {
+					database.UpdateTaskStatus(taskID, db.StatusBlocked)
+					database.AppendTaskLog(taskID, "system", "Final step finished and opened its PR — parked in blocked for a human to review and merge")
+				} else {
+					database.UpdateTaskStatus(taskID, db.StatusDone)
+					database.AppendTaskLog(taskID, "system", "Work committed and pushed — workflow advances to the next step")
+				}
 			} else {
 				database.UpdateTaskStatus(taskID, db.StatusBlocked)
 				database.AppendTaskLog(taskID, "system", "Waiting for user input")

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4155,8 +4155,11 @@ func ensureDaemonRunning(dangerousMode bool) error {
 }
 
 func getPidFilePath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".local", "share", "task", "daemon.pid")
+	// Key the daemon PID/lock file to the DB's directory so an isolated instance
+	// (WORKTREE_DB_PATH set, e.g. the QA harness) gets its own daemon lock and can
+	// run a full daemon alongside the live one. For the live instance this resolves
+	// to the historical ~/.local/share/task/daemon.pid — no behavior change.
+	return filepath.Join(filepath.Dir(db.DefaultPath()), "daemon.pid")
 }
 
 func readPidFile(path string) (int, error) {

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4621,7 +4621,7 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 			if pipeline.IsWorkflowTask(task) && workflowStepFinished(task) {
 				if pipeline.IsTerminalStep(database, task) {
 					database.UpdateTaskStatus(taskID, db.StatusBlocked)
-					database.AppendTaskLog(taskID, "system", "Final step finished and opened its PR — parked in blocked for a human to review and merge")
+					database.AppendTaskLog(taskID, "system", pipeline.TerminalStepParkedLog)
 				} else {
 					database.UpdateTaskStatus(taskID, db.StatusDone)
 					database.AppendTaskLog(taskID, "system", "Work committed and pushed — workflow advances to the next step")

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4634,10 +4634,11 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 }
 
 // workflowStepFinished reports whether a workflow step has committed AND pushed
-// its work: its worktree is clean and HEAD is at its upstream. That is the signal
-// a step completed its handoff (per the composed step instructions), used to
-// distinguish "finished but forgot taskyou_complete" (advance the DAG) from
-// "stopped mid-work / to ask" (block). Conservative: any doubt returns false.
+// its work: its worktree is clean and HEAD matches the pushed remote-tracking ref.
+// That is the signal a step completed its handoff (per the composed step
+// instructions), used to distinguish "finished but forgot taskyou_complete"
+// (advance the DAG) from "stopped mid-work / to ask" (block). Conservative: any
+// doubt returns false.
 func workflowStepFinished(task *db.Task) bool {
 	wt := task.WorktreePath
 	if wt == "" {
@@ -4647,13 +4648,24 @@ func workflowStepFinished(task *db.Task) bool {
 	if out, err := osexec.Command("git", "-C", wt, "status", "--porcelain").Output(); err != nil || len(strings.TrimSpace(string(out))) != 0 {
 		return false
 	}
-	// HEAD pushed to its upstream branch.
 	head, errH := osexec.Command("git", "-C", wt, "rev-parse", "HEAD").Output()
-	up, errU := osexec.Command("git", "-C", wt, "rev-parse", "@{u}").Output()
-	if errH != nil || errU != nil {
+	if errH != nil {
 		return false
 	}
-	return strings.TrimSpace(string(head)) == strings.TrimSpace(string(up))
+	// Compare HEAD to the remote-tracking ref for this branch. `git push` updates
+	// refs/remotes/origin/<branch> even when the worktree branch has no upstream
+	// tracking configured — which non-root step worktrees don't, since they check
+	// out the shared branch without `-u`. (Using @{u} here would wrongly fail.)
+	branch, errB := osexec.Command("git", "-C", wt, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	br := strings.TrimSpace(string(branch))
+	if errB != nil || br == "" || br == "HEAD" {
+		return false
+	}
+	remote, errR := osexec.Command("git", "-C", wt, "rev-parse", "refs/remotes/origin/"+br).Output()
+	if errR != nil {
+		return false
+	}
+	return strings.TrimSpace(string(head)) == strings.TrimSpace(string(remote))
 }
 
 // handlePreToolUseHook handles PreToolUse hooks from Claude (before tool execution).

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4633,39 +4633,12 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 	return nil
 }
 
-// workflowStepFinished reports whether a workflow step has committed AND pushed
-// its work: its worktree is clean and HEAD matches the pushed remote-tracking ref.
-// That is the signal a step completed its handoff (per the composed step
-// instructions), used to distinguish "finished but forgot taskyou_complete"
-// (advance the DAG) from "stopped mid-work / to ask" (block). Conservative: any
-// doubt returns false.
+// workflowStepFinished reports whether a workflow step has committed AND pushed its
+// work (see executor.WorkflowStepFinished). Used by the Stop hook to advance a step
+// that finished but didn't call taskyou_complete; the daemon's sweep is the backstop
+// for when the hook fires at a transient moment.
 func workflowStepFinished(task *db.Task) bool {
-	wt := task.WorktreePath
-	if wt == "" {
-		return false
-	}
-	// Clean tree — everything committed.
-	if out, err := osexec.Command("git", "-C", wt, "status", "--porcelain").Output(); err != nil || len(strings.TrimSpace(string(out))) != 0 {
-		return false
-	}
-	head, errH := osexec.Command("git", "-C", wt, "rev-parse", "HEAD").Output()
-	if errH != nil {
-		return false
-	}
-	// Compare HEAD to the remote-tracking ref for this branch. `git push` updates
-	// refs/remotes/origin/<branch> even when the worktree branch has no upstream
-	// tracking configured — which non-root step worktrees don't, since they check
-	// out the shared branch without `-u`. (Using @{u} here would wrongly fail.)
-	branch, errB := osexec.Command("git", "-C", wt, "rev-parse", "--abbrev-ref", "HEAD").Output()
-	br := strings.TrimSpace(string(branch))
-	if errB != nil || br == "" || br == "HEAD" {
-		return false
-	}
-	remote, errR := osexec.Command("git", "-C", wt, "rev-parse", "refs/remotes/origin/"+br).Output()
-	if errR != nil {
-		return false
-	}
-	return strings.TrimSpace(string(head)) == strings.TrimSpace(string(remote))
+	return executor.WorkflowStepFinished(task.WorktreePath)
 }
 
 // handlePreToolUseHook handles PreToolUse hooks from Claude (before tool execution).

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4607,8 +4607,19 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 		// Claude finished its turn and is waiting for user input
 		// This is the key transition: processing → blocked (needs input)
 		if task.Status == db.StatusProcessing {
-			database.UpdateTaskStatus(taskID, db.StatusBlocked)
-			database.AppendTaskLog(taskID, "system", "Waiting for user input")
+			// A workflow step is instructed to call taskyou_complete when done. If
+			// the agent ends its turn without it but has committed AND pushed its
+			// work (clean worktree, HEAD == upstream), parking it in 'blocked' would
+			// stall the whole DAG for a step that actually finished. Auto-complete it
+			// so the workflow advances. A step that stopped to ask a question or left
+			// work uncommitted/unpushed hasn't finished — block as before.
+			if pipeline.IsWorkflowTask(task) && workflowStepFinished(task) {
+				database.UpdateTaskStatus(taskID, db.StatusDone)
+				database.AppendTaskLog(taskID, "system", "Workflow step pushed its work but didn't call taskyou_complete — auto-completed to advance the workflow")
+			} else {
+				database.UpdateTaskStatus(taskID, db.StatusBlocked)
+				database.AppendTaskLog(taskID, "system", "Waiting for user input")
+			}
 		}
 	case "tool_use":
 		// Claude stopped because it's about to execute a tool
@@ -4617,6 +4628,29 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 	}
 
 	return nil
+}
+
+// workflowStepFinished reports whether a workflow step has committed AND pushed
+// its work: its worktree is clean and HEAD is at its upstream. That is the signal
+// a step completed its handoff (per the composed step instructions), used to
+// distinguish "finished but forgot taskyou_complete" (advance the DAG) from
+// "stopped mid-work / to ask" (block). Conservative: any doubt returns false.
+func workflowStepFinished(task *db.Task) bool {
+	wt := task.WorktreePath
+	if wt == "" {
+		return false
+	}
+	// Clean tree — everything committed.
+	if out, err := osexec.Command("git", "-C", wt, "status", "--porcelain").Output(); err != nil || len(strings.TrimSpace(string(out))) != 0 {
+		return false
+	}
+	// HEAD pushed to its upstream branch.
+	head, errH := osexec.Command("git", "-C", wt, "rev-parse", "HEAD").Output()
+	up, errU := osexec.Command("git", "-C", wt, "rev-parse", "@{u}").Output()
+	if errH != nil || errU != nil {
+		return false
+	}
+	return strings.TrimSpace(string(head)) == strings.TrimSpace(string(up))
 }
 
 // handlePreToolUseHook handles PreToolUse hooks from Claude (before tool execution).

--- a/cmd/task/stophook_test.go
+++ b/cmd/task/stophook_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// TestWorkflowStepFinished: a step counts as finished only when its worktree is
+// clean AND its HEAD is pushed to its upstream — the "did the handoff" signal used
+// to auto-advance a step whose agent forgot taskyou_complete.
+func TestWorkflowStepFinished(t *testing.T) {
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	git(t, root, "init", "--bare", remote)
+	wt := filepath.Join(root, "wt")
+	if err := os.Mkdir(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, wt, "init")
+	git(t, wt, "remote", "add", "origin", remote)
+
+	task := &db.Task{WorktreePath: wt}
+
+	// Committed but NOT pushed → not finished.
+	if err := os.WriteFile(filepath.Join(wt, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, wt, "add", ".")
+	git(t, wt, "commit", "-m", "work")
+	if workflowStepFinished(task) {
+		t.Error("committed but unpushed step should NOT be finished")
+	}
+
+	// Pushed + clean → finished.
+	git(t, wt, "push", "-u", "origin", "HEAD")
+	if !workflowStepFinished(task) {
+		t.Error("clean + pushed step SHOULD be finished")
+	}
+
+	// Uncommitted change → not finished.
+	if err := os.WriteFile(filepath.Join(wt, "f2.txt"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if workflowStepFinished(task) {
+		t.Error("dirty worktree should NOT be finished")
+	}
+
+	// Empty worktree path → not finished.
+	if workflowStepFinished(&db.Task{WorktreePath: ""}) {
+		t.Error("empty worktree path should NOT be finished")
+	}
+}

--- a/cmd/task/stophook_test.go
+++ b/cmd/task/stophook_test.go
@@ -20,8 +20,9 @@ func git(t *testing.T, dir string, args ...string) {
 }
 
 // TestWorkflowStepFinished: a step counts as finished only when its worktree is
-// clean AND its HEAD is pushed to its upstream — the "did the handoff" signal used
-// to auto-advance a step whose agent forgot taskyou_complete.
+// clean AND its HEAD is pushed. Critically, non-root workflow steps check out the
+// shared branch WITHOUT upstream tracking (no `-u`), so the check must use the
+// remote-tracking ref, not @{u}.
 func TestWorkflowStepFinished(t *testing.T) {
 	root := t.TempDir()
 	remote := filepath.Join(root, "remote.git")
@@ -32,6 +33,8 @@ func TestWorkflowStepFinished(t *testing.T) {
 	}
 	git(t, wt, "init")
 	git(t, wt, "remote", "add", "origin", remote)
+	// Mimic a workflow step: work on a shared branch, no upstream tracking.
+	git(t, wt, "checkout", "-b", "pipeline/shared")
 
 	task := &db.Task{WorktreePath: wt}
 
@@ -45,10 +48,13 @@ func TestWorkflowStepFinished(t *testing.T) {
 		t.Error("committed but unpushed step should NOT be finished")
 	}
 
-	// Pushed + clean → finished.
-	git(t, wt, "push", "-u", "origin", "HEAD")
+	// Pushed WITHOUT -u (no upstream tracking, like a real step) → finished.
+	git(t, wt, "push", "origin", "HEAD:pipeline/shared")
+	if _, err := exec.Command("git", "-C", wt, "rev-parse", "@{u}").Output(); err == nil {
+		t.Fatal("test precondition failed: expected NO upstream tracking after push without -u")
+	}
 	if !workflowStepFinished(task) {
-		t.Error("clean + pushed step SHOULD be finished")
+		t.Error("clean + pushed step (no upstream tracking) SHOULD be finished")
 	}
 
 	// Uncommitted change → not finished.

--- a/internal/db/dependencies.go
+++ b/internal/db/dependencies.go
@@ -240,23 +240,92 @@ func (db *DB) ProcessCompletedBlocker(blockerID int64) ([]*Task, error) {
 				continue
 			}
 
-			// Only update if task is in blocked status
-			if task.Status == StatusBlocked {
+			// Only flip a task that is actually waiting in the DAG (blocked and
+			// never started). A blocked task that has already started is waiting on
+			// a human (needs-input / PR review), not on this dependency.
+			if task.Status == StatusBlocked && task.StartedAt == nil {
 				newStatus := StatusBacklog
 				if info.autoQueue {
 					newStatus = StatusQueued
 				}
 				if err := db.UpdateTaskStatus(info.taskID, newStatus); err != nil {
-					continue
+					// Best-effort: a lost write (e.g. SQLITE_BUSY) leaves the task
+					// blocked; RequeueReadyTasks sweeps it up later. Surface it.
+					return unblocked, fmt.Errorf("requeue unblocked task %d: %w", info.taskID, err)
 				}
 				task.Status = newStatus
+				unblocked = append(unblocked, task) // only report an actual flip
 			}
-
-			unblocked = append(unblocked, task)
 		}
 	}
 
 	return unblocked, nil
+}
+
+// RequeueReadyTasks is the eventually-consistent safety net for
+// ProcessCompletedBlocker. That runs once, best-effort, the instant a blocker
+// completes; a single dropped write (SQLITE_BUSY, a crash) would orphan the
+// dependent in 'blocked' forever, stalling a workflow. This sweep re-queues any
+// task still waiting in the DAG — blocked, never started — whose blockers have
+// all completed. Idempotent: it only touches tasks that are genuinely ready.
+// Returns the tasks it moved.
+func (db *DB) RequeueReadyTasks() ([]*Task, error) {
+	// Candidate = blocked, never-started task that has at least one dependency.
+	rows, err := db.Query(`
+		SELECT DISTINCT t.id
+		FROM tasks t
+		JOIN task_dependencies d ON d.blocked_id = t.id
+		WHERE t.status = ? AND t.started_at IS NULL
+	`, StatusBlocked)
+	if err != nil {
+		return nil, fmt.Errorf("find ready tasks: %w", err)
+	}
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan ready task: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+
+	var moved []*Task
+	for _, id := range ids {
+		openCount, err := db.GetOpenBlockerCount(id)
+		if err != nil || openCount != 0 {
+			continue
+		}
+		autoQueue, err := db.hasAutoQueueBlocker(id)
+		if err != nil {
+			continue
+		}
+		newStatus := StatusBacklog
+		if autoQueue {
+			newStatus = StatusQueued
+		}
+		if err := db.UpdateTaskStatus(id, newStatus); err != nil {
+			continue // try again on the next sweep
+		}
+		if task, err := db.GetTask(id); err == nil && task != nil {
+			moved = append(moved, task)
+		}
+	}
+	return moved, nil
+}
+
+// hasAutoQueueBlocker reports whether any of the task's dependencies has
+// auto_queue set (so an unblocked task is queued rather than dropped to backlog).
+func (db *DB) hasAutoQueueBlocker(taskID int64) (bool, error) {
+	var n int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM task_dependencies WHERE blocked_id = ? AND auto_queue = 1
+	`, taskID).Scan(&n)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
 }
 
 // GetAllDependencies returns all dependencies for a given task (both blockers and blocked).

--- a/internal/db/dependencies_test.go
+++ b/internal/db/dependencies_test.go
@@ -486,3 +486,28 @@ func TestHasQuestionLog(t *testing.T) {
 		t.Error("a question was logged, want true")
 	}
 }
+
+func TestHasLogLineContaining(t *testing.T) {
+	db, cleanup := setupDepsTestDB(t)
+	defer cleanup()
+	tk := &Task{Title: "step", Status: StatusBlocked}
+	if err := db.CreateTask(tk); err != nil {
+		t.Fatal(err)
+	}
+	marker := "parked for merge review"
+	if got, _ := db.HasLogLineContaining(tk.ID, marker); got {
+		t.Error("marker not logged yet, want false")
+	}
+	if err := db.AppendTaskLog(tk.ID, "system", "some unrelated work happened"); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := db.HasLogLineContaining(tk.ID, marker); got {
+		t.Error("unrelated log only, want false")
+	}
+	if err := db.AppendTaskLog(tk.ID, "system", "step "+marker+" awaiting human"); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := db.HasLogLineContaining(tk.ID, marker); !got {
+		t.Error("marker substring is present, want true")
+	}
+}

--- a/internal/db/dependencies_test.go
+++ b/internal/db/dependencies_test.go
@@ -461,3 +461,28 @@ func statusOfTask(t *testing.T, db *DB, id int64) string {
 	}
 	return tk.Status
 }
+
+// TestHasQuestionLog: the needs-input guard for the finished-step sweep.
+func TestHasQuestionLog(t *testing.T) {
+	db, cleanup := setupDepsTestDB(t)
+	defer cleanup()
+	tk := &Task{Title: "step", Status: StatusBlocked}
+	if err := db.CreateTask(tk); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := db.HasQuestionLog(tk.ID); got {
+		t.Error("no question logged yet, want false")
+	}
+	if err := db.AppendTaskLog(tk.ID, "system", "did some work"); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := db.HasQuestionLog(tk.ID); got {
+		t.Error("only a system log, want false")
+	}
+	if err := db.AppendTaskLog(tk.ID, "question", "which approach?"); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := db.HasQuestionLog(tk.ID); !got {
+		t.Error("a question was logged, want true")
+	}
+}

--- a/internal/db/dependencies_test.go
+++ b/internal/db/dependencies_test.go
@@ -267,28 +267,28 @@ func TestProcessCompletedBlocker(t *testing.T) {
 		t.Fatalf("Failed to add dependency: %v", err)
 	}
 
-	// Complete task1
+	// Complete task1 — UpdateTaskStatus runs ProcessCompletedBlocker, which queues task2.
 	if err := db.UpdateTaskStatus(task1.ID, StatusDone); err != nil {
 		t.Fatalf("Failed to update task1 status: %v", err)
 	}
 
-	// Process completion (this is normally called by UpdateTaskStatus)
-	unblocked, err := db.ProcessCompletedBlocker(task1.ID)
-	if err != nil {
-		t.Fatalf("Failed to process completed blocker: %v", err)
-	}
-
-	if len(unblocked) != 1 {
-		t.Errorf("Expected 1 unblocked task, got %d", len(unblocked))
-	}
-
-	// Check that task2 was queued (auto-queue was enabled)
+	// task2 was queued (auto-queue was enabled).
 	task2Updated, err := db.GetTask(task2.ID)
 	if err != nil {
 		t.Fatalf("Failed to get task2: %v", err)
 	}
 	if task2Updated.Status != StatusQueued {
 		t.Errorf("Expected task2 status to be queued, got %s", task2Updated.Status)
+	}
+
+	// ProcessCompletedBlocker is idempotent: a second call reports no flips because
+	// task2 is already queued (only genuine blocked→queued transitions are reported).
+	unblocked, err := db.ProcessCompletedBlocker(task1.ID)
+	if err != nil {
+		t.Fatalf("Failed to process completed blocker: %v", err)
+	}
+	if len(unblocked) != 0 {
+		t.Errorf("second ProcessCompletedBlocker should be a no-op, got %d unblocked", len(unblocked))
 	}
 }
 
@@ -383,4 +383,81 @@ func TestIsBlocked(t *testing.T) {
 	if !blocked {
 		t.Error("Task should be blocked after adding dependency")
 	}
+}
+
+// TestRequeueReadyTasks covers the safety-net sweep that recovers workflow DAG
+// advances when the one-shot ProcessCompletedBlocker flip is dropped.
+func TestRequeueReadyTasks(t *testing.T) {
+	db, cleanup := setupDepsTestDB(t)
+	defer cleanup()
+
+	// A: ready — blocker already done, dependent blocked+never-started, auto_queue.
+	// Created with the blocker pre-done and the dep added after, so nothing flipped
+	// the dependent — exactly the "dropped flip" the sweep must recover.
+	aBlk := &Task{Title: "A blocker", Status: StatusDone}
+	aDep := &Task{Title: "A dep", Status: StatusBlocked}
+	mustCreate(t, db, aBlk, aDep)
+	if err := db.AddDependency(aBlk.ID, aDep.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// B: not ready — blocker still open.
+	bBlk := &Task{Title: "B blocker", Status: StatusProcessing}
+	bDep := &Task{Title: "B dep", Status: StatusBlocked}
+	mustCreate(t, db, bBlk, bDep)
+	if err := db.AddDependency(bBlk.ID, bDep.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// C: blocker done but dependent already STARTED (ran, now needs input) — must
+	// NOT be re-queued; it's waiting on a human, not on the DAG.
+	cBlk := &Task{Title: "C blocker", Status: StatusDone}
+	cDep := &Task{Title: "C dep", Status: StatusBlocked}
+	mustCreate(t, db, cBlk, cDep)
+	if err := db.AddDependency(cBlk.ID, cDep.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	// Mark cDep started (processing sets started_at), then blocked (needs-input).
+	if err := db.UpdateTaskStatus(cDep.ID, StatusProcessing); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpdateTaskStatus(cDep.ID, StatusBlocked); err != nil {
+		t.Fatal(err)
+	}
+
+	moved, err := db.RequeueReadyTasks()
+	if err != nil {
+		t.Fatalf("RequeueReadyTasks: %v", err)
+	}
+
+	if got := statusOfTask(t, db, aDep.ID); got != StatusQueued {
+		t.Errorf("A dep = %s, want queued (ready → swept)", got)
+	}
+	if got := statusOfTask(t, db, bDep.ID); got != StatusBlocked {
+		t.Errorf("B dep = %s, want blocked (open blocker)", got)
+	}
+	if got := statusOfTask(t, db, cDep.ID); got != StatusBlocked {
+		t.Errorf("C dep = %s, want blocked (already started → needs input, not swept)", got)
+	}
+	if len(moved) != 1 || moved[0].ID != aDep.ID {
+		t.Errorf("moved = %d tasks, want just the A dep", len(moved))
+	}
+}
+
+func mustCreate(t *testing.T, db *DB, tasks ...*Task) {
+	t.Helper()
+	for _, tk := range tasks {
+		if err := db.CreateTask(tk); err != nil {
+			t.Fatalf("create %q: %v", tk.Title, err)
+		}
+	}
+}
+
+func statusOfTask(t *testing.T, db *DB, id int64) string {
+	t.Helper()
+	tk, err := db.GetTask(id)
+	if err != nil || tk == nil {
+		t.Fatalf("get task %d: %v", id, err)
+	}
+	return tk.Status
 }

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -1206,6 +1206,18 @@ func (db *DB) HasQuestionLog(taskID int64) (bool, error) {
 	return n > 0, nil
 }
 
+// HasLogLineContaining reports whether the task has any log line whose content
+// contains substr. Used to make a periodic sweep idempotent — e.g. logging a
+// "parked for merge review" note exactly once for a terminal workflow step.
+func (db *DB) HasLogLineContaining(taskID int64, substr string) (bool, error) {
+	var n int
+	err := db.QueryRow(`SELECT COUNT(*) FROM task_logs WHERE task_id = ? AND content LIKE ?`, taskID, "%"+substr+"%").Scan(&n)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
 // GetTaskLogs retrieves logs for a task.
 func (db *DB) GetTaskLogs(taskID int64, limit int) ([]*TaskLog, error) {
 	if limit <= 0 {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -697,9 +698,13 @@ func (db *DB) UpdateTaskStatus(id int64, status string) error {
 		}
 	}
 
-	// Process dependent tasks when a blocker is completed
+	// Process dependent tasks when a blocker is completed. Best-effort: a dropped
+	// write is recovered by the daemon's RequeueReadyTasks sweep, but log it so a
+	// stalled workflow isn't a silent mystery.
 	if status == StatusDone || status == StatusArchived {
-		db.ProcessCompletedBlocker(id)
+		if _, err := db.ProcessCompletedBlocker(id); err != nil {
+			log.Printf("ProcessCompletedBlocker(%d): %v", id, err)
+		}
 	}
 
 	return nil

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -1194,6 +1194,18 @@ func (db *DB) AppendTaskLog(taskID int64, lineType, content string) error {
 	return nil
 }
 
+// HasQuestionLog reports whether the task ever recorded a needs-input question
+// (line_type "question"). The workflow "finished but couldn't signal" sweep uses
+// this to avoid auto-completing a step that is genuinely waiting on a human answer.
+func (db *DB) HasQuestionLog(taskID int64) (bool, error) {
+	var n int
+	err := db.QueryRow(`SELECT COUNT(*) FROM task_logs WHERE task_id = ? AND line_type = 'question'`, taskID).Scan(&n)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
 // GetTaskLogs retrieves logs for a task.
 func (db *DB) GetTaskLogs(taskID int64, limit int) ([]*TaskLog, error) {
 	if limit <= 0 {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bborn/workflow/internal/events"
 	"github.com/bborn/workflow/internal/github"
 	"github.com/bborn/workflow/internal/hooks"
+	"github.com/bborn/workflow/internal/pipeline"
 )
 
 // TaskEvent represents a change to a task.
@@ -354,6 +355,32 @@ func (e *Executor) reconcileOrphanedTasks() {
 	}
 }
 
+// reconcileReadyTasks is the safety net for workflow DAG auto-advance: it
+// re-queues any step still 'blocked' + never-started whose blockers have all
+// completed, in case the one-shot ProcessCompletedBlocker flip was dropped (a
+// SQLITE_BUSY write, a crash between the done-write and the queue-write). Without
+// this, a single lost flip strands a workflow forever.
+func (e *Executor) reconcileReadyTasks() {
+	moved, err := e.db.RequeueReadyTasks()
+	if err != nil {
+		e.logger.Error("Failed to reconcile ready tasks", "error", err)
+		return
+	}
+	if len(moved) == 0 {
+		return
+	}
+	for _, task := range moved {
+		e.logLine(task.ID, "system", "Dependencies complete — re-queued by safety-net sweep")
+		e.hooks.OnStatusChange(task, task.Status, "Dependencies complete")
+		e.logger.Info("Re-queued ready task", "id", task.ID, "title", task.Title)
+	}
+	// Nudge the loop to pick up the newly-queued work immediately.
+	select {
+	case e.wakeupCh <- struct{}{}:
+	default:
+	}
+}
+
 // tmuxWindowExistsForTask reports whether a live executor tmux window exists for
 // the task in any daemon session. The executor runs inside a window named
 // "task-<id>" within a "task-daemon-*" session; if that window is gone, the
@@ -662,6 +689,19 @@ func GetClaudePIDFromPane(paneID string) int {
 
 // KillClaudeProcess terminates the Claude process for a task to free up memory.
 // This is called when a task is completed, closed, or deleted.
+// teardownWorkflowStepSession kills the executor process and tmux window for a
+// completed workflow step. Ordinary tasks keep their window for human review (the
+// 30-minute janitor cleans them up); a workflow step is unattended and its next
+// step is waiting, so releasing its session promptly avoids a stale window
+// lingering across the handoff. No-op for non-workflow tasks.
+func (e *Executor) teardownWorkflowStepSession(task *db.Task) {
+	if !pipeline.IsWorkflowTask(task) {
+		return
+	}
+	e.KillClaudeProcess(task.ID)
+	KillAllWindowsByNameAllSessions(TmuxWindowName(task.ID))
+}
+
 // Exported for use by the UI when deleting tasks.
 func (e *Executor) KillClaudeProcess(taskID int64) bool {
 	pid := e.getClaudePID(taskID)
@@ -854,6 +894,7 @@ func (e *Executor) worker(ctx context.Context) {
 	const authCheckInterval = 15        // 30 seconds at 2 second ticks
 	const reviewReconcileInterval = 30  // 60 seconds at 2 second ticks
 	const prDisplayRefreshInterval = 45 // 90 seconds at 2 second ticks
+	const readyTasksInterval = 8        // 16 seconds at 2 second ticks
 
 	for {
 		select {
@@ -884,6 +925,13 @@ func (e *Executor) worker(ctx context.Context) {
 			// once their PR has merged or closed.
 			if tickCount%reviewReconcileInterval == 0 {
 				e.reconcileReviewTasks()
+			}
+
+			// Safety net for the auto-advance of workflow DAGs: re-queue any step
+			// still waiting on dependencies that have all completed (in case the
+			// one-shot ProcessCompletedBlocker flip was dropped).
+			if tickCount%readyTasksInterval == 0 {
+				e.reconcileReadyTasks()
 			}
 
 			// Periodically refresh cached PR state for actively-watched tasks so
@@ -1457,6 +1505,11 @@ func (e *Executor) executeTask(ctx context.Context, task *db.Task) {
 		// task.completed already fired via db.UpdateTaskStatus when the status was set.
 		e.logLine(task.ID, "system", "Task completed")
 		e.hooks.OnStatusChange(task, db.StatusDone, "Task completed")
+		// A finished workflow step's interactive session never exits on its own
+		// (it idles at the prompt after calling taskyou_complete). Left alone it
+		// lingers until the 30-minute janitor, holding a tmux window that can
+		// interfere with the next step's setup. Tear it down now.
+		e.teardownWorkflowStepSession(task)
 	} else if result.Success {
 		// Agent finished successfully - move to backlog for human review.
 		// Only humans should mark tasks as done, but agent-success is the

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2477,6 +2477,17 @@ func createTmuxWindow(daemonSession, windowName, workDir, script, allowedProject
 	return "", fmt.Errorf("new-window failed: %v (output: %s)", err, outputStr)
 }
 
+// setEnvSetting sets an env var in a Claude Code settings map's "env" block without
+// clobbering any env vars already present (merged from an existing settings.local.json).
+func setEnvSetting(settings map[string]interface{}, key, value string) {
+	env, ok := settings["env"].(map[string]interface{})
+	if !ok {
+		env = make(map[string]interface{})
+	}
+	env[key] = value
+	settings["env"] = env
+}
+
 // setupClaudeHooks creates a .claude/settings.local.json in workDir to configure hooks.
 // The hooks call back to `task claude-hook` to update task status.
 func (e *Executor) setupClaudeHooks(workDir string, taskID int64) (cleanup func(), err error) {
@@ -2588,6 +2599,17 @@ func (e *Executor) setupClaudeHooks(workDir string, taskID int64) (cleanup func(
 	} else {
 		finalConfig = hooksConfig
 	}
+
+	// Force MCP tools to load upfront instead of being deferred behind ToolSearch.
+	// With deferral on (Claude Code's default), the agent has to *search* for
+	// taskyou_complete before it can call it — and often burns its whole turn never
+	// finding it, so the task never signals done and the workflow stalls. The per-server
+	// `alwaysLoad` flag we set on taskyou is the more precise lever, but it isn't honored
+	// in the project-scoped ~/.claude.json location we're required to use (moving taskyou
+	// to .mcp.json would reintroduce approval prompts). Disabling tool-search for the
+	// session is the placement- and version-independent guarantee. These are lean,
+	// single-purpose executor sessions, so loading tools upfront is a fine trade.
+	setEnvSetting(finalConfig, "ENABLE_TOOL_SEARCH", "false")
 
 	data, err := json.MarshalIndent(finalConfig, "", "  ")
 	if err != nil {
@@ -4514,12 +4536,14 @@ func writeWorkflowMCPConfig(worktreePath string, taskID int64, configDir string)
 	// Use "stdio" transport - Claude Code spawns the process and communicates via stdin/stdout
 	// Auto-approve all TaskYou tools so users don't have to manually approve each call.
 	//
-	// alwaysLoad: with many MCP servers configured (a user's global ~/.claude.json can
-	// have dozens), Claude Code defers MCP tools behind ToolSearch to save context — so
-	// an agent has to *search* for taskyou_complete before it can call it, and often
-	// burns its turn failing to, leaving the workflow step stalled. alwaysLoad forces
-	// taskyou's tools to load at session start so the agent can always signal completion.
-	// It's a fast local stdio server, so the connect-before-first-prompt wait is trivial.
+	// alwaysLoad asks Claude Code to load taskyou's tools at session start rather than
+	// deferring them behind ToolSearch — so an agent can always reach taskyou_complete to
+	// signal done instead of burning its turn searching for it. It's the precise, per-server
+	// lever, but it isn't honored in this project-scoped ~/.claude.json location (and we
+	// can't move to .mcp.json without reintroducing approval prompts), so it's belt-and-
+	// suspenders: setupClaudeHooks disables tool-search for the whole session via
+	// ENABLE_TOOL_SEARCH=false, which is the actual guarantee. Fast local stdio server, so
+	// the connect-before-first-prompt wait is trivial either way.
 	taskyouServer := map[string]interface{}{
 		"type":       "stdio",
 		"command":    taskExecutable,
@@ -4581,6 +4605,15 @@ func writeWorkflowMCPConfig(worktreePath string, taskID int64, configDir string)
 	delete(mcpServers, "workflow")
 	mcpServers["taskyou"] = taskyouServer
 	projectConfig["mcpServers"] = mcpServers
+
+	// Pre-trust the worktree. A fresh worktree path is unknown to Claude Code, so on
+	// first launch it blocks on the "Do you trust the files in this folder?" onboarding
+	// prompt — which stalls an unattended workflow step forever (no human to answer).
+	// ty created this worktree from the user's own already-trusted project, so trusting
+	// it is safe and matches intent. Setting these two flags skips the dialog entirely.
+	projectConfig["hasTrustDialogAccepted"] = true
+	projectConfig["hasCompletedProjectOnboarding"] = true
+
 	projects[worktreePath] = projectConfig
 	config["projects"] = projects
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -381,6 +381,44 @@ func (e *Executor) reconcileReadyTasks() {
 	}
 }
 
+// reconcileFinishedWorkflowSteps recovers workflow steps that finished their work
+// (committed + pushed) but got parked in 'blocked' — because the agent couldn't
+// call taskyou_complete (its MCP tool was deferred behind ToolSearch) and the Stop
+// hook's auto-complete fired at a transient moment (e.g. a temp file briefly
+// dirtying the worktree). Those steps stall the whole DAG. This sweep marks any
+// such step 'done' once its state has settled, then advances the workflow. It
+// skips steps that asked a question (genuine needs-input) so it never advances past
+// one waiting on a human.
+func (e *Executor) reconcileFinishedWorkflowSteps() {
+	tasks, err := e.db.ListTasks(db.ListTasksOptions{Status: db.StatusBlocked, Tag: "pipeline", Limit: 500})
+	if err != nil {
+		e.logger.Error("Failed to list blocked pipeline tasks", "error", err)
+		return
+	}
+	for _, task := range tasks {
+		// Only steps that actually ran; leave un-started (DAG-waiting) ones to
+		// reconcileReadyTasks.
+		if task.StartedAt == nil || task.WorktreePath == "" {
+			continue
+		}
+		// Don't advance past a genuine needs-input question.
+		if hasQ, err := e.db.HasQuestionLog(task.ID); err != nil || hasQ {
+			continue
+		}
+		if !WorkflowStepFinished(task.WorktreePath) {
+			continue
+		}
+		if err := e.updateStatus(task.ID, db.StatusDone); err != nil {
+			e.logger.Error("Failed to auto-complete finished workflow step", "id", task.ID, "error", err)
+			continue
+		}
+		e.logLine(task.ID, "system", "Finished (work committed + pushed) but never signalled — auto-completed by sweep to advance the workflow")
+		e.hooks.OnStatusChange(task, db.StatusDone, "Auto-completed: work pushed")
+		e.teardownWorkflowStepSession(task)
+		e.logger.Info("Auto-completed finished workflow step", "id", task.ID, "title", task.Title)
+	}
+}
+
 // tmuxWindowExistsForTask reports whether a live executor tmux window exists for
 // the task in any daemon session. The executor runs inside a window named
 // "task-<id>" within a "task-daemon-*" session; if that window is gone, the
@@ -689,6 +727,37 @@ func GetClaudePIDFromPane(paneID string) int {
 
 // KillClaudeProcess terminates the Claude process for a task to free up memory.
 // This is called when a task is completed, closed, or deleted.
+// WorkflowStepFinished reports whether a workflow step has committed AND pushed its
+// work: its worktree is clean and HEAD matches the pushed remote-tracking ref. That
+// is the signal a step completed its handoff (per the composed step instructions),
+// used both by the Stop hook (auto-complete a step that finished but didn't call
+// taskyou_complete) and by the daemon's reconcile sweep (recover a step that was
+// blocked because the hook fired at a transient moment). Conservative: any doubt
+// returns false. Compares to refs/remotes/origin/<branch> rather than @{u} because
+// non-root step worktrees check out the shared branch without upstream tracking.
+func WorkflowStepFinished(worktreePath string) bool {
+	if worktreePath == "" {
+		return false
+	}
+	if out, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain").Output(); err != nil || len(strings.TrimSpace(string(out))) != 0 {
+		return false
+	}
+	head, errH := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	if errH != nil {
+		return false
+	}
+	branch, errB := exec.Command("git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	br := strings.TrimSpace(string(branch))
+	if errB != nil || br == "" || br == "HEAD" {
+		return false
+	}
+	remote, errR := exec.Command("git", "-C", worktreePath, "rev-parse", "refs/remotes/origin/"+br).Output()
+	if errR != nil {
+		return false
+	}
+	return strings.TrimSpace(string(head)) == strings.TrimSpace(string(remote))
+}
+
 // teardownWorkflowStepSession kills the executor process and tmux window for a
 // completed workflow step. Ordinary tasks keep their window for human review (the
 // 30-minute janitor cleans them up); a workflow step is unattended and its next
@@ -932,6 +1001,13 @@ func (e *Executor) worker(ctx context.Context) {
 			// one-shot ProcessCompletedBlocker flip was dropped).
 			if tickCount%readyTasksInterval == 0 {
 				e.reconcileReadyTasks()
+			}
+
+			// Safety net for workflow steps that finished (committed + pushed) but
+			// couldn't signal completion (deferred taskyou_complete / transient Stop
+			// hook miss): complete them so the DAG advances instead of stalling.
+			if tickCount%readyTasksInterval == 0 {
+				e.reconcileFinishedWorkflowSteps()
 			}
 
 			// Periodically refresh cached PR state for actively-watched tasks so

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4436,11 +4436,19 @@ func writeWorkflowMCPConfig(worktreePath string, taskID int64, configDir string)
 
 	// Build the TaskYou MCP server config
 	// Use "stdio" transport - Claude Code spawns the process and communicates via stdin/stdout
-	// Auto-approve all TaskYou tools so users don't have to manually approve each call
+	// Auto-approve all TaskYou tools so users don't have to manually approve each call.
+	//
+	// alwaysLoad: with many MCP servers configured (a user's global ~/.claude.json can
+	// have dozens), Claude Code defers MCP tools behind ToolSearch to save context — so
+	// an agent has to *search* for taskyou_complete before it can call it, and often
+	// burns its turn failing to, leaving the workflow step stalled. alwaysLoad forces
+	// taskyou's tools to load at session start so the agent can always signal completion.
+	// It's a fast local stdio server, so the connect-before-first-prompt wait is trivial.
 	taskyouServer := map[string]interface{}{
-		"type":    "stdio",
-		"command": taskExecutable,
-		"args":    []string{"mcp-server", "--task-id", fmt.Sprintf("%d", taskID)},
+		"type":       "stdio",
+		"command":    taskExecutable,
+		"args":       []string{"mcp-server", "--task-id", fmt.Sprintf("%d", taskID)},
+		"alwaysLoad": true,
 		"autoApprove": []string{
 			"taskyou_complete",
 			"taskyou_needs_input",

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -382,13 +382,13 @@ func (e *Executor) reconcileReadyTasks() {
 }
 
 // reconcileFinishedWorkflowSteps recovers workflow steps that finished their work
-// (committed + pushed) but got parked in 'blocked' — because the agent couldn't
-// call taskyou_complete (its MCP tool was deferred behind ToolSearch) and the Stop
-// hook's auto-complete fired at a transient moment (e.g. a temp file briefly
-// dirtying the worktree). Those steps stall the whole DAG. This sweep marks any
-// such step 'done' once its state has settled, then advances the workflow. It
-// skips steps that asked a question (genuine needs-input) so it never advances past
-// one waiting on a human.
+// (committed + pushed) but got parked in 'blocked' — because the Stop hook's
+// git-state check fired at a transient moment (e.g. a temp file briefly dirtying
+// the worktree, or the push still settling). Those steps stall the whole DAG. This
+// sweep marks any such step 'done' once its state has settled, then advances the
+// workflow. It skips steps that asked a question (genuine needs-input) and the
+// terminal step (which parks in 'blocked' on purpose, awaiting a human merge), so
+// it never advances past one that's legitimately waiting.
 func (e *Executor) reconcileFinishedWorkflowSteps() {
 	tasks, err := e.db.ListTasks(db.ListTasksOptions{Status: db.StatusBlocked, Tag: "pipeline", Limit: 500})
 	if err != nil {
@@ -403,6 +403,11 @@ func (e *Executor) reconcileFinishedWorkflowSteps() {
 		}
 		// Don't advance past a genuine needs-input question.
 		if hasQ, err := e.db.HasQuestionLog(task.ID); err != nil || hasQ {
+			continue
+		}
+		// The terminal step is meant to stay 'blocked' once it finishes (its PR awaits
+		// a human merge), so never auto-complete it to 'done'.
+		if pipeline.IsTerminalStep(e.db, task) {
 			continue
 		}
 		if !WorkflowStepFinished(task.WorktreePath) {
@@ -2477,17 +2482,6 @@ func createTmuxWindow(daemonSession, windowName, workDir, script, allowedProject
 	return "", fmt.Errorf("new-window failed: %v (output: %s)", err, outputStr)
 }
 
-// setEnvSetting sets an env var in a Claude Code settings map's "env" block without
-// clobbering any env vars already present (merged from an existing settings.local.json).
-func setEnvSetting(settings map[string]interface{}, key, value string) {
-	env, ok := settings["env"].(map[string]interface{})
-	if !ok {
-		env = make(map[string]interface{})
-	}
-	env[key] = value
-	settings["env"] = env
-}
-
 // setupClaudeHooks creates a .claude/settings.local.json in workDir to configure hooks.
 // The hooks call back to `task claude-hook` to update task status.
 func (e *Executor) setupClaudeHooks(workDir string, taskID int64) (cleanup func(), err error) {
@@ -2599,17 +2593,6 @@ func (e *Executor) setupClaudeHooks(workDir string, taskID int64) (cleanup func(
 	} else {
 		finalConfig = hooksConfig
 	}
-
-	// Force MCP tools to load upfront instead of being deferred behind ToolSearch.
-	// With deferral on (Claude Code's default), the agent has to *search* for
-	// taskyou_complete before it can call it — and often burns its whole turn never
-	// finding it, so the task never signals done and the workflow stalls. The per-server
-	// `alwaysLoad` flag we set on taskyou is the more precise lever, but it isn't honored
-	// in the project-scoped ~/.claude.json location we're required to use (moving taskyou
-	// to .mcp.json would reintroduce approval prompts). Disabling tool-search for the
-	// session is the placement- and version-independent guarantee. These are lean,
-	// single-purpose executor sessions, so loading tools upfront is a fine trade.
-	setEnvSetting(finalConfig, "ENABLE_TOOL_SEARCH", "false")
 
 	data, err := json.MarshalIndent(finalConfig, "", "  ")
 	if err != nil {
@@ -4537,13 +4520,12 @@ func writeWorkflowMCPConfig(worktreePath string, taskID int64, configDir string)
 	// Auto-approve all TaskYou tools so users don't have to manually approve each call.
 	//
 	// alwaysLoad asks Claude Code to load taskyou's tools at session start rather than
-	// deferring them behind ToolSearch — so an agent can always reach taskyou_complete to
-	// signal done instead of burning its turn searching for it. It's the precise, per-server
-	// lever, but it isn't honored in this project-scoped ~/.claude.json location (and we
-	// can't move to .mcp.json without reintroducing approval prompts), so it's belt-and-
-	// suspenders: setupClaudeHooks disables tool-search for the whole session via
-	// ENABLE_TOOL_SEARCH=false, which is the actual guarantee. Fast local stdio server, so
-	// the connect-before-first-prompt wait is trivial either way.
+	// deferring them behind ToolSearch, so a task that wants them (e.g. taskyou_needs_input
+	// to ask a question) can reach them without a search step. Best-effort: it isn't honored
+	// in this project-scoped ~/.claude.json location on current Claude versions, and we can't
+	// move to .mcp.json without reintroducing approval prompts. Workflow *completion* does
+	// not depend on it — that's git-based (a step commits + pushes; ty advances the DAG) —
+	// so a deferred taskyou server never stalls a workflow.
 	taskyouServer := map[string]interface{}{
 		"type":       "stdio",
 		"command":    taskExecutable,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -406,8 +406,18 @@ func (e *Executor) reconcileFinishedWorkflowSteps() {
 			continue
 		}
 		// The terminal step is meant to stay 'blocked' once it finishes (its PR awaits
-		// a human merge), so never auto-complete it to 'done'.
+		// a human merge), so never auto-complete it to 'done'. But if the Stop hook fired
+		// mid-push it left the generic "waiting for input" state; once the step has
+		// genuinely settled (committed + pushed), clarify it's parked for merge review
+		// (once) and tear down its now-idle session.
 		if pipeline.IsTerminalStep(e.db, task) {
+			if WorkflowStepFinished(task.WorktreePath) {
+				if logged, _ := e.db.HasLogLineContaining(task.ID, pipeline.TerminalStepParkedLog); !logged {
+					e.logLine(task.ID, "system", pipeline.TerminalStepParkedLog)
+					e.teardownWorkflowStepSession(task)
+					e.logger.Info("Terminal workflow step parked for merge review", "id", task.ID, "title", task.Title)
+				}
+			}
 			continue
 		}
 		if !WorkflowStepFinished(task.WorktreePath) {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1501,6 +1501,12 @@ func TestWriteWorkflowMCPConfig(t *testing.T) {
 			t.Errorf("taskyou type = %v, want stdio", taskyou["type"])
 		}
 
+		// alwaysLoad keeps taskyou's tools (esp. taskyou_complete) out of Claude
+		// Code's tool-search deferral, so agents can always signal completion.
+		if taskyou["alwaysLoad"] != true {
+			t.Errorf("taskyou alwaysLoad = %v, want true", taskyou["alwaysLoad"])
+		}
+
 		args, ok := taskyou["args"].([]interface{})
 		if !ok {
 			t.Fatal("expected args array in taskyou config")

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1501,8 +1501,9 @@ func TestWriteWorkflowMCPConfig(t *testing.T) {
 			t.Errorf("taskyou type = %v, want stdio", taskyou["type"])
 		}
 
-		// alwaysLoad keeps taskyou's tools (esp. taskyou_complete) out of Claude
-		// Code's tool-search deferral, so agents can always signal completion.
+		// alwaysLoad is the precise per-server opt-out of Claude Code's tool-search
+		// deferral (belt-and-suspenders alongside the session-wide ENABLE_TOOL_SEARCH=false
+		// set in setupClaudeHooks), so agents can always reach taskyou_complete.
 		if taskyou["alwaysLoad"] != true {
 			t.Errorf("taskyou alwaysLoad = %v, want true", taskyou["alwaysLoad"])
 		}
@@ -1536,6 +1537,38 @@ func TestWriteWorkflowMCPConfig(t *testing.T) {
 			if i < len(autoApprove) && autoApprove[i] != tool {
 				t.Errorf("autoApprove[%d] = %v, want %v", i, autoApprove[i], tool)
 			}
+		}
+	})
+
+	t.Run("pre-trusts the worktree so onboarding doesn't stall the step", func(t *testing.T) {
+		configPath := setupTempConfigDir(t)
+		worktreePath := t.TempDir()
+
+		if err := writeWorkflowMCPConfig(worktreePath, 123, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("failed to read claude.json: %v", err)
+		}
+		var config map[string]interface{}
+		if err := json.Unmarshal(data, &config); err != nil {
+			t.Fatalf("failed to parse claude.json: %v", err)
+		}
+		projects := config["projects"].(map[string]interface{})
+		projectConfig, ok := projects[worktreePath].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected project config for %s", worktreePath)
+		}
+
+		// Without these, a fresh worktree blocks on the "trust this folder?" prompt
+		// with no human to answer, hanging the unattended workflow step.
+		if projectConfig["hasTrustDialogAccepted"] != true {
+			t.Errorf("hasTrustDialogAccepted = %v, want true", projectConfig["hasTrustDialogAccepted"])
+		}
+		if projectConfig["hasCompletedProjectOnboarding"] != true {
+			t.Errorf("hasCompletedProjectOnboarding = %v, want true", projectConfig["hasCompletedProjectOnboarding"])
 		}
 	})
 
@@ -2036,6 +2069,86 @@ func TestCleanupWorktreeNonWorktreeTask(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(projectDir, ".claude", "settings.local.json")); !os.IsNotExist(err) {
 		t.Error("expected settings.local.json to be removed")
 	}
+}
+
+// TestSetupClaudeHooksDisablesToolSearch verifies setupClaudeHooks writes
+// ENABLE_TOOL_SEARCH=false into the worktree settings' env block so taskyou's MCP tools
+// (esp. taskyou_complete) load upfront instead of being deferred behind ToolSearch — and
+// that it preserves any env vars already present in an existing settings.local.json.
+func TestSetupClaudeHooksDisablesToolSearch(t *testing.T) {
+	readEnv := func(t *testing.T, workDir string) map[string]interface{} {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(workDir, ".claude", "settings.local.json"))
+		if err != nil {
+			t.Fatalf("read settings.local.json: %v", err)
+		}
+		var cfg map[string]interface{}
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("parse settings.local.json: %v", err)
+		}
+		env, ok := cfg["env"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected env block in settings.local.json")
+		}
+		return env
+	}
+
+	newExec := func(t *testing.T) *Executor {
+		t.Helper()
+		tmpFile, err := os.CreateTemp("", "hooks-*.db")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+		tmpFile.Close()
+		database, err := db.Open(tmpFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { database.Close() })
+		return New(database, config.New(database))
+	}
+
+	t.Run("fresh settings", func(t *testing.T) {
+		exec := newExec(t)
+		workDir := t.TempDir()
+		cleanup, err := exec.setupClaudeHooks(workDir, 1)
+		if err != nil {
+			t.Fatalf("setupClaudeHooks: %v", err)
+		}
+		if cleanup != nil {
+			defer cleanup()
+		}
+		if env := readEnv(t, workDir); env["ENABLE_TOOL_SEARCH"] != "false" {
+			t.Errorf("ENABLE_TOOL_SEARCH = %v, want \"false\"", env["ENABLE_TOOL_SEARCH"])
+		}
+	})
+
+	t.Run("preserves existing env vars", func(t *testing.T) {
+		exec := newExec(t)
+		workDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(workDir, ".claude"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		existing := `{"env":{"FOO":"bar"}}`
+		if err := os.WriteFile(filepath.Join(workDir, ".claude", "settings.local.json"), []byte(existing), 0644); err != nil {
+			t.Fatal(err)
+		}
+		cleanup, err := exec.setupClaudeHooks(workDir, 1)
+		if err != nil {
+			t.Fatalf("setupClaudeHooks: %v", err)
+		}
+		if cleanup != nil {
+			defer cleanup()
+		}
+		env := readEnv(t, workDir)
+		if env["ENABLE_TOOL_SEARCH"] != "false" {
+			t.Errorf("ENABLE_TOOL_SEARCH = %v, want \"false\"", env["ENABLE_TOOL_SEARCH"])
+		}
+		if env["FOO"] != "bar" {
+			t.Errorf("existing env var FOO = %v, want \"bar\" (must be preserved)", env["FOO"])
+		}
+	})
 }
 
 // TestBuildPromptUniversalGuidance verifies that the worktree-safety constraint and the

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1501,9 +1501,8 @@ func TestWriteWorkflowMCPConfig(t *testing.T) {
 			t.Errorf("taskyou type = %v, want stdio", taskyou["type"])
 		}
 
-		// alwaysLoad is the precise per-server opt-out of Claude Code's tool-search
-		// deferral (belt-and-suspenders alongside the session-wide ENABLE_TOOL_SEARCH=false
-		// set in setupClaudeHooks), so agents can always reach taskyou_complete.
+		// alwaysLoad asks Claude Code to load taskyou's tools upfront (best-effort) so a
+		// task that wants them (e.g. taskyou_needs_input) can reach them without a search.
 		if taskyou["alwaysLoad"] != true {
 			t.Errorf("taskyou alwaysLoad = %v, want true", taskyou["alwaysLoad"])
 		}
@@ -2069,86 +2068,6 @@ func TestCleanupWorktreeNonWorktreeTask(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(projectDir, ".claude", "settings.local.json")); !os.IsNotExist(err) {
 		t.Error("expected settings.local.json to be removed")
 	}
-}
-
-// TestSetupClaudeHooksDisablesToolSearch verifies setupClaudeHooks writes
-// ENABLE_TOOL_SEARCH=false into the worktree settings' env block so taskyou's MCP tools
-// (esp. taskyou_complete) load upfront instead of being deferred behind ToolSearch — and
-// that it preserves any env vars already present in an existing settings.local.json.
-func TestSetupClaudeHooksDisablesToolSearch(t *testing.T) {
-	readEnv := func(t *testing.T, workDir string) map[string]interface{} {
-		t.Helper()
-		data, err := os.ReadFile(filepath.Join(workDir, ".claude", "settings.local.json"))
-		if err != nil {
-			t.Fatalf("read settings.local.json: %v", err)
-		}
-		var cfg map[string]interface{}
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			t.Fatalf("parse settings.local.json: %v", err)
-		}
-		env, ok := cfg["env"].(map[string]interface{})
-		if !ok {
-			t.Fatal("expected env block in settings.local.json")
-		}
-		return env
-	}
-
-	newExec := func(t *testing.T) *Executor {
-		t.Helper()
-		tmpFile, err := os.CreateTemp("", "hooks-*.db")
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(func() { os.Remove(tmpFile.Name()) })
-		tmpFile.Close()
-		database, err := db.Open(tmpFile.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(func() { database.Close() })
-		return New(database, config.New(database))
-	}
-
-	t.Run("fresh settings", func(t *testing.T) {
-		exec := newExec(t)
-		workDir := t.TempDir()
-		cleanup, err := exec.setupClaudeHooks(workDir, 1)
-		if err != nil {
-			t.Fatalf("setupClaudeHooks: %v", err)
-		}
-		if cleanup != nil {
-			defer cleanup()
-		}
-		if env := readEnv(t, workDir); env["ENABLE_TOOL_SEARCH"] != "false" {
-			t.Errorf("ENABLE_TOOL_SEARCH = %v, want \"false\"", env["ENABLE_TOOL_SEARCH"])
-		}
-	})
-
-	t.Run("preserves existing env vars", func(t *testing.T) {
-		exec := newExec(t)
-		workDir := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(workDir, ".claude"), 0755); err != nil {
-			t.Fatal(err)
-		}
-		existing := `{"env":{"FOO":"bar"}}`
-		if err := os.WriteFile(filepath.Join(workDir, ".claude", "settings.local.json"), []byte(existing), 0644); err != nil {
-			t.Fatal(err)
-		}
-		cleanup, err := exec.setupClaudeHooks(workDir, 1)
-		if err != nil {
-			t.Fatalf("setupClaudeHooks: %v", err)
-		}
-		if cleanup != nil {
-			defer cleanup()
-		}
-		env := readEnv(t, workDir)
-		if env["ENABLE_TOOL_SEARCH"] != "false" {
-			t.Errorf("ENABLE_TOOL_SEARCH = %v, want \"false\"", env["ENABLE_TOOL_SEARCH"])
-		}
-		if env["FOO"] != "bar" {
-			t.Errorf("existing env var FOO = %v, want \"bar\" (must be preserved)", env["FOO"])
-		}
-	})
 }
 
 // TestBuildPromptUniversalGuidance verifies that the worktree-safety constraint and the

--- a/internal/pipeline/compose.go
+++ b/internal/pipeline/compose.go
@@ -119,7 +119,10 @@ func composeInstruction(def Definition, step Step) string {
 	} else {
 		b.WriteString("- Do NOT open a pull request — a later step does that.\n")
 	}
-	b.WriteString("- Then call `taskyou_complete` with a one-line summary. That advances the workflow.")
+	// The push IS the completion signal — ty detects a committed-and-pushed step and
+	// advances the DAG automatically. There is no tool to call and nothing to wait on;
+	// finishing your turn with the work pushed is what hands off to the next step.
+	b.WriteString("- That's it. Once your work is committed and pushed, the workflow advances on its own — don't wait, poll, or look for a tool to signal completion.")
 
 	return b.String()
 }

--- a/internal/pipeline/group.go
+++ b/internal/pipeline/group.go
@@ -43,6 +43,13 @@ func hasPipelineTag(tags string) bool {
 	return false
 }
 
+// TerminalStepParkedLog is the system-log line marking a finished terminal step as
+// parked in 'blocked' awaiting a human merge. The Stop hook writes it when it catches
+// the step finished; the daemon sweep writes it (once) when the Stop hook fired mid-
+// push and left the generic "waiting for input" state instead. Shared so both paths
+// use the same text and the sweep can dedupe against it.
+const TerminalStepParkedLog = "Final workflow step finished — parked in 'blocked' for a human to review and merge."
+
 // IsTerminalStep reports whether a workflow step is the sink — the step nothing
 // else depends on, which is the one that opens the PR (see composeInstruction).
 // A finished terminal step parks in 'blocked' awaiting a human merge review rather

--- a/internal/pipeline/group.go
+++ b/internal/pipeline/group.go
@@ -43,6 +43,22 @@ func hasPipelineTag(tags string) bool {
 	return false
 }
 
+// IsTerminalStep reports whether a workflow step is the sink — the step nothing
+// else depends on, which is the one that opens the PR (see composeInstruction).
+// A finished terminal step parks in 'blocked' awaiting a human merge review rather
+// than advancing to 'done'; every other step goes 'done' so its dependents
+// auto-queue. Non-workflow tasks are never terminal steps.
+func IsTerminalStep(database *db.DB, task *db.Task) bool {
+	if !IsWorkflowTask(task) {
+		return false
+	}
+	dependents, err := database.GetBlockedBy(task.ID)
+	if err != nil {
+		return false
+	}
+	return len(dependents) == 0
+}
+
 // GroupWorkflows partitions tasks into workflow groups (2+ members sharing a
 // branch) and the remaining ungrouped tasks, preserving input order for the rest.
 func GroupWorkflows(tasks []*db.Task) (groups []*Group, rest []*db.Task) {

--- a/internal/pipeline/group_test.go
+++ b/internal/pipeline/group_test.go
@@ -98,3 +98,34 @@ func TestIsWorkflowTaskRequiresTagAndBranch(t *testing.T) {
 		t.Error("tagged + branch → should be a workflow task")
 	}
 }
+
+func TestIsTerminalStep(t *testing.T) {
+	database := testDB(t)
+	branch := "pipeline/1-x"
+
+	// Two workflow steps on a shared branch, wired first → last (last depends on first).
+	first := &db.Task{Title: "[Plan] x", Status: db.StatusDone, Type: db.TypeCode, Project: "test", Tags: "pipeline", BranchName: branch}
+	must(t, database.CreateTask(first))
+	last := &db.Task{Title: "[Verify] x", Status: db.StatusProcessing, Type: db.TypeCode, Project: "test", Tags: "pipeline", SourceBranch: branch}
+	must(t, database.CreateTask(last))
+	must(t, database.AddDependency(first.ID, last.ID, true)) // first blocks last
+
+	first, _ = database.GetTask(first.ID)
+	last, _ = database.GetTask(last.ID)
+
+	// The sink (nothing depends on it) is the terminal step; the earlier step isn't.
+	if IsTerminalStep(database, first) {
+		t.Error("first step has a dependent (last) — should NOT be terminal")
+	}
+	if !IsTerminalStep(database, last) {
+		t.Error("last step has no dependents — should be terminal")
+	}
+
+	// A non-workflow task is never a terminal step, even with no dependents.
+	plain := &db.Task{Title: "plain", Status: db.StatusProcessing, Type: db.TypeCode, Project: "test"}
+	must(t, database.CreateTask(plain))
+	plain, _ = database.GetTask(plain.ID)
+	if IsTerminalStep(database, plain) {
+		t.Error("non-workflow task should never be a terminal step")
+	}
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,12 +1,29 @@
 package pipeline
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/bborn/workflow/internal/db"
 )
+
+// TestMain isolates the whole package's tests from the developer's real workflows
+// dir (~/.config/task/workflows). registry() overlays custom YAML from WorkflowsDir()
+// onto the in-code built-ins, so a stray local workflow named like a built-in (e.g.
+// plan-code-review) would shadow it and break tests that assert the built-in shape.
+// Pointing TY_WORKFLOWS_DIR at an empty dir makes every test see built-ins only.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pipeline-workflows-empty-*")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("TY_WORKFLOWS_DIR", dir)
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 func testDB(t *testing.T) *db.DB {
 	t.Helper()

--- a/scripts/qa/lib.sh
+++ b/scripts/qa/lib.sh
@@ -13,21 +13,25 @@ TY_QA_SID="${TY_QA_SID:-qa}"
 export WORKTREE_DB_PATH="$TY_QA_ROOT/tasks.db"
 export WORKTREE_SESSION_ID="$TY_QA_SID"
 
-# Isolate ALL tmux usage onto a dedicated server socket so server-global state —
-# the root S-arrow key bindings and join/break-pane the TUI issues — never touches
-# the user's live tmux server. This function shadows the `tmux` binary for every
-# script that sources lib.sh, so bare `tmux ...` calls route to the isolated socket.
-# ty itself is launched *inside* this server (via `tmux new-session ... ty`), so it
-# inherits $TMUX and routes its own bare `tmux` calls to the same socket. Use
-# `command tmux` to reach the real binary on the default server.
-export TY_QA_TMUX_SOCKET="${TY_QA_TMUX_SOCKET:-taskyou-qa-$TY_QA_SID}"
+# Isolate ALL tmux usage onto a private tmux server via TMUX_TMPDIR. tmux's default
+# socket lives under $TMUX_TMPDIR, so pointing it at the instance dir gives every
+# tmux command here — AND ty's own internal `tmux` calls, which inherit this env
+# (they're plain exec.Command with no cmd.Env) — a private server that never touches
+# the user's live tmux. This is what lets a full isolated *daemon* (Tier 3) run
+# alongside the live one: the daemon inherits TMUX_TMPDIR, so its executor windows
+# land on the private server. We also clear $TMUX so a script or daemon launched
+# from inside the user's live tmux still routes to the private server, not the
+# ambient one. (Requires the daemon PID lock to be keyed to the DB dir — it is.)
+export TMUX_TMPDIR="$TY_QA_ROOT/tmux"
+mkdir -p "$TMUX_TMPDIR"
+unset TMUX
 # Resolve the real binary once instead of using `command tmux` inside the
 # wrapper: macOS stock bash 3.2 has an errexit bug where a failing
 # `command foo || true` still aborts a `set -e` script, which broke every
 # ty-qa script at the first `tmux kill-session` against a not-yet-running
 # QA server.
 TY_QA_TMUX_BIN="$(command -v tmux)"
-tmux() { "$TY_QA_TMUX_BIN" -L "$TY_QA_TMUX_SOCKET" "$@"; }
+tmux() { env -u TMUX "$TY_QA_TMUX_BIN" "$@"; }
 
 # Derived handles.
 TY_BIN="${TY_BIN:-$TY_QA_ROOT/ty}"
@@ -37,8 +41,9 @@ TY_UI_SESSION="task-ui-$TY_QA_SID"
 TY_DAEMON_SESSION="task-daemon-$TY_QA_SID"
 TY_UI_PANE="$TY_UI_SESSION:tui"
 
-# Run the isolated binary with the instance env.
-ty() { "$TY_BIN" "$@"; }
+# Run the isolated binary with the instance env. TMUX is cleared (see above) so
+# ty's own tmux calls route to the private server.
+ty() { env -u TMUX "$TY_BIN" "$@"; }
 
 ty_qa_require_built() {
   if [[ ! -x "$TY_BIN" ]]; then

--- a/scripts/qa/ty-qa-daemon.sh
+++ b/scripts/qa/ty-qa-daemon.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Start the isolated FULL daemon (harness Tier 3), running real end-to-end executor
+# spawning — alongside the live daemon, without touching it. Works because:
+#   - the daemon PID lock is keyed to the instance DB dir (not a global path), so
+#     both daemons can hold their own lock; and
+#   - tmux is isolated via TMUX_TMPDIR (set in lib.sh), so the isolated daemon's
+#     executor windows land on a private tmux server.
+# Usage: ty-qa-daemon.sh          # start (backgrounded)
+#        ty-qa-daemon.sh stop      # stop just the daemon
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+PIDFILE="$TY_QA_ROOT/daemon.pid"
+LOG="$TY_QA_ROOT/daemon.log"
+
+if [[ "${1:-}" == "stop" ]]; then
+  [[ -f "$PIDFILE" ]] && kill "$(cat "$PIDFILE")" 2>/dev/null && echo "stopped isolated daemon" || echo "not running"
+  exit 0
+fi
+
+ty_qa_require_built
+
+if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+  echo "isolated daemon already running (pid $(cat "$PIDFILE"))"
+  exit 0
+fi
+
+nohup env -u TMUX "$TY_BIN" daemon >"$LOG" 2>&1 &
+sleep 2
+if [[ -f "$PIDFILE" ]]; then
+  echo "isolated daemon started (pid $(cat "$PIDFILE")); log: $LOG"
+else
+  echo "daemon did not write a PID file — check $LOG" >&2
+  tail -5 "$LOG" >&2 || true
+  exit 1
+fi

--- a/scripts/qa/ty-qa-down.sh
+++ b/scripts/qa/ty-qa-down.sh
@@ -6,6 +6,11 @@
 set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
+# Stop the isolated full daemon (Tier 3), if running. Its PID file is keyed to the
+# instance DB dir (see getPidFilePath), so this never touches the live daemon.
+if [[ -f "$TY_QA_ROOT/daemon.pid" ]]; then
+  kill "$(cat "$TY_QA_ROOT/daemon.pid")" 2>/dev/null || true
+fi
 tmux kill-session -t "$TY_UI_SESSION" 2>/dev/null || true
 tmux kill-session -t "$TY_DAEMON_SESSION" 2>/dev/null || true
 


### PR DESCRIPTION
Closes three daemon-side reliability gaps that stalled workflows, found by dogfooding the `plan-code-verify` workflow (after the `.mcp.json` hijack fix, #637). Each gap forced a manual salvage during the dogfood run; this makes the DAG advance on its own.

## Gap 1 — a step that finished but forgot `taskyou_complete` gets parked `blocked`
The Stop hook (`cmd/task/main.go`) turned `end_turn` while `processing` into `blocked`, so a step whose agent committed + pushed its work but didn't call `taskyou_complete` stalled the whole DAG.
**Fix:** a workflow step that pushed its work — clean worktree **and** `HEAD == upstream` — auto-completes to `done` (via new `workflowStepFinished`). A step that stopped mid-work or to ask (uncommitted / unpushed) still blocks. Conservative: any doubt → block. (+`TestWorkflowStepFinished`)

## Gap 2 — one dropped auto-queue write orphans a workflow forever
`ProcessCompletedBlocker` was a single-shot, best-effort re-queue: a lost `SQLITE_BUSY` write left the dependent `blocked` permanently, and it masked misses by reporting tasks it never actually flipped (the call-site error was discarded too).
**Fix:**
- report only genuine `blocked → queued` flips; skip already-started (needs-input) tasks; propagate errors; log at the call site.
- add **`RequeueReadyTasks`** — an idempotent safety-net sweep the daemon runs every ~16s that re-queues any *never-started* `blocked` step whose blockers are all done. (+`TestRequeueReadyTasks`, `TestProcessCompletedBlocker` updated for the non-masking behavior)

The `started_at IS NULL` guard is what safely distinguishes "waiting in the DAG" from "ran and is waiting on a human".

## Gap 3 — completed step's session lingers up to 30 minutes
The MCP `onComplete` callback is a no-op (never wired), and `pollTmuxSession` intentionally doesn't kill on `done`, so a finished step's interactive session idled until the 30-min janitor — holding a tmux window across the handoff.
**Fix:** tear down a done **workflow** step's session immediately (`teardownWorkflowStepSession`, gated on `pipeline.IsWorkflowTask`); ordinary tasks keep their window for human review.

## Tests
Full suite green. New/updated: `TestWorkflowStepFinished`, `TestRequeueReadyTasks`, `TestProcessCompletedBlocker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
