### PR TITLE
fix(workflow): never auto-complete a step that produced no commit (sweep was silently dropping Build/review stages)

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4634,7 +4634,7 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 			// 'done' so its dependents auto-queue. A step that stopped to ask a question
 			// or left work uncommitted/unpushed hasn't finished — block as before, and
 			// the daemon's sweep is the backstop for a Stop hook that fires mid-push.
-			if pipeline.IsWorkflowTask(task) && workflowStepFinished(task) {
+			if pipeline.IsWorkflowTask(task) && workflowStepFinished(database, task) {
 				if pipeline.IsTerminalStep(database, task) {
 					database.UpdateTaskStatus(taskID, db.StatusBlocked)
 					database.AppendTaskLog(taskID, "system", pipeline.TerminalStepParkedLog)
@@ -4656,12 +4656,17 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 	return nil
 }
 
-// workflowStepFinished reports whether a workflow step has committed AND pushed its
-// work (see executor.WorkflowStepFinished). Used by the Stop hook to advance a step
-// that finished but didn't call taskyou_complete; the daemon's sweep is the backstop
-// for when the hook fires at a transient moment.
-func workflowStepFinished(task *db.Task) bool {
-	return executor.WorkflowStepFinished(task.WorktreePath)
+// workflowStepFinished reports whether a workflow step produced a commit and pushed it
+// (see executor.WorkflowStepFinished). Used by the Stop hook to advance a step whose
+// agent ended its turn; the daemon's sweep is the backstop for when the hook fires at a
+// transient moment. A step that ran but committed nothing is NOT finished — it stays
+// 'blocked' for a human rather than silently completing with no work.
+func workflowStepFinished(database *db.DB, task *db.Task) bool {
+	baseCommit, err := database.GetTaskBaseCommit(task.ID)
+	if err != nil {
+		return false
+	}
+	return executor.WorkflowStepFinished(task.WorktreePath, baseCommit)
 }
 
 // handlePreToolUseHook handles PreToolUse hooks from Claude (before tool execution).

--- a/cmd/task/stophook_test.go
+++ b/cmd/task/stophook_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/executor"
 )
 
 func git(t *testing.T, dir string, args ...string) {
@@ -20,10 +20,23 @@ func git(t *testing.T, dir string, args ...string) {
 	}
 }
 
-// TestWorkflowStepFinished: a step counts as finished only when its worktree is
-// clean AND its HEAD is pushed. Critically, non-root workflow steps check out the
-// shared branch WITHOUT upstream tracking (no `-u`), so the check must use the
-// remote-tracking ref, not @{u}.
+// headSHA returns the worktree's current HEAD commit.
+func headSHA(t *testing.T, dir string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestWorkflowStepFinished: a step counts as finished only when it PRODUCED A COMMIT
+// (HEAD moved off the worktree's base commit) and pushed it, with a clean worktree.
+//
+// The base-commit check is load-bearing: a freshly-created step worktree is clean and
+// its HEAD (the parent step's commit) is already reachable from origin. Reporting that
+// as "finished" let the daemon sweep mark steps done before their agent ever started,
+// silently dropping Build/Review stages and shipping unreviewed code.
 func TestWorkflowStepFinished(t *testing.T) {
 	root := t.TempDir()
 	remote := filepath.Join(root, "remote.git")
@@ -37,7 +50,21 @@ func TestWorkflowStepFinished(t *testing.T) {
 	// Mimic a workflow step: work on a shared branch, no upstream tracking.
 	git(t, wt, "checkout", "-b", "pipeline/shared")
 
-	task := &db.Task{WorktreePath: wt}
+	// The parent step's commit — already pushed. This is where a new step's worktree
+	// starts, and it is the step's base commit.
+	if err := os.WriteFile(filepath.Join(wt, "parent.txt"), []byte("parent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, wt, "add", ".")
+	git(t, wt, "commit", "-m", "parent step work")
+	git(t, wt, "push", "origin", "HEAD:pipeline/shared")
+	base := headSHA(t, wt)
+
+	// THE REGRESSION: a step that has produced nothing sits at its base commit with a
+	// clean worktree, and that commit IS on origin. It must NOT read as finished.
+	if executor.WorkflowStepFinished(wt, base) {
+		t.Error("a step sitting at its base commit (no work) must NOT be finished — this silently drops unstarted steps")
+	}
 
 	// Committed but NOT pushed → not finished.
 	if err := os.WriteFile(filepath.Join(wt, "f.txt"), []byte("x"), 0o644); err != nil {
@@ -45,7 +72,7 @@ func TestWorkflowStepFinished(t *testing.T) {
 	}
 	git(t, wt, "add", ".")
 	git(t, wt, "commit", "-m", "work")
-	if workflowStepFinished(task) {
+	if executor.WorkflowStepFinished(wt, base) {
 		t.Error("committed but unpushed step should NOT be finished")
 	}
 
@@ -54,32 +81,34 @@ func TestWorkflowStepFinished(t *testing.T) {
 	if _, err := exec.Command("git", "-C", wt, "rev-parse", "@{u}").Output(); err == nil {
 		t.Fatal("test precondition failed: expected NO upstream tracking after push without -u")
 	}
-	if !workflowStepFinished(task) {
-		t.Error("clean + pushed step (no upstream tracking) SHOULD be finished")
+	if !executor.WorkflowStepFinished(wt, base) {
+		t.Error("clean + committed + pushed step SHOULD be finished")
 	}
 
 	// DETACHED HEAD → still finished. Non-root steps share one branch and git won't
-	// attach two worktrees to it, so those worktrees run detached. HEAD is still the
-	// pushed commit, so the step IS finished — the old --abbrev-ref check saw "HEAD"
-	// and wrongly reported unfinished forever, stalling the whole DAG.
+	// attach two worktrees to it, so those worktrees run detached.
 	git(t, wt, "checkout", "--detach", "HEAD")
 	if out, err := exec.Command("git", "-C", wt, "rev-parse", "--abbrev-ref", "HEAD").Output(); err != nil || strings.TrimSpace(string(out)) != "HEAD" {
 		t.Fatalf("test precondition failed: expected a detached HEAD, got %q (%v)", strings.TrimSpace(string(out)), err)
 	}
-	if !workflowStepFinished(task) {
-		t.Error("clean + pushed step on a DETACHED HEAD SHOULD be finished")
+	if !executor.WorkflowStepFinished(wt, base) {
+		t.Error("clean + committed + pushed step on a DETACHED HEAD SHOULD be finished")
 	}
 
 	// Uncommitted change → not finished.
 	if err := os.WriteFile(filepath.Join(wt, "f2.txt"), []byte("y"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if workflowStepFinished(task) {
+	if executor.WorkflowStepFinished(wt, base) {
 		t.Error("dirty worktree should NOT be finished")
 	}
 
+	// No recorded base commit → no evidence of work → never finished.
+	if executor.WorkflowStepFinished(wt, "") {
+		t.Error("a step with no recorded base commit must NOT be finished")
+	}
 	// Empty worktree path → not finished.
-	if workflowStepFinished(&db.Task{WorktreePath: ""}) {
+	if executor.WorkflowStepFinished("", base) {
 		t.Error("empty worktree path should NOT be finished")
 	}
 }

--- a/internal/db/dependencies_test.go
+++ b/internal/db/dependencies_test.go
@@ -487,6 +487,46 @@ func TestHasQuestionLog(t *testing.T) {
 	}
 }
 
+// TestBaseCommitAndSessionStartedAt covers the two signals that keep the sweep from
+// completing a step that never ran: the worktree's base commit, and whether an executor
+// session actually started (worktree setup alone must NOT count as a session).
+func TestBaseCommitAndSessionStartedAt(t *testing.T) {
+	db, cleanup := setupDepsTestDB(t)
+	defer cleanup()
+	tk := &Task{Title: "step", Status: StatusProcessing}
+	if err := db.CreateTask(tk); err != nil {
+		t.Fatal(err)
+	}
+
+	if sha, _ := db.GetTaskBaseCommit(tk.ID); sha != "" {
+		t.Errorf("base commit before recording = %q, want empty", sha)
+	}
+	if err := db.SetTaskBaseCommit(tk.ID, "abc123"); err != nil {
+		t.Fatal(err)
+	}
+	if sha, _ := db.GetTaskBaseCommit(tk.ID); sha != "abc123" {
+		t.Errorf("base commit = %q, want abc123", sha)
+	}
+
+	// A task flips to 'processing' and sets up its worktree long before any session.
+	if started, _ := db.HasSessionStarted(tk.ID); started {
+		t.Error("no session has started yet")
+	}
+	if err := db.AppendTaskLog(tk.ID, "system", "Created worktree at /x (branch: pipeline/1-y)"); err != nil {
+		t.Fatal(err)
+	}
+	if started, _ := db.HasSessionStarted(tk.ID); started {
+		t.Error("worktree setup is NOT a session start — conflating them let the sweep complete unstarted steps")
+	}
+
+	if err := db.AppendTaskLog(tk.ID, "system", "Starting new session (executor: claude)"); err != nil {
+		t.Fatal(err)
+	}
+	if started, _ := db.HasSessionStarted(tk.ID); !started {
+		t.Error("session start should be detected once the session begins")
+	}
+}
+
 func TestHasLogLineContaining(t *testing.T) {
 	db, cleanup := setupDepsTestDB(t)
 	defer cleanup()

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -320,6 +320,12 @@ func (db *DB) migrate() error {
 		// claude command so a step can route through a non-Anthropic proxy (ollama)
 		// without swapping CLAUDE_CONFIG_DIR.
 		`ALTER TABLE tasks ADD COLUMN env TEXT DEFAULT ''`,
+		// The commit a task's worktree was created at. A workflow step that has done no
+		// work still sits at this commit, so it is what distinguishes "hasn't produced
+		// anything" from "finished" — without it the auto-complete sweep cannot tell a
+		// freshly-created worktree (clean, HEAD already on origin) from a completed step
+		// and will silently mark unstarted steps done.
+		`ALTER TABLE tasks ADD COLUMN base_commit TEXT DEFAULT ''`,
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -1236,6 +1236,41 @@ func (db *DB) HasLogLineContaining(taskID int64, substr string) (bool, error) {
 	return n > 0, nil
 }
 
+// SetTaskBaseCommit records the commit a task's worktree was created at. Written once,
+// right after the worktree exists and before any agent session starts.
+func (db *DB) SetTaskBaseCommit(taskID int64, sha string) error {
+	_, err := db.Exec(`UPDATE tasks SET base_commit = ? WHERE id = ?`, sha, taskID)
+	return err
+}
+
+// GetTaskBaseCommit returns the commit a task's worktree was created at, or "" if it
+// was never recorded (a task from before the column existed).
+func (db *DB) GetTaskBaseCommit(taskID int64) (string, error) {
+	var sha string
+	err := db.QueryRow(`SELECT COALESCE(base_commit, '') FROM tasks WHERE id = ?`, taskID).Scan(&sha)
+	if err != nil {
+		return "", err
+	}
+	return sha, nil
+}
+
+// HasSessionStarted reports whether the task's executor session actually began. A task
+// flips to 'processing' and then spends tens of seconds on worktree setup (clone, bundle,
+// migrations) before any session exists — so this, not the absence of a tmux window, is
+// how to tell "hasn't started yet" from "ran and finished". Conflating the two let the
+// sweep complete steps before their agent ever launched.
+func (db *DB) HasSessionStarted(taskID int64) (bool, error) {
+	var n int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM task_logs
+		WHERE task_id = ? AND (content LIKE 'Starting new session%' OR content LIKE 'Resuming%')
+	`, taskID).Scan(&n)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
 // GetTaskLogs retrieves logs for a task.
 func (db *DB) GetTaskLogs(taskID int64, limit int) ([]*TaskLog, error) {
 	if limit <= 0 {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -382,6 +382,11 @@ func (e *Executor) reconcileReadyTasks() {
 	}
 }
 
+// minWorkflowStepRuntime is how long a step's session must have been running before the
+// sweep will consider recovering it. A real step that clones, installs and builds takes
+// far longer; anything "completing" faster is almost certainly a step we caught mid-setup.
+const minWorkflowStepRuntime = 30 * time.Second
+
 // reconcileFinishedWorkflowSteps recovers workflow steps that finished their work
 // (committed + pushed) but never reached 'done'. Two shapes: (1) parked in 'blocked'
 // because the Stop hook's git-state check fired at a transient moment (a temp file
@@ -389,9 +394,16 @@ func (e *Executor) reconcileReadyTasks() {
 // 'processing' because the executor session ended without signalling — a non-Claude
 // executor that fires no Stop hook, or a Claude agent that looped and was killed. Both
 // stall the whole DAG. This sweep marks any such settled step 'done' (or parks the
-// terminal step for merge review), then advances the workflow. It skips steps that
-// asked a question (genuine needs-input), the terminal step's own merge-park, and any
-// 'processing' step whose executor window is still live (genuinely working).
+// terminal step for merge review), then advances the workflow.
+//
+// It is deliberately paranoid, because the failure mode of over-eagerness is silent and
+// severe: completing a step that never ran drops it from the DAG and lets downstream
+// steps proceed on unreviewed work. So a step is only ever completed when it PRODUCED A
+// COMMIT (WorkflowStepFinished compares HEAD against the worktree's recorded base
+// commit) and pushed it. On top of that it skips: steps that asked a question (genuine
+// needs-input), the terminal step's own merge-park, and any 'processing' step whose
+// session hasn't started, is younger than minWorkflowStepRuntime, or still owns a live
+// executor window.
 func (e *Executor) reconcileFinishedWorkflowSteps() {
 	// Steps that ended their turn ('blocked') OR are stuck 'processing' after their
 	// session ended without signalling done — e.g. a non-Claude executor that fires no
@@ -413,15 +425,34 @@ func (e *Executor) reconcileFinishedWorkflowSteps() {
 		if task.StartedAt == nil || task.WorktreePath == "" {
 			continue
 		}
-		// A 'processing' step is still owned by a live executor session — leave it be.
-		// Only once its window is gone (the session ended without moving the task off
-		// 'processing') is it a candidate for recovery. WorkflowStepFinished below is the
-		// real guard; this just avoids racing a running agent.
-		if task.Status == db.StatusProcessing && tmuxWindowExistsForTask(task.ID) {
-			continue
+		// A 'processing' step is only a recovery candidate once its session has actually
+		// STARTED and then gone away. A task flips to 'processing' before worktree setup
+		// (clone, bundle, migrations — tens of seconds), during which no session and no
+		// tmux window exist yet: "window gone" alone cannot tell "not started yet" from
+		// "finished", and treating the former as the latter silently marks unstarted
+		// steps done. Require real evidence the session ran, a minimum runtime, and only
+		// then an absent window.
+		if task.Status == db.StatusProcessing {
+			started, err := e.db.HasSessionStarted(task.ID)
+			if err != nil || !started {
+				continue // session never launched — nothing to recover
+			}
+			if time.Since(task.StartedAt.Time) < minWorkflowStepRuntime {
+				continue // too young to have meaningfully run and finished
+			}
+			if tmuxWindowExistsForTask(task.ID) {
+				continue // still owned by a live session
+			}
 		}
 		// Don't advance past a genuine needs-input question.
 		if hasQ, err := e.db.HasQuestionLog(task.ID); err != nil || hasQ {
+			continue
+		}
+		// The step's starting commit. Without it we cannot tell "produced work" from
+		// "sitting where it started", so WorkflowStepFinished refuses to complete.
+		baseCommit, err := e.db.GetTaskBaseCommit(task.ID)
+		if err != nil {
+			e.logger.Error("Failed to read base commit", "id", task.ID, "error", err)
 			continue
 		}
 		// The terminal step is meant to stay 'blocked' once it finishes (its PR awaits
@@ -430,7 +461,7 @@ func (e *Executor) reconcileFinishedWorkflowSteps() {
 		// genuinely settled (committed + pushed), clarify it's parked for merge review
 		// (once) and tear down its now-idle session.
 		if pipeline.IsTerminalStep(e.db, task) {
-			if WorkflowStepFinished(task.WorktreePath) {
+			if WorkflowStepFinished(task.WorktreePath, baseCommit) {
 				if logged, _ := e.db.HasLogLineContaining(task.ID, pipeline.TerminalStepParkedLog); !logged {
 					e.logLine(task.ID, "system", pipeline.TerminalStepParkedLog)
 					e.teardownWorkflowStepSession(task)
@@ -439,7 +470,7 @@ func (e *Executor) reconcileFinishedWorkflowSteps() {
 			}
 			continue
 		}
-		if !WorkflowStepFinished(task.WorktreePath) {
+		if !WorkflowStepFinished(task.WorktreePath, baseCommit) {
 			continue
 		}
 		if err := e.updateStatus(task.ID, db.StatusDone); err != nil {
@@ -776,20 +807,47 @@ func GetClaudePIDFromPane(paneID string) int {
 // forever, stalling the whole DAG. Reachability-from-origin holds whether the worktree
 // is on the shared branch, on a parallel step's own branch, or detached — as long as the
 // push landed. (A push failure leaves HEAD on no origin ref, so it still reads unfinished.)
-func WorkflowStepFinished(worktreePath string) bool {
+// gitHeadCommit returns the HEAD sha of a worktree, or "" if it can't be read.
+func gitHeadCommit(worktreePath string) string {
 	if worktreePath == "" {
+		return ""
+	}
+	out, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func WorkflowStepFinished(worktreePath, baseCommit string) bool {
+	// No worktree, or no recorded starting point, means we have no evidence the step
+	// produced anything. Never auto-complete on no evidence.
+	if worktreePath == "" || baseCommit == "" {
 		return false
 	}
 	if out, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain").Output(); err != nil || len(strings.TrimSpace(string(out))) != 0 {
 		return false
 	}
-	head, errH := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	headOut, errH := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
 	if errH != nil {
 		return false
 	}
-	// Which origin branches contain HEAD? Non-empty means the step's commit was pushed.
+	head := strings.TrimSpace(string(headOut))
+
+	// THE step must have produced a commit. A worktree that was just created — or whose
+	// agent ran and wrote nothing — is clean and sits at baseCommit, which is already
+	// reachable from origin. Without this check such a step reads as "finished" and the
+	// sweep silently marks it done before the agent has even started, dropping the step
+	// (and, worse, letting the DAG advance past unreviewed work).
+	if head == baseCommit {
+		return false
+	}
+
+	// And that commit must be pushed: HEAD reachable from an origin ref. Checked by
+	// reachability rather than "HEAD == origin/<--abbrev-ref>" because non-root steps
+	// share one branch and run on a DETACHED HEAD, where --abbrev-ref yields "HEAD".
 	refs, errR := exec.Command("git", "-C", worktreePath, "branch", "-r", "--contains",
-		strings.TrimSpace(string(head)), "--format=%(refname:short)").Output()
+		head, "--format=%(refname:short)").Output()
 	if errR != nil {
 		return false
 	}
@@ -1540,6 +1598,17 @@ func (e *Executor) executeTask(ctx context.Context, task *db.Task) {
 		return
 	}
 	e.events.EmitTaskWorktreeReady(task)
+
+	// Record the commit this worktree starts at, before anything can run in it. This is
+	// what lets WorkflowStepFinished tell "produced a commit" from "still sitting where
+	// it started" — worktree setup (clone, bundle, migrations) can run for tens of
+	// seconds while the task is already 'processing', and without this the sweep marks
+	// the step done before its agent ever starts.
+	if base := gitHeadCommit(workDir); base != "" {
+		if err := e.db.SetTaskBaseCommit(task.ID, base); err != nil {
+			e.logger.Warn("could not record worktree base commit", "task", task.ID, "error", err)
+		}
+	}
 
 	// Prepare attachments (write to .claude/attachments for seamless access)
 	attachmentPaths, cleanupAttachments := e.prepareAttachments(task.ID, workDir)
@@ -4443,7 +4512,7 @@ func claudeEnvPrefix(dir string) string {
 // claude command right before `claude` — the same slot claudeEnvPrefix uses for
 // CLAUDE_CONFIG_DIR. This is how a single workflow step routes through a
 // non-Anthropic proxy like ollama: set ANTHROPIC_BASE_URL/AUTH_TOKEN (and
-// ANTHROPIC_API_KEY='') here and the spawned claude hits ollama instead of
+// ANTHROPIC_API_KEY=”) here and the spawned claude hits ollama instead of
 // Anthropic, WITHOUT swapping CLAUDE_CONFIG_DIR — so the default config dir
 // (plugins, MCP, TaskYou's trusted worktrees) stays intact and process env
 // wins over any stored creds. Keys are emitted in sorted order so the built

--- a/internal/pipeline/definition_file.go
+++ b/internal/pipeline/definition_file.go
@@ -22,14 +22,14 @@ import (
 
 // stepYAML is the on-disk form of a step.
 type stepYAML struct {
-	Name     string   `yaml:"name"`
-	Kind     string   `yaml:"kind,omitempty"` // Run another kind here (its instructions apply; if it has steps, they're inlined).
-	Executor string   `yaml:"executor,omitempty"`
-	Model    string   `yaml:"model,omitempty"`
-	ConfigDir string  `yaml:"config_dir,omitempty"` // Per-step CLAUDE_CONFIG_DIR override: route this step's Claude through a different config (e.g. an ollama-backed one) without changing the project. ~ is expanded.
-	Env      map[string]string `yaml:"env,omitempty"` // Per-step env overrides injected as a process-env prefix on the claude command (e.g. ANTHROPIC_BASE_URL/AUTH_TOKEN to route through ollama). Distinct from config_dir: env injection keeps the default config dir intact and is what actually reaches a token-auth proxy like ollama.
-	Deps     []string `yaml:"deps,omitempty"`
-	Prompt   string   `yaml:"prompt,omitempty"` // Optional when `kind` is set: the referenced kind supplies the instructions.
+	Name      string            `yaml:"name"`
+	Kind      string            `yaml:"kind,omitempty"` // Run another kind here (its instructions apply; if it has steps, they're inlined).
+	Executor  string            `yaml:"executor,omitempty"`
+	Model     string            `yaml:"model,omitempty"`
+	ConfigDir string            `yaml:"config_dir,omitempty"` // Per-step CLAUDE_CONFIG_DIR override: route this step's Claude through a different config (e.g. an ollama-backed one) without changing the project. ~ is expanded.
+	Env       map[string]string `yaml:"env,omitempty"`        // Per-step env overrides injected as a process-env prefix on the claude command (e.g. ANTHROPIC_BASE_URL/AUTH_TOKEN to route through ollama). Distinct from config_dir: env injection keeps the default config dir intact and is what actually reaches a token-auth proxy like ollama.
+	Deps      []string          `yaml:"deps,omitempty"`
+	Prompt    string            `yaml:"prompt,omitempty"` // Optional when `kind` is set: the referenced kind supplies the instructions.
 	// Verbatim marks a step whose prompt IS the full instruction (no DAG-derived
 	// git handoff is added). It's set when `ty pipeline edit` ejects a built-in
 	// workflow, so the ejected file behaves identically to the built-in.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -36,15 +36,15 @@ import (
 // it; Instruction is the task body template ({{goal}} and {{branch}} are
 // substituted at build time); Deps names the steps that must finish first.
 type Step struct {
-	Name        string   // Unique label, e.g. "Plan", "Code", "Review A", "Collect".
-	Kind        string   // Optional: another kind this step runs. Sets the task's Type (so that kind's instructions apply); if that kind has steps, it's a sub-workflow inlined at build (see flatten.go).
-	Executor    string   // Executor slug (db.ExecutorClaude, db.ExecutorCodex, ...).
-	Model       string   // Per-task model override ("" = the executor's default).
-	ConfigDir   string   // Per-task CLAUDE_CONFIG_DIR override ("" = use the project's/default config dir). Routes this step's Claude through a different config (e.g. ollama) without changing the project.
+	Name        string            // Unique label, e.g. "Plan", "Code", "Review A", "Collect".
+	Kind        string            // Optional: another kind this step runs. Sets the task's Type (so that kind's instructions apply); if that kind has steps, it's a sub-workflow inlined at build (see flatten.go).
+	Executor    string            // Executor slug (db.ExecutorClaude, db.ExecutorCodex, ...).
+	Model       string            // Per-task model override ("" = the executor's default).
+	ConfigDir   string            // Per-task CLAUDE_CONFIG_DIR override ("" = use the project's/default config dir). Routes this step's Claude through a different config (e.g. ollama) without changing the project.
 	Env         map[string]string // Per-task env overrides injected as a process-env prefix on the claude command (e.g. ANTHROPIC_BASE_URL/AUTH_TOKEN to route through ollama). nil = no overrides. Kept distinct from ConfigDir: env injection keeps the default config dir (plugins, MCP, trusted worktrees) intact and process env wins over stored creds — the mechanism that actually reaches ollama.
-	Instruction string   // Full body template (built-in / verbatim steps). Takes precedence over Prompt.
-	Prompt      string   // Custom-workflow body: what the step does; the git handoff is composed from the DAG (see compose.go).
-	Deps        []string // Names of steps that must complete before this one runs.
+	Instruction string            // Full body template (built-in / verbatim steps). Takes precedence over Prompt.
+	Prompt      string            // Custom-workflow body: what the step does; the git handoff is composed from the DAG (see compose.go).
+	Deps        []string          // Names of steps that must complete before this one runs.
 }
 
 // Definition is a "kind": one authored recipe. With Steps it is a workflow (a DAG
@@ -283,17 +283,17 @@ func Create(database *db.DB, opts Options) (*Result, error) {
 	tasks := make([]*db.Task, 0, len(steps))
 	for _, s := range steps {
 		task := &db.Task{
-			Title:          stepTitle(s.Name, goal),
-			Body:           goal, // Placeholder; rewritten once the branch is known.
-			Status:         db.StatusBacklog,
-			Type:           stepType(s),
-			Project:        opts.Project,
-			Executor:       s.Executor,
-			Model:          s.Model,
+			Title:           stepTitle(s.Name, goal),
+			Body:            goal, // Placeholder; rewritten once the branch is known.
+			Status:          db.StatusBacklog,
+			Type:            stepType(s),
+			Project:         opts.Project,
+			Executor:        s.Executor,
+			Model:           s.Model,
 			ClaudeConfigDir: s.ConfigDir,
 			EnvJSON:         encodeStepEnv(s.Env),
-			PermissionMode: opts.PermissionMode,
-			Tags:           "pipeline",
+			PermissionMode:  opts.PermissionMode,
+			Tags:            "pipeline",
 		}
 		if err := database.CreateTask(task); err != nil {
 			return nil, fmt.Errorf("create %s step: %w", s.Name, err)


### PR DESCRIPTION
## The damage
The auto-complete sweep marked pipeline steps `done` ~10s in — **before their agent ever started**. No session, no commit, no artifact. On a 3-pipeline run it killed every **Build, CodeReviewA, CodeReviewB, DesignReview** step; each `Verify` then found nothing upstream, built the slice solo, and shipped an **unreviewed PR** (e.g. bborn/influencekit#1270, 3,546 lines, only `plan`/`planrevise`/`verify` commits).

## Root cause — two regressions from today, combined
- **#640** relaxed `WorkflowStepFinished` to *"clean worktree AND HEAD reachable from any origin ref"*. A freshly-created worktree is clean and its HEAD is the **base commit**, already on origin → **an empty worktree read as finished**. The old check was accidentally safe (non-root steps run detached; a root step's branch isn't on origin yet — both returned false). I removed both accidents.
- **#641** let the sweep scan `processing` steps, using *"no tmux window"* as *"the session ended"*. A task flips to `processing` **before** worktree setup (clone/bundle/migrations, ~15–20s) and has no window then either — so **"not started yet" looked identical to "finished"**. The sweep ticks every 16s and lands inside that window; concurrency and slow init widen it.

## The fix (defense in depth)
1. **Record `base_commit`** when the worktree is created, before anything can run in it. `WorkflowStepFinished` now requires **`HEAD != base_commit`** — a step that produced no commit is never finished, whatever the timing. No recorded base ⇒ never finished.
2. The sweep's `processing` path requires the session to have **actually started** (`HasSessionStarted`, from the session-start log — worktree setup doesn't count), not merely to lack a window.
3. **Minimum runtime floor** (30s) before a `processing` step can be recovered.

A step that runs but commits nothing is now **not** finished: the Stop hook leaves it `blocked` for a human rather than silently completing and advancing the DAG.

## Tests
The regression is pinned: *a clean worktree sitting at its base commit must read as NOT finished*. Plus committed-but-unpushed, detached-HEAD-and-pushed (#640 stays fixed), dirty, empty-base; and that **worktree setup is not mistaken for a session start**. Full suite + golangci-lint v2.8.0 green (also gofmt'd two files left unformatted by `cb76f55d`).

⚠️ **After merging, the running daemon must be restarted (`make build`) — it currently holds the bad code in memory.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)