### PR TITLE
fix(docs): exclude internal plan/QA dirs from Jekyll Pages build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,10 @@
+# GitHub Pages / Jekyll config for the TaskYou docs site.
+#
+# The public site is the install/landing page plus the reference docs at the
+# top level. Internal engineering artifacts (implementation plans, QA reports)
+# live under docs/ for convenience but are NOT part of the published site — and
+# they contain Go source with `{{ ... }}` struct/template literals that Jekyll's
+# Liquid parser chokes on. Exclude them from the build.
+exclude:
+  - superpowers
+  - qa


### PR DESCRIPTION
## Problem

The `pages-build-deployment` was failing ([run 29194579417](https://github.com/bborn/taskyou/actions/runs/29194579417/job/86655150522)):

```
Error: Liquid syntax error (line 1109): Variable '{{ UID: 1, Headers: map[string]string{"Auto-Submitted": "no"}' was not properly terminated with regexp: /\}\}/
```

`docs/superpowers/plans/2026-06-25-ty-email-bidirectional.md` contains a Go struct literal `[]Message{{ ... }}`. Jekyll's Liquid parser sees `{{` and tries to render it as a template variable, aborting the whole site build.

## Fix

`docs/superpowers/` (implementation plans) and `docs/qa/` (QA reports) are internal engineering artifacts — not part of the published site — and are full of Go source with `{{ ... }}` literals. Added `docs/_config.yml` excluding both directories from the Jekyll build. Fixes the immediate failure and prevents recurrence as more plans land.

## Verification

Ran the exact CI container locally (`ghcr.io/actions/jekyll-build-pages:v1.0.13`) against `docs/`:
- The `{{` Liquid error is gone.
- Zero `superpowers/`/`qa/` files are rendered.
- Build proceeds to the github-metadata stage (which succeeds in real CI with a valid token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)