### PR TITLE
ty-chrome: let a task drive a group of browser tabs (like Claude in Chrome)

### DIFF
--- a/extensions/ty-chrome/README.md
+++ b/extensions/ty-chrome/README.md
@@ -65,19 +65,38 @@ Requires a `ty` build that has the `/api/tasks/{id}/annotations` and
 - On page while annotating: **S** select · **B** box · **N** note ·
   **Esc** exit mode · **⌘↩** send (also saves an open comment)
 
-## Browser bridge (executor → your browser)
+## Browser bridge (executor → your browser window)
 
 While the side panel is open on a matched task, the executor can see and drive
-your live tab instead of launching its own browser. On first connect the
-daemon drops `.taskyou/browser/HOWTO.md` into the worktree with ready-to-use
-curl commands, and annotation nudges mention the bridge — so the executor
-discovers it on its own:
+your live browser instead of launching its own — the same "control a group of
+tabs" model as the Claude in Chrome extension. On first connect the daemon
+drops `.taskyou/browser/HOWTO.md` into the worktree with ready-to-use curl
+commands, and annotation nudges mention the bridge — so the executor discovers
+it on its own:
 
 - `screenshot` / `snapshot` — written into the worktree as PNG/HTML files the
   executor can Read directly (the PNG is its "eyes")
 - `console` — real page console logs + uncaught JS errors (MAIN-world tap)
 - `click` / `type` — interact via CSS selectors
-- `navigate` (localhost-only) / `reload`
+- `navigate` (any http/https site) / `reload`
+
+**The tab group.** The executor isn't limited to the matched tab — it can drive
+every tab in that tab's window, plus tabs it opens itself, so it can pull up
+docs or an issue tracker alongside your app:
+
+- `tabs` — list the tabs in the window `[{tab,url,title,active,primary}]`
+- `open` — open a new tab at any URL (docs, external sites) → returns its `tab` id
+- `activate` — bring a tab to the foreground
+- `close` — close a tab
+
+Any see/act command takes an optional `"tab":<id>` to target a specific tab in
+the window (default: the matched app tab). Screenshotting a background tab
+brings it to the foreground first.
+
+The bridge pins to the (task, tab) it started on, so the executor navigating the
+app tab to an external site — or foregrounding another tab to screenshot it —
+won't tear the session down. It stops when you close the panel or the pinned
+tab.
 
 Transport: the panel long-polls `GET /api/tasks/{id}/browser/poll`; the
 executor POSTs to `/api/tasks/{id}/browser` and blocks until the result comes

--- a/extensions/ty-chrome/README.md
+++ b/extensions/ty-chrome/README.md
@@ -81,17 +81,20 @@ it on its own:
 - `navigate` (any http/https site) / `reload`
 
 **The tab group.** The executor isn't limited to the matched tab — it can drive
-every tab in that tab's window, plus tabs it opens itself, so it can pull up
-docs or an issue tracker alongside your app:
+every tab in this task's **tab group**, plus tabs it opens itself, so it can
+pull up docs or an issue tracker alongside your app:
 
-- `tabs` — list the tabs in the window `[{tab,url,title,active,primary}]`
+- `tabs` — list the tabs in the group `[{tab,url,title,active,primary}]`
 - `open` — open a new tab at any URL (docs, external sites) → returns its `tab` id
 - `activate` — bring a tab to the foreground
 - `close` — close a tab
 
-Any see/act command takes an optional `"tab":<id>` to target a specific tab in
-the window (default: the matched app tab). Screenshotting a background tab
-brings it to the foreground first.
+When the bridge connects, the matched tab is placed in a real Chrome tab group
+labeled **`ty #<id>`** (orange). That group *is* the boundary: the executor
+can't see or touch your other tabs, and you can drag a tab in or out of the
+group to grant or revoke access. Any see/act command takes an optional
+`"tab":<id>` to target a specific tab in the group (default: the matched app
+tab). Screenshotting a background tab brings it to the foreground first.
 
 The bridge pins to the (task, tab) it started on, so the executor navigating the
 app tab to an external site — or foregrounding another tab to screenshot it —

--- a/extensions/ty-chrome/manifest.json
+++ b/extensions/ty-chrome/manifest.json
@@ -3,7 +3,7 @@
   "name": "TaskYou — Live Annotate",
   "version": "0.1.0",
   "description": "Point, click, and annotate pages served by a taskyou task; deliver context straight to the task's executor.",
-  "permissions": ["storage", "tabs", "sidePanel", "scripting"],
+  "permissions": ["storage", "tabs", "tabGroups", "sidePanel", "scripting"],
   "host_permissions": ["<all_urls>"],
   "background": { "service_worker": "sw.js" },
   "commands": {

--- a/extensions/ty-chrome/sidepanel.css
+++ b/extensions/ty-chrome/sidepanel.css
@@ -62,6 +62,12 @@ body {
   color: var(--muted);
 }
 
+.bridge-status {
+  font-size: 10px;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
 .chip {
   background: var(--accent);
   color: #fff;

--- a/extensions/ty-chrome/sidepanel.html
+++ b/extensions/ty-chrome/sidepanel.html
@@ -55,6 +55,7 @@
     <div class="sec-head">
       <h2>Executor</h2>
       <span id="executor-state" class="muted"></span>
+      <span id="bridge-status" class="muted bridge-status hidden"></span>
       <label class="auto-reload" title="Reload the page when the executor finishes working">
         <input type="checkbox" id="auto-reload" checked /> auto-reload
       </label>

--- a/extensions/ty-chrome/sidepanel.js
+++ b/extensions/ty-chrome/sidepanel.js
@@ -57,7 +57,10 @@ async function refresh() {
   }
   $('no-connection').classList.toggle('hidden', !!state.connected);
 
-  currentTask = state.task || null;
+  // While the bridge is running it may foreground another tab (to screenshot a
+  // docs tab, say) whose URL doesn't port-match — keep showing the pinned task
+  // so the executor console doesn't blank out mid-session.
+  currentTask = state.task || (bridgeActive ? bridgeTask : null);
   renderTask();
   updateCount(state.annotationCount);
 
@@ -310,32 +313,67 @@ chrome.runtime.onMessage.addListener((msg) => {
 });
 
 // --- Browser bridge: while the panel is open and a task is matched, long-poll
-// ty serve for executor commands and run them against the live tab. This is
-// what lets the executor see/drive the page without its own browser.
+// ty serve for executor commands and run them against the live browser window.
+// This is what lets the executor see/drive the page — and any other tab in the
+// window it opens — without its own browser.
+//
+// The loop pins to the (task, tab) it started on. It deliberately does NOT
+// follow the panel's active tab: the executor can bring a docs tab or a newly
+// opened external tab to the foreground (e.g. to screenshot it) without the
+// active-tab change tearing the bridge down. It stops when the panel is hidden
+// or the pinned tab is closed.
 let bridgeActive = false;
+let bridgeTask = null; // the task the running bridge is pinned to
+
+async function updateBridgeStatus(active, primaryTabId) {
+  const el = $('bridge-status');
+  if (!el) return;
+  if (!active) {
+    el.classList.add('hidden');
+    el.textContent = '';
+    return;
+  }
+  let count = 1;
+  try {
+    const primary = await chrome.tabs.get(primaryTabId);
+    count = (await chrome.tabs.query({ windowId: primary.windowId })).length;
+  } catch {}
+  el.textContent = count > 1 ? `🔗 driving ${count} tabs` : '🔗 executor can drive this tab';
+  el.classList.remove('hidden');
+}
 
 async function bridgeLoop() {
   if (bridgeActive) return;
+  const task = currentTask;
+  const taskId = task?.id;
+  const primaryTabId = activeTabId;
+  if (taskId == null || primaryTabId == null) return;
   bridgeActive = true;
+  bridgeTask = task;
+  updateBridgeStatus(true, primaryTabId);
   try {
-    let injected = false;
-    while (document.visibilityState === 'visible' && currentTask && activeTabId != null) {
-      if (!injected) {
-        // Early console-tap injection so logs accumulate before the executor asks
-        await send({ type: 'ensureBridge', tabId: activeTabId });
-        injected = true;
+    // Early console-tap injection (so logs accumulate before the executor asks)
+    // and pin the tab→task match so external navigation doesn't drop the task.
+    await send({ type: 'ensureBridge', tabId: primaryTabId, taskId });
+    while (document.visibilityState === 'visible') {
+      try {
+        await chrome.tabs.get(primaryTabId); // pinned tab closed → stop
+      } catch {
+        break;
       }
-      const taskId = currentTask.id;
       const r = await send({ type: 'browserPoll', taskId });
       if (r?.command) {
-        const result = await send({ type: 'browserExec', tabId: activeTabId, command: r.command });
+        const result = await send({ type: 'browserExec', tabId: primaryTabId, command: r.command });
         await send({ type: 'browserResult', taskId, id: r.command.id, result: result ?? { error: 'no result' } });
+        updateBridgeStatus(true, primaryTabId);
       } else if (r?.error) {
         await new Promise((res) => setTimeout(res, 3000));
       }
     }
   } finally {
     bridgeActive = false;
+    bridgeTask = null;
+    updateBridgeStatus(false);
   }
 }
 

--- a/extensions/ty-chrome/sidepanel.js
+++ b/extensions/ty-chrome/sidepanel.js
@@ -336,7 +336,9 @@ async function updateBridgeStatus(active, primaryTabId) {
   let count = 1;
   try {
     const primary = await chrome.tabs.get(primaryTabId);
-    count = (await chrome.tabs.query({ windowId: primary.windowId })).length;
+    if (primary.groupId != null && primary.groupId !== -1) {
+      count = (await chrome.tabs.query({ groupId: primary.groupId })).length;
+    }
   } catch {}
   el.textContent = count > 1 ? `🔗 driving ${count} tabs` : '🔗 executor can drive this tab';
   el.classList.remove('hidden');

--- a/extensions/ty-chrome/sw.js
+++ b/extensions/ty-chrome/sw.js
@@ -137,13 +137,38 @@ async function ensureInjected(tabId) {
 }
 
 // --- Browser bridge tab group ------------------------------------------------
-// The "group" the executor can drive is every tab in the matched tab's window:
-// the app tab plus any docs/issue-tracker tabs the executor opens. Deriving the
-// group from the window (rather than a stored set) keeps it correct even after
-// the MV3 service worker is torn down and restarted.
+// The "group" the executor can drive is a real Chrome tab group (labeled
+// "ty #<id>", orange): the matched app tab plus any docs/issue-tracker tabs the
+// executor opens. This is a visible, user-revocable boundary — the executor
+// can't see or touch your other tabs, and you can drag a tab in/out of the
+// group to grant/revoke. The group id is read from Chrome per-command, so it
+// survives MV3 service-worker teardown; nothing is stored.
+
+const TAB_GROUP_NONE = -1; // chrome.tabGroups.TAB_GROUP_ID_NONE
+
+// Ensure the matched tab is in a ty tab group, creating one if it's ungrouped.
+// If the tab is already in a group (the user's or ours), we adopt it rather
+// than yanking the tab out of the user's grouping.
+async function ensureTaskGroup(primaryTabId, taskId) {
+  const tab = await chrome.tabs.get(primaryTabId);
+  if (tab.groupId != null && tab.groupId !== TAB_GROUP_NONE) return tab.groupId;
+  const groupId = await chrome.tabs.group({ tabIds: [primaryTabId] });
+  try {
+    await chrome.tabGroups.update(groupId, {
+      title: taskId != null ? `ty #${taskId}` : 'ty',
+      color: 'orange',
+    });
+  } catch {}
+  return groupId;
+}
+
+async function groupOf(primaryTabId) {
+  const tab = await chrome.tabs.get(primaryTabId);
+  return tab.groupId ?? TAB_GROUP_NONE;
+}
 
 // Resolve which tab a command targets: the optional params.tab (must be a live
-// tab in the primary tab's window), else the primary (matched) tab itself.
+// tab in the same tab group as the primary), else the primary (matched) tab.
 async function resolveTargetTab(primaryTabId, params) {
   const requested = params?.tab;
   if (requested == null) return primaryTabId;
@@ -155,8 +180,8 @@ async function resolveTargetTab(primaryTabId, params) {
     chrome.tabs.get(target).catch(() => null),
   ]);
   if (!tab) throw new Error(`tab ${target} not found`);
-  if (tab.windowId !== primary.windowId) {
-    throw new Error(`tab ${target} is not in this task's browser window`);
+  if (primary.groupId === TAB_GROUP_NONE || tab.groupId !== primary.groupId) {
+    throw new Error(`tab ${target} is not in this task's tab group`);
   }
   return target;
 }
@@ -385,9 +410,12 @@ const handlers = {
         // --- Tab-group control (drive more than the matched tab) ---
         case 'tabs': {
           const primary = await chrome.tabs.get(tabId);
-          const list = await chrome.tabs.query({ windowId: primary.windowId });
+          const members =
+            primary.groupId === TAB_GROUP_NONE
+              ? [primary]
+              : await chrome.tabs.query({ groupId: primary.groupId });
           return {
-            tabs: list.map((t) => ({
+            tabs: members.map((t) => ({
               tab: t.id,
               url: t.url,
               title: t.title,
@@ -405,6 +433,9 @@ const handlers = {
             url,
             active: params.activate !== false,
           });
+          // Add the new tab to the task's group so it's inside the boundary.
+          const groupId = await ensureTaskGroup(tabId);
+          await chrome.tabs.group({ groupId, tabIds: [tab.id] }).catch(() => {});
           return { ok: true, tab: tab.id, url };
         }
         case 'activate':
@@ -442,12 +473,14 @@ const handlers = {
     }
   },
 
-  // Inject the bridge into the matched tab and pin the tab→task match so the
-  // executor can navigate it to an external site without the port-based match
-  // dropping the task (which would tear the bridge down mid-session).
+  // Inject the bridge into the matched tab, put it in a visible "ty #<id>" tab
+  // group (the boundary the executor can drive), and pin the tab→task match so
+  // the executor can navigate it to an external site without the port-based
+  // match dropping the task (which would tear the bridge down mid-session).
   async ensureBridge({ tabId, taskId }) {
     try {
       await ensureInjected(tabId);
+      await ensureTaskGroup(tabId, taskId).catch(() => {});
       if (taskId != null) {
         const task = (await candidateTasks().catch(() => [])).find((t) => t.id === taskId);
         if (task) {

--- a/extensions/ty-chrome/sw.js
+++ b/extensions/ty-chrome/sw.js
@@ -136,6 +136,58 @@ async function ensureInjected(tabId) {
   await chrome.scripting.executeScript({ target: { tabId }, files: ['console-tap.js'], world: 'MAIN' });
 }
 
+// --- Browser bridge tab group ------------------------------------------------
+// The "group" the executor can drive is every tab in the matched tab's window:
+// the app tab plus any docs/issue-tracker tabs the executor opens. Deriving the
+// group from the window (rather than a stored set) keeps it correct even after
+// the MV3 service worker is torn down and restarted.
+
+// Resolve which tab a command targets: the optional params.tab (must be a live
+// tab in the primary tab's window), else the primary (matched) tab itself.
+async function resolveTargetTab(primaryTabId, params) {
+  const requested = params?.tab;
+  if (requested == null) return primaryTabId;
+  const target = Number(requested);
+  if (!Number.isInteger(target)) throw new Error(`invalid tab id: ${requested}`);
+  if (target === primaryTabId) return target;
+  const [primary, tab] = await Promise.all([
+    chrome.tabs.get(primaryTabId),
+    chrome.tabs.get(target).catch(() => null),
+  ]);
+  if (!tab) throw new Error(`tab ${target} not found`);
+  if (tab.windowId !== primary.windowId) {
+    throw new Error(`tab ${target} is not in this task's browser window`);
+  }
+  return target;
+}
+
+// Only http/https can be driven; block file:, chrome:, javascript:, etc.
+function normalizeNavUrl(raw) {
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new Error(`invalid url: ${raw}`);
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    throw new Error(`unsupported url scheme "${u.protocol}" — only http/https`);
+  }
+  return u.href;
+}
+
+async function captureTab(targetTabId) {
+  const tab = await chrome.tabs.get(targetTabId);
+  // captureVisibleTab only sees the window's foreground tab, so bring the
+  // target forward first (matches how the executor expects "look at tab X").
+  if (!tab.active) {
+    await chrome.tabs.update(targetTabId, { active: true });
+    await chrome.windows.update(tab.windowId, { focused: true }).catch(() => {});
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  const win = (await chrome.tabs.get(targetTabId)).windowId;
+  return chrome.tabs.captureVisibleTab(win, { format: 'png' });
+}
+
 chrome.tabs.onActivated.addListener(async ({ tabId }) => {
   try {
     const tab = await chrome.tabs.get(tabId);
@@ -311,34 +363,77 @@ const handlers = {
   },
 
   async browserExec({ tabId, command }) {
+    const params = command.params || {};
     try {
       switch (command.action) {
         case 'screenshot': {
-          const tab = await chrome.tabs.get(tabId);
-          const data = await chrome.tabs.captureVisibleTab(tab.windowId, { format: 'png' });
-          return { data };
+          const target = await resolveTargetTab(tabId, params);
+          return { data: await captureTab(target) };
         }
-        case 'reload':
-          await chrome.tabs.reload(tabId);
-          return { ok: true };
+        case 'reload': {
+          const target = await resolveTargetTab(tabId, params);
+          await chrome.tabs.reload(target);
+          return { ok: true, tab: target };
+        }
         case 'navigate': {
-          const url = new URL(command.params?.url || '');
-          if (url.hostname !== 'localhost' && url.hostname !== '127.0.0.1') {
-            return { error: 'navigate is restricted to localhost' };
-          }
-          await chrome.tabs.update(tabId, { url: url.href });
-          return { ok: true, url: url.href };
+          const url = normalizeNavUrl(params.url || '');
+          const target = await resolveTargetTab(tabId, params);
+          await chrome.tabs.update(target, { url });
+          return { ok: true, url, tab: target };
         }
+
+        // --- Tab-group control (drive more than the matched tab) ---
+        case 'tabs': {
+          const primary = await chrome.tabs.get(tabId);
+          const list = await chrome.tabs.query({ windowId: primary.windowId });
+          return {
+            tabs: list.map((t) => ({
+              tab: t.id,
+              url: t.url,
+              title: t.title,
+              active: t.active,
+              primary: t.id === tabId,
+            })),
+          };
+        }
+        case 'open':
+        case 'open_tab': {
+          const url = normalizeNavUrl(params.url || '');
+          const primary = await chrome.tabs.get(tabId);
+          const tab = await chrome.tabs.create({
+            windowId: primary.windowId,
+            url,
+            active: params.activate !== false,
+          });
+          return { ok: true, tab: tab.id, url };
+        }
+        case 'activate':
+        case 'switch_tab': {
+          const target = await resolveTargetTab(tabId, params);
+          const tab = await chrome.tabs.get(target);
+          await chrome.tabs.update(target, { active: true });
+          await chrome.windows.update(tab.windowId, { focused: true }).catch(() => {});
+          return { ok: true, tab: target };
+        }
+        case 'close':
+        case 'close_tab': {
+          const target = await resolveTargetTab(tabId, params);
+          await chrome.tabs.remove(target);
+          return { ok: true, closed: target };
+        }
+
         case 'snapshot':
         case 'click':
         case 'type':
-        case 'console':
-          await ensureInjected(tabId);
-          return await chrome.tabs.sendMessage(tabId, {
+        case 'console': {
+          const target = await resolveTargetTab(tabId, params);
+          await ensureInjected(target);
+          return await chrome.tabs.sendMessage(target, {
             type: 'ty-cmd',
             action: command.action,
-            params: command.params || {},
+            params,
           });
+        }
         default:
           return { error: 'unknown action: ' + command.action };
       }
@@ -347,9 +442,19 @@ const handlers = {
     }
   },
 
-  async ensureBridge({ tabId }) {
+  // Inject the bridge into the matched tab and pin the tab→task match so the
+  // executor can navigate it to an external site without the port-based match
+  // dropping the task (which would tear the bridge down mid-session).
+  async ensureBridge({ tabId, taskId }) {
     try {
       await ensureInjected(tabId);
+      if (taskId != null) {
+        const task = (await candidateTasks().catch(() => [])).find((t) => t.id === taskId);
+        if (task) {
+          matches.set(tabId, { task, manual: true });
+          setBadge(tabId, task);
+        }
+      }
       return { ok: true };
     } catch (e) {
       return { error: e.message };

--- a/internal/web/browser.go
+++ b/internal/web/browser.go
@@ -276,10 +276,12 @@ func (s *Server) ensureBrowserHowto(task *db.Task) {
 
 	base := s.baseURL
 	endpoint := fmt.Sprintf("%s/api/tasks/%d/browser", base, task.ID)
-	howto := fmt.Sprintf(`# Browser bridge — see and drive the user's live browser
+	howto := fmt.Sprintf(`# Browser bridge — see and drive the user's live browser window
 
 The ty-chrome extension is connected to this task. Use the user's real browser
-tab instead of launching your own. Every command is:
+instead of launching your own. You can drive the whole window your app is in:
+the matched app tab, any other tab in that window, and new tabs you open
+(including external sites like docs or issue trackers). Every command is:
 
     curl -s -X POST %s \
       -H 'Content-Type: application/json' -d '{"action":"...","params":{...}}'
@@ -287,18 +289,30 @@ tab instead of launching your own. Every command is:
 Responses are {"ok":true,"result":{...}}. If the side panel is closed you get
 a 503; ask the user to open it.
 
-## Actions
+## See the page (do this first and after every change)
 
-- **See the page** (most useful — do this first and after every change):
-  '{"action":"screenshot"}' → result.path is a PNG in this worktree; Read it.
+- **Screenshot**: '{"action":"screenshot"}' → result.path is a PNG in this worktree; Read it.
 - **DOM snapshot**: '{"action":"snapshot"}' → result.path (full HTML), result.title, result.url
 - **Console logs + JS errors**: '{"action":"console"}' → result.logs
+
+## Act on the page
+
 - **Click**: '{"action":"click","params":{"selector":"#buy-btn"}}'
 - **Type**: '{"action":"type","params":{"selector":"input[name=q]","text":"hello"}}'
-- **Navigate** (localhost only): '{"action":"navigate","params":{"url":"http://localhost:%d/"}}'
+- **Navigate** (any http/https site): '{"action":"navigate","params":{"url":"https://example.com/"}}'
 - **Reload**: '{"action":"reload"}'
 
-Screenshot after each interaction to verify what actually happened.
+## Control the group of tabs
+
+- **List tabs**: '{"action":"tabs"}' → result.tabs = [{tab,url,title,active,primary}]
+- **Open a tab**: '{"action":"open","params":{"url":"https://docs...","activate":true}}' → result.tab
+- **Focus a tab**: '{"action":"activate","params":{"tab":<id>}}'
+- **Close a tab**: '{"action":"close","params":{"tab":<id>}}'
+
+Any see/act command takes an optional '"tab":<id>' to target a specific tab in
+the window (default: the matched app tab, e.g. localhost:%d). Screenshotting a
+background tab brings it to the foreground first. Screenshot after each
+interaction to verify what actually happened.
 `, endpoint, task.Port)
 
 	os.WriteFile(path, []byte(howto), 0o644)

--- a/internal/web/browser.go
+++ b/internal/web/browser.go
@@ -279,9 +279,10 @@ func (s *Server) ensureBrowserHowto(task *db.Task) {
 	howto := fmt.Sprintf(`# Browser bridge — see and drive the user's live browser window
 
 The ty-chrome extension is connected to this task. Use the user's real browser
-instead of launching your own. You can drive the whole window your app is in:
-the matched app tab, any other tab in that window, and new tabs you open
-(including external sites like docs or issue trackers). Every command is:
+instead of launching your own. You can drive the tabs in this task's tab group
+(labeled "ty #%d" in the tab strip): the matched app tab plus new tabs you open
+(including external sites like docs or issue trackers). Tabs outside the group
+are off-limits. Every command is:
 
     curl -s -X POST %s \
       -H 'Content-Type: application/json' -d '{"action":"...","params":{...}}'
@@ -310,10 +311,10 @@ a 503; ask the user to open it.
 - **Close a tab**: '{"action":"close","params":{"tab":<id>}}'
 
 Any see/act command takes an optional '"tab":<id>' to target a specific tab in
-the window (default: the matched app tab, e.g. localhost:%d). Screenshotting a
+the group (default: the matched app tab, e.g. localhost:%d). Screenshotting a
 background tab brings it to the foreground first. Screenshot after each
 interaction to verify what actually happened.
-`, endpoint, task.Port)
+`, task.ID, endpoint, task.Port)
 
 	os.WriteFile(path, []byte(howto), 0o644)
 }

--- a/internal/web/browser_test.go
+++ b/internal/web/browser_test.go
@@ -149,6 +149,31 @@ func TestBrowserRelay_ScreenshotWritesFile(t *testing.T) {
 	}
 }
 
+func TestBrowserHowto_DocumentsTabGroupActions(t *testing.T) {
+	srv, database, _ := setupServer(t)
+	task, wt := setupAnnotationTask(t, database, false)
+
+	srv.ensureBrowserHowto(task)
+
+	howto, err := os.ReadFile(filepath.Join(wt, ".taskyou", "browser", "HOWTO.md"))
+	if err != nil {
+		t.Fatalf("HOWTO.md not written: %v", err)
+	}
+	got := string(howto)
+	// The bridge now advertises tab-group control and external navigation.
+	for _, want := range []string{
+		`"action":"tabs"`,
+		`"action":"open"`,
+		`"action":"activate"`,
+		`"action":"close"`,
+		`https://`, // navigate is no longer localhost-only
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("HOWTO missing %q", want)
+		}
+	}
+}
+
 func TestAnnotationNudge_MentionsBrowserWhenConnected(t *testing.T) {
 	srv, database, runner := setupServer(t)
 	task, _ := setupAnnotationTask(t, database, true)

--- a/internal/web/browser_test.go
+++ b/internal/web/browser_test.go
@@ -166,7 +166,9 @@ func TestBrowserHowto_DocumentsTabGroupActions(t *testing.T) {
 		`"action":"open"`,
 		`"action":"activate"`,
 		`"action":"close"`,
-		`https://`, // navigate is no longer localhost-only
+		`https://`,   // navigate is no longer localhost-only
+		"tab group",  // the executor is scoped to a Chrome tab group
+		"ty #",       // ...labeled with the task id
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("HOWTO missing %q", want)

--- a/internal/web/browser_test.go
+++ b/internal/web/browser_test.go
@@ -166,9 +166,9 @@ func TestBrowserHowto_DocumentsTabGroupActions(t *testing.T) {
 		`"action":"open"`,
 		`"action":"activate"`,
 		`"action":"close"`,
-		`https://`,   // navigate is no longer localhost-only
-		"tab group",  // the executor is scoped to a Chrome tab group
-		"ty #",       // ...labeled with the task id
+		`https://`,  // navigate is no longer localhost-only
+		"tab group", // the executor is scoped to a Chrome tab group
+		"ty #",      // ...labeled with the task id
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("HOWTO missing %q", want)


### PR DESCRIPTION
## Why

The task asked: could the ty-chrome extension replicate Claude Code Desktop's [*browse external sites*](https://code.claude.com/docs/en/desktop#browse-external-sites) — letting a taskyou task control **a group of browser tabs**, the way the Claude in Chrome extension does?

It mostly could already: the browser bridge lets the executor see and drive the user's live tab (screenshot / snapshot / console / click / type / navigate / reload). Two things held it back from "control a group of tabs":

1. It only ever acted on the **single** tab the side panel was pinned to.
2. `navigate` was **localhost-only**, so the executor couldn't open docs or an issue tracker.

## What changed

The executor can now drive a real **Chrome tab group** — the matched app tab, plus any docs/issue-tracker tabs it opens itself:

| Action | Effect |
|---|---|
| `tabs` | list the group's tabs `[{tab,url,title,active,primary}]` |
| `open` | open a new tab at any http/https URL → returns its `tab` id |
| `activate` | bring a tab to the foreground |
| `close` | close a tab |
| *(existing)* `screenshot`/`snapshot`/`console`/`click`/`type`/`navigate`/`reload` | now accept an optional `"tab":<id>` to target a specific tab in the group |

- **Tab-group boundary (not the whole window).** On connect the matched tab is placed in a visible Chrome tab group labeled **`ty #<id>`** (orange). That group *is* the boundary: the executor can't see or touch your other tabs, and you can drag a tab in/out of the group to grant/revoke access. The group id is read from Chrome per-command, so it survives MV3 service-worker teardown. If the tab is already in a group, we adopt it rather than yanking it out of your grouping.
- **External navigation**: `navigate`/`open` accept any `http`/`https` URL (scheme-validated to block `file:`/`chrome:`/`javascript:`), not just localhost.
- **Background screenshots**: screenshotting a non-foreground tab brings it forward first, since `captureVisibleTab` only sees the active tab.
- **Task-scoped bridge**: the panel bridge now pins to the `(task, tab)` it started on instead of following the panel's active tab. The executor foregrounding a docs tab — or navigating the app tab to an external site — no longer tears the session down. The tab→task match is pinned on connect so external navigation doesn't drop the task.
- **UI**: a small `🔗 driving N tabs` indicator in the Executor header shows when the bridge is live.
- Updated the worktree `HOWTO.md` cheat-sheet + extension README, and added a Go test asserting the HOWTO advertises the new actions and the group boundary.

## Files

- `extensions/ty-chrome/manifest.json` — `tabGroups` permission
- `extensions/ty-chrome/sw.js` — tab-group scoping (ensureTaskGroup, group-checked target resolution), tab actions, external navigate, activate-then-capture, sticky match on connect
- `extensions/ty-chrome/sidepanel.js` — task-scoped/pinned bridge loop + bridge status
- `extensions/ty-chrome/sidepanel.html` / `sidepanel.css` — `#bridge-status` indicator
- `internal/web/browser.go` — HOWTO documents the group, new actions & external navigate
- `internal/web/browser_test.go` — HOWTO content test
- `extensions/ty-chrome/README.md` — docs

## Testing

- `go test ./internal/web/` ✅ (incl. `TestBrowserHowto_DocumentsTabGroupActions`)
- `go build ./...` ✅, `node --check` on all touched JS ✅, manifest JSON validated ✅
- ⚠️ **Not yet exercised live in Chrome** — the daemon-side relay is transport-agnostic and unit-tested, but the tab-group logic runs in the extension's service worker. Recommend a manual smoke test (load unpacked, open the panel on a task, confirm the app tab gets grouped as `ty #<id>`, then have the executor `open` a docs tab + `screenshot` it) before merge.

## Follow-ups considered (not in this PR)

Per-tab console taps injected eagerly on `open` (early logs currently start at the first `console` call); a `wait`/`waitForSelector` action so the executor doesn't have to poll `screenshot`; and optionally restoring the user's original foreground tab after a background-tab screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
