### PR TITLE
ty-chrome: auto-match tasks on .localhost/.test dev hostnames

### DIFF
--- a/extensions/ty-chrome/README.md
+++ b/extensions/ty-chrome/README.md
@@ -23,8 +23,10 @@ annotate page ──► POST /api/tasks/{id}/annotations (ty serve)
 
 Tab→task matching is automatic: each taskyou task has a dedicated port
 (3100–4099, exposed as `$WORKTREE_PORT` in the task shell). If the tab's URL is
-`localhost:<port>`, the extension finds the processing/blocked task with that
-port. No match? Pick the task manually in the side panel.
+on a loopback host with that port — `localhost`, `127.0.0.1`, or any `.localhost`
+/ `.test` subdomain (e.g. `qa-brand.influencekit.test:<port>`) — the extension
+finds the processing/blocked task with that port. No match? Pick the task
+manually in the side panel.
 
 ## Install
 
@@ -145,6 +147,7 @@ Host permissions are `<all_urls>` because Chrome's `captureVisibleTab` (used
 to bake your markers into the screenshot) accepts only `<all_urls>` or
 `activeTab` — and `activeTab` grants die on every page reload, which would
 silently drop screenshots in the edit loop this tool exists for. Tab→task
-auto-matching still only ever targets `localhost`/`127.0.0.1` ports; other
-pages are annotatable only if you manually pick a task. This is a
+auto-matching still only ever targets loopback hosts (`localhost`, `127.0.0.1`,
+and RFC-reserved `.localhost` / `.test` subdomains) by port; other pages are
+annotatable only if you manually pick a task. This is a
 load-unpacked dev tool talking to your own machine.

--- a/extensions/ty-chrome/sw.js
+++ b/extensions/ty-chrome/sw.js
@@ -79,10 +79,24 @@ async function candidateTasks() {
   return [...processing, ...blocked];
 }
 
+// A hostname is "loopback" if it's localhost/127.0.0.1 or ends in a
+// TLD reserved for local use (.localhost, .test per RFC 6761 — these always
+// resolve to the loopback interface). Multi-tenant local dev setups serve each
+// tenant on its own subdomain (e.g. qa-brand-4801.influencekit.test:3143), so
+// port-based task matching must recognize those, not just bare localhost.
+function isLoopbackHost(hostname) {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.test')
+  );
+}
+
 function tabPort(url) {
   try {
     const u = new URL(url);
-    if (u.hostname !== 'localhost' && u.hostname !== '127.0.0.1') return null;
+    if (!isLoopbackHost(u.hostname)) return null;
     return u.port ? Number(u.port) : null;
   } catch {
     return null;


### PR DESCRIPTION
Follow-up to #644 (merged).

## Problem

Tab→task auto-matching bailed unless the tab's hostname was literally `localhost` or `127.0.0.1`:

```js
if (u.hostname !== 'localhost' && u.hostname !== '127.0.0.1') return null;
```

Multi-tenant local dev setups serve each tenant on its own loopback subdomain — e.g. InfluenceKit's `qa-brand-4801.influencekit.test:3143`. For those, `tabPort()` returned `null` before ever reading the port, so the side panel showed **"No task matches this tab's port"** and fell back to *Pick a task…* even though a task with that exact port existed.

## Fix

Recognize RFC 6761 loopback TLDs: match by port on `localhost`, `127.0.0.1`, and any `.localhost` / `.test` subdomain. Both TLDs are reserved and always resolve to the loopback interface, so auto-matching stays local-only.

```js
function isLoopbackHost(hostname) {
  return hostname === 'localhost' || hostname === '127.0.0.1' ||
         hostname.endsWith('.localhost') || hostname.endsWith('.test');
}
```

## Files

- `extensions/ty-chrome/sw.js` — `isLoopbackHost()` helper; `tabPort()` uses it
- `extensions/ty-chrome/README.md` — matching + security notes updated

## Testing

- `node --check` on `sw.js` ✅
- The extension has no JS test harness (vanilla MV3), so this is logic-reviewed. Manual check: load unpacked, browse a task's `*.test:<port>` URL, confirm the badge/panel auto-matches the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)