### PR TITLE
fix(workflow): a step on a detached HEAD never counts as finished → DAG stalls

### DIFF
--- a/cmd/task/stophook_test.go
+++ b/cmd/task/stophook_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bborn/workflow/internal/db"
@@ -55,6 +56,18 @@ func TestWorkflowStepFinished(t *testing.T) {
 	}
 	if !workflowStepFinished(task) {
 		t.Error("clean + pushed step (no upstream tracking) SHOULD be finished")
+	}
+
+	// DETACHED HEAD → still finished. Non-root steps share one branch and git won't
+	// attach two worktrees to it, so those worktrees run detached. HEAD is still the
+	// pushed commit, so the step IS finished — the old --abbrev-ref check saw "HEAD"
+	// and wrongly reported unfinished forever, stalling the whole DAG.
+	git(t, wt, "checkout", "--detach", "HEAD")
+	if out, err := exec.Command("git", "-C", wt, "rev-parse", "--abbrev-ref", "HEAD").Output(); err != nil || strings.TrimSpace(string(out)) != "HEAD" {
+		t.Fatalf("test precondition failed: expected a detached HEAD, got %q (%v)", strings.TrimSpace(string(out)), err)
+	}
+	if !workflowStepFinished(task) {
+		t.Error("clean + pushed step on a DETACHED HEAD SHOULD be finished")
 	}
 
 	// Uncommitted change → not finished.

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -743,13 +743,20 @@ func GetClaudePIDFromPane(paneID string) int {
 // KillClaudeProcess terminates the Claude process for a task to free up memory.
 // This is called when a task is completed, closed, or deleted.
 // WorkflowStepFinished reports whether a workflow step has committed AND pushed its
-// work: its worktree is clean and HEAD matches the pushed remote-tracking ref. That
-// is the signal a step completed its handoff (per the composed step instructions),
-// used both by the Stop hook (auto-complete a step that finished but didn't call
+// work: its worktree is clean and HEAD has been pushed to some origin branch. That is
+// the signal a step completed its handoff (per the composed step instructions), used
+// both by the Stop hook (auto-complete a step that finished but didn't call
 // taskyou_complete) and by the daemon's reconcile sweep (recover a step that was
 // blocked because the hook fired at a transient moment). Conservative: any doubt
-// returns false. Compares to refs/remotes/origin/<branch> rather than @{u} because
-// non-root step worktrees check out the shared branch without upstream tracking.
+// returns false.
+//
+// It checks "HEAD is reachable from an origin ref" rather than "HEAD == origin/<branch
+// of --abbrev-ref>" because non-root steps share one branch and git will not attach two
+// worktrees to it — so those worktrees run on a DETACHED HEAD. Deriving the branch from
+// --abbrev-ref then yields "HEAD" and the old check wrongly reported the step unfinished
+// forever, stalling the whole DAG. Reachability-from-origin holds whether the worktree
+// is on the shared branch, on a parallel step's own branch, or detached — as long as the
+// push landed. (A push failure leaves HEAD on no origin ref, so it still reads unfinished.)
 func WorkflowStepFinished(worktreePath string) bool {
 	if worktreePath == "" {
 		return false
@@ -761,16 +768,18 @@ func WorkflowStepFinished(worktreePath string) bool {
 	if errH != nil {
 		return false
 	}
-	branch, errB := exec.Command("git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD").Output()
-	br := strings.TrimSpace(string(branch))
-	if errB != nil || br == "" || br == "HEAD" {
-		return false
-	}
-	remote, errR := exec.Command("git", "-C", worktreePath, "rev-parse", "refs/remotes/origin/"+br).Output()
+	// Which origin branches contain HEAD? Non-empty means the step's commit was pushed.
+	refs, errR := exec.Command("git", "-C", worktreePath, "branch", "-r", "--contains",
+		strings.TrimSpace(string(head)), "--format=%(refname:short)").Output()
 	if errR != nil {
 		return false
 	}
-	return strings.TrimSpace(string(head)) == strings.TrimSpace(string(remote))
+	for _, line := range strings.Split(strings.TrimSpace(string(refs)), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "origin/") {
+			return true
+		}
+	}
+	return false
 }
 
 // teardownWorkflowStepSession kills the executor process and tmux window for a


### PR DESCRIPTION
## The bug
`WorkflowStepFinished` derived the branch from `git rev-parse --abbrev-ref HEAD` and returned false when it was `HEAD` (detached). But **non-root workflow steps share one branch, and git won't attach two worktrees to the same branch** — so those worktrees run on a **detached HEAD**. A step could commit + push cleanly and still be reported unfinished forever, so neither the Stop hook nor the reconcile sweep advanced it → **the whole workflow stalls at that step**. Whether a step re-attached (`git checkout -B`) was left to agent whim, so it was an intermittent hang.

## The fix
Judge "finished" by whether **HEAD is reachable from an origin branch** (the push landed) rather than matching a branch name from `--abbrev-ref`. Holds whether the worktree is on the shared branch, a parallel step's own branch, or detached — and still reads unfinished when the push failed.

## How it was found
Dogfooding a **parallel-review** workflow: the Code step pushed from a detached HEAD and the DAG hung there. With the fix, the daemon completed the stuck step within one sweep and the parallel reviews ran concurrently. Regression case added to `TestWorkflowStepFinished`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)