### PR TITLE
fix(workflow): symlink-resolve the write-guard + sweep recovers stuck 'processing' steps

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -382,23 +382,41 @@ func (e *Executor) reconcileReadyTasks() {
 }
 
 // reconcileFinishedWorkflowSteps recovers workflow steps that finished their work
-// (committed + pushed) but got parked in 'blocked' — because the Stop hook's
-// git-state check fired at a transient moment (e.g. a temp file briefly dirtying
-// the worktree, or the push still settling). Those steps stall the whole DAG. This
-// sweep marks any such step 'done' once its state has settled, then advances the
-// workflow. It skips steps that asked a question (genuine needs-input) and the
-// terminal step (which parks in 'blocked' on purpose, awaiting a human merge), so
-// it never advances past one that's legitimately waiting.
+// (committed + pushed) but never reached 'done'. Two shapes: (1) parked in 'blocked'
+// because the Stop hook's git-state check fired at a transient moment (a temp file
+// briefly dirtying the worktree, or the push still settling); (2) stuck in
+// 'processing' because the executor session ended without signalling — a non-Claude
+// executor that fires no Stop hook, or a Claude agent that looped and was killed. Both
+// stall the whole DAG. This sweep marks any such settled step 'done' (or parks the
+// terminal step for merge review), then advances the workflow. It skips steps that
+// asked a question (genuine needs-input), the terminal step's own merge-park, and any
+// 'processing' step whose executor window is still live (genuinely working).
 func (e *Executor) reconcileFinishedWorkflowSteps() {
-	tasks, err := e.db.ListTasks(db.ListTasksOptions{Status: db.StatusBlocked, Tag: "pipeline", Limit: 500})
-	if err != nil {
-		e.logger.Error("Failed to list blocked pipeline tasks", "error", err)
-		return
+	// Steps that ended their turn ('blocked') OR are stuck 'processing' after their
+	// session ended without signalling done — e.g. a non-Claude executor that fires no
+	// Stop hook, or a Claude agent that looped and was killed. A 'processing' step is
+	// only touched once its executor window is GONE (see below), so one that's genuinely
+	// still working is never disturbed.
+	var tasks []*db.Task
+	for _, status := range []string{db.StatusBlocked, db.StatusProcessing} {
+		got, err := e.db.ListTasks(db.ListTasksOptions{Status: status, Tag: "pipeline", Limit: 500})
+		if err != nil {
+			e.logger.Error("Failed to list pipeline tasks", "status", status, "error", err)
+			continue
+		}
+		tasks = append(tasks, got...)
 	}
 	for _, task := range tasks {
 		// Only steps that actually ran; leave un-started (DAG-waiting) ones to
 		// reconcileReadyTasks.
 		if task.StartedAt == nil || task.WorktreePath == "" {
+			continue
+		}
+		// A 'processing' step is still owned by a live executor session — leave it be.
+		// Only once its window is gone (the session ended without moving the task off
+		// 'processing') is it a candidate for recovery. WorkflowStepFinished below is the
+		// real guard; this just avoids racing a running agent.
+		if task.Status == db.StatusProcessing && tmuxWindowExistsForTask(task.ID) {
 			continue
 		}
 		// Don't advance past a genuine needs-input question.

--- a/internal/executor/worktree_guard.go
+++ b/internal/executor/worktree_guard.go
@@ -260,15 +260,45 @@ func cleanPath(p, cwd string) string {
 }
 
 // pathWithin reports whether target is at or below root. Both must be absolute.
+// Symlinks are resolved first so a worktree under a symlinked path isn't mistaken for
+// an escape — e.g. macOS /tmp → /private/tmp: WORKTREE_PATH is /tmp/… but a tool may
+// resolve a write to /private/tmp/…, which without this reads as outside the worktree
+// and gets falsely denied (trapping the agent in a retry loop). Resolving also makes
+// the guard *stricter* against a real symlink that escapes the worktree.
 func pathWithin(root, target string) bool {
 	if root == "" || target == "" {
 		return false
 	}
+	root = resolveSymlinks(root)
+	target = resolveSymlinks(target)
 	rel, err := filepath.Rel(root, target)
 	if err != nil {
 		return false
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// resolveSymlinks returns path with its longest existing prefix resolved through
+// symlinks, re-appending any not-yet-existing tail. A write target need not exist yet
+// (it's about to be created), so we resolve the deepest ancestor directory that does.
+func resolveSymlinks(path string) string {
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	rest := ""
+	dir := path
+	for {
+		parent := filepath.Dir(dir)
+		rest = filepath.Join(filepath.Base(dir), rest)
+		if parent == dir {
+			return path // reached the filesystem root without resolving anything
+		}
+		dir = parent
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Join(resolved, rest)
+		}
+	}
 }
 
 // allowlisted reports whether abs is at or below any allowlisted prefix.

--- a/internal/executor/worktree_guard_test.go
+++ b/internal/executor/worktree_guard_test.go
@@ -2,8 +2,36 @@ package executor
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+// TestPathWithinResolvesSymlinks guards the fix for the guard falsely denying writes
+// when the worktree lives under a symlinked path (macOS /tmp -> /private/tmp): the
+// worktree root is /tmp/… but a tool resolves a write to /private/tmp/…, which without
+// symlink resolution reads as an escape and traps the agent in a retry loop.
+func TestPathWithinResolvesSymlinks(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "wtlink")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	// Root is the symlink path; the write target is the resolved real path (and a
+	// not-yet-created file, as a real write target is).
+	if !pathWithin(link, filepath.Join(real, "REVIEW.md")) {
+		t.Error("a write to the resolved real path should be WITHIN a symlinked worktree root")
+	}
+	// And the reverse: root is the real path, the write goes through the symlink.
+	if !pathWithin(real, filepath.Join(link, "REVIEW.md")) {
+		t.Error("a write via the symlinked path should be WITHIN the real worktree root")
+	}
+	// A genuine escape is still outside.
+	if pathWithin(link, filepath.Join(t.TempDir(), "x")) {
+		t.Error("a path outside the worktree must NOT be reported within")
+	}
+}
 
 // wt is a representative managed-worktree root (contains the .task-worktrees segment).
 const wt = "/home/u/proj/.task-worktrees/4244-speed"


### PR DESCRIPTION
Two reliability gaps found dogfooding a workflow whose steps ran under `/tmp` (follows #640).

## 1. Write-guard didn't resolve symlinks
`pathWithin` compared paths with `filepath.Rel` only. On macOS `/tmp`→`/private/tmp`, `WORKTREE_PATH` is `/tmp/…` but a tool resolves a write to `/private/tmp/…` — read as an escape and **denied**, trapping the agent in a retry loop so it never ended its turn. Now both root and target are symlink-resolved first (deepest existing ancestor, since a write target may not exist yet). This also makes the guard **stricter** against a real symlink that escapes the worktree. Real projects under `/Users/…` never hit this, but the fix is correct and defensive.

## 2. Sweep only recovered 'blocked' steps
A step whose executor session ended **without signalling done** — a non-Claude executor (no Stop hook) or a Claude agent that looped and was killed — sat in `processing` forever and hung the DAG. The sweep now also scans `processing` pipeline steps, but only touches one whose **executor window is gone** (`WorkflowStepFinished` stays the real guard), so a genuinely-working step is never disturbed.

Both surfaced in the same run: the guard loop (#1) left a review step stuck `processing` (#2). Adds `TestPathWithinResolvesSymlinks`; full suite + golangci-lint v2.8.0 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)