### PR TITLE
Fix workflow-step handoff stalls: stale re-baseline, opaque parking, silent daemon-down queueing

### DIFF
--- a/cmd/task/bulk.go
+++ b/cmd/task/bulk.go
@@ -294,6 +294,9 @@ Examples:
 			}
 
 			printBulkSummary("queue", succeeded, failed)
+			if succeeded > 0 {
+				ensureDaemonForQueuedWork()
+			}
 		},
 	}
 	bulkExecuteCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (skip permission prompts)")

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -986,6 +986,7 @@ Examples:
 				fmt.Println(dimStyle.Render("Staged but not started — queue the root step to run it."))
 			} else {
 				fmt.Println(dimStyle.Render("Running — steps advance automatically; parallel reviewers run at once."))
+				ensureDaemonForQueuedWork()
 			}
 		},
 	}
@@ -1994,6 +1995,7 @@ Examples:
 				msg += " (accept-edits mode)"
 			}
 			fmt.Println(successStyle.Render(msg))
+			ensureDaemonForQueuedWork()
 		},
 	}
 	executeCmd.Flags().Bool("dangerous", false, "Execute in dangerous mode (alias for --permission-mode dangerous)")
@@ -4111,6 +4113,22 @@ func runLocal(dangerousMode bool, debugStatePath, cpuProfilePath, memProfilePath
 	return nil
 }
 
+// ensureDaemonForQueuedWork makes sure work queued from the CLI will actually
+// run. The daemon is the only thing that picks up 'queued' tasks; without this,
+// `ty pipeline`/`ty execute` on a machine whose daemon died print a cheerful
+// success message and the task sits in 'queued' forever with no hint why.
+// Mirrors the TUI's startup behavior (runLocal): start it if we can, warn
+// loudly if we can't.
+func ensureDaemonForQueuedWork() {
+	// Per-task permission modes are already stored on the tasks themselves; the
+	// daemon-wide dangerous flag only comes from the environment here (the root
+	// --dangerous flag is scoped to the TUI/daemon commands).
+	if err := ensureDaemonRunning(os.Getenv("WORKTREE_DANGEROUS_MODE") == "1"); err != nil {
+		fmt.Fprintln(os.Stderr, errorStyle.Render("Warning: daemon is not running and could not be started: "+err.Error()))
+		fmt.Fprintln(os.Stderr, dimStyle.Render("Queued work will not execute until you run 'ty daemon' or 'ty restart'."))
+	}
+}
+
 // ensureDaemonRunning starts the daemon if it's not already running.
 // If dangerousMode is true, sets WORKTREE_DANGEROUS_MODE=1 for the daemon.
 // If the daemon is already running (even with a different mode), it is left as-is.
@@ -4634,13 +4652,22 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 			// 'done' so its dependents auto-queue. A step that stopped to ask a question
 			// or left work uncommitted/unpushed hasn't finished — block as before, and
 			// the daemon's sweep is the backstop for a Stop hook that fires mid-push.
-			if pipeline.IsWorkflowTask(task) && workflowStepFinished(database, task) {
-				if pipeline.IsTerminalStep(database, task) {
-					database.UpdateTaskStatus(taskID, db.StatusBlocked)
-					database.AppendTaskLog(taskID, "system", pipeline.TerminalStepParkedLog)
+			if pipeline.IsWorkflowTask(task) {
+				if reason := workflowStepUnfinishedReason(database, task); reason == "" {
+					if pipeline.IsTerminalStep(database, task) {
+						database.UpdateTaskStatus(taskID, db.StatusBlocked)
+						database.AppendTaskLog(taskID, "system", pipeline.TerminalStepParkedLog)
+					} else {
+						database.UpdateTaskStatus(taskID, db.StatusDone)
+						database.AppendTaskLog(taskID, "system", "Work committed and pushed — workflow advances to the next step")
+					}
 				} else {
-					database.UpdateTaskStatus(taskID, db.StatusDone)
-					database.AppendTaskLog(taskID, "system", "Work committed and pushed — workflow advances to the next step")
+					// Park with the concrete reason. The generic "Waiting for user
+					// input" reads as a question the agent never asked and hides
+					// what actually blocked the handoff (e.g. leftover untracked
+					// files), leaving the DAG stalled with no clue on the board.
+					database.UpdateTaskStatus(taskID, db.StatusBlocked)
+					database.AppendTaskLog(taskID, "system", "Step ended its turn without completing the handoff — "+reason)
 				}
 			} else {
 				database.UpdateTaskStatus(taskID, db.StatusBlocked)
@@ -4662,15 +4689,21 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 // transient moment. A step that ran but committed nothing is NOT finished — it stays
 // 'blocked' for a human rather than silently completing with no work.
 func workflowStepFinished(database *db.DB, task *db.Task) bool {
+	return workflowStepUnfinishedReason(database, task) == ""
+}
+
+// workflowStepUnfinishedReason returns "" when the step's handoff is complete, or
+// a short reason why not (see executor.WorkflowStepUnfinishedReason).
+func workflowStepUnfinishedReason(database *db.DB, task *db.Task) string {
 	baseCommit, err := database.GetTaskBaseCommit(task.ID)
 	if err != nil {
-		return false
+		return "could not load the step's baseline commit"
 	}
 	baseDirty, err := database.GetTaskBaseDirty(task.ID)
 	if err != nil {
-		return false
+		return "could not load the step's baseline dirt snapshot"
 	}
-	return executor.WorkflowStepFinished(task.WorktreePath, baseCommit, baseDirty)
+	return executor.WorkflowStepUnfinishedReason(task.WorktreePath, baseCommit, baseDirty)
 }
 
 // handlePreToolUseHook handles PreToolUse hooks from Claude (before tool execution).

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4683,17 +4683,13 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 	return nil
 }
 
-// workflowStepFinished reports whether a workflow step produced a commit and pushed it
-// (see executor.WorkflowStepFinished). Used by the Stop hook to advance a step whose
-// agent ended its turn; the daemon's sweep is the backstop for when the hook fires at a
-// transient moment. A step that ran but committed nothing is NOT finished — it stays
-// 'blocked' for a human rather than silently completing with no work.
-func workflowStepFinished(database *db.DB, task *db.Task) bool {
-	return workflowStepUnfinishedReason(database, task) == ""
-}
-
-// workflowStepUnfinishedReason returns "" when the step's handoff is complete, or
-// a short reason why not (see executor.WorkflowStepUnfinishedReason).
+// workflowStepUnfinishedReason returns "" when the step's handoff is complete
+// (produced a commit, pushed it, no leftover work of its own), or a short reason
+// why not (see executor.WorkflowStepUnfinishedReason). Used by the Stop hook to
+// advance a step whose agent ended its turn; the daemon's sweep is the backstop
+// for when the hook fires at a transient moment. A step that ran but committed
+// nothing is NOT finished — it stays 'blocked' for a human rather than silently
+// completing with no work.
 func workflowStepUnfinishedReason(database *db.DB, task *db.Task) string {
 	baseCommit, err := database.GetTaskBaseCommit(task.ID)
 	if err != nil {

--- a/cmd/task/stophook_test.go
+++ b/cmd/task/stophook_test.go
@@ -176,3 +176,77 @@ func TestWorkflowStepFinishedIgnoresInitDirt(t *testing.T) {
 		t.Error("a step that left NEW uncommitted work must NOT be finished")
 	}
 }
+
+// TestWorkflowStepUnfinishedReason: when a step's handoff is incomplete, the reason
+// must say WHY — the generic "Waiting for user input" hid the actual blocker (e.g.
+// scratch files the agent fetched but never committed) and left DAGs stalled with a
+// board that looked like the agent had asked a question. The Verify-step incident:
+// an agent fetched four peer reports as untracked files, committed and pushed its own
+// output, and the step parked forever with no hint.
+func TestWorkflowStepUnfinishedReason(t *testing.T) {
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	git(t, root, "init", "--bare", remote)
+	wt := filepath.Join(root, "wt")
+	if err := os.Mkdir(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, wt, "init")
+	git(t, wt, "remote", "add", "origin", remote)
+	git(t, wt, "checkout", "-b", "pipeline/shared")
+	if err := os.WriteFile(filepath.Join(wt, "parent.txt"), []byte("parent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, wt, "add", ".")
+	git(t, wt, "commit", "-m", "parent step work")
+	git(t, wt, "push", "origin", "HEAD:pipeline/shared")
+	base := headSHA(t, wt)
+
+	// Sitting at base: reason names the missing commit, not a question.
+	reason := executor.WorkflowStepUnfinishedReason(wt, base, "")
+	if !strings.Contains(reason, "no new commit") {
+		t.Errorf("expected a 'no new commit' reason, got %q", reason)
+	}
+
+	// Committed but not pushed.
+	if err := os.WriteFile(filepath.Join(wt, "out.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, wt, "add", ".")
+	git(t, wt, "commit", "-m", "work")
+	if reason := executor.WorkflowStepUnfinishedReason(wt, base, ""); !strings.Contains(reason, "not pushed") {
+		t.Errorf("expected a 'not pushed' reason, got %q", reason)
+	}
+	git(t, wt, "push", "origin", "HEAD:pipeline/shared")
+
+	// The incident shape: work committed AND pushed, but fetched scratch left
+	// untracked. The reason must name the offending files.
+	for _, f := range []string{"peer-a.md", "peer-b.md"} {
+		if err := os.WriteFile(filepath.Join(wt, f), []byte("scratch"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reason = executor.WorkflowStepUnfinishedReason(wt, base, "")
+	if !strings.Contains(reason, "uncommitted files") || !strings.Contains(reason, "peer-a.md") {
+		t.Errorf("expected the reason to name the leftover files, got %q", reason)
+	}
+
+	// Baseline dirt is NOT the step's fault and must not block (nor be named).
+	reason = executor.WorkflowStepUnfinishedReason(wt, base, "peer-a.md\npeer-b.md")
+	if reason != "" {
+		t.Errorf("baseline dirt must not block the handoff, got %q", reason)
+	}
+
+	// Finished ⇔ empty reason, and the bool wrapper agrees.
+	for _, f := range []string{"peer-a.md", "peer-b.md"} {
+		if err := os.Remove(filepath.Join(wt, f)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if reason := executor.WorkflowStepUnfinishedReason(wt, base, ""); reason != "" {
+		t.Errorf("expected finished (empty reason), got %q", reason)
+	}
+	if !executor.WorkflowStepFinished(wt, base, "") {
+		t.Error("WorkflowStepFinished should agree with an empty reason")
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -843,11 +843,27 @@ func gitDirtyPaths(worktreePath string) (string, bool) {
 	return strings.Join(paths, "\n"), true
 }
 
+// WorkflowStepFinished reports whether a workflow step completed its handoff:
+// produced a commit beyond its recorded baseline, pushed it, and left no
+// uncommitted work of its own. See WorkflowStepUnfinishedReason for the
+// individual checks.
 func WorkflowStepFinished(worktreePath, baseCommit, baseDirty string) bool {
+	return WorkflowStepUnfinishedReason(worktreePath, baseCommit, baseDirty) == ""
+}
+
+// WorkflowStepUnfinishedReason returns "" when the step's handoff is complete,
+// or a short human-readable reason why it is not. The reason is surfaced on the
+// task's activity log so a parked step says WHY it parked ("left uncommitted
+// files: …") instead of the generic "Waiting for user input" — which reads as
+// a question and sends a human hunting for one that was never asked.
+func WorkflowStepUnfinishedReason(worktreePath, baseCommit, baseDirty string) string {
 	// No worktree, or no recorded starting point, means we have no evidence the step
 	// produced anything. Never auto-complete on no evidence.
-	if worktreePath == "" || baseCommit == "" {
-		return false
+	if worktreePath == "" {
+		return "no worktree recorded for this step"
+	}
+	if baseCommit == "" {
+		return "no baseline commit recorded — cannot judge the step's output"
 	}
 
 	// The step must not have left uncommitted work of its OWN. It is NOT enough to ask
@@ -857,7 +873,7 @@ func WorkflowStepFinished(worktreePath, baseCommit, baseDirty string) bool {
 	// was already there when this step started.
 	cur, ok := gitDirtyPaths(worktreePath)
 	if !ok {
-		return false
+		return "could not read the worktree's git status"
 	}
 	if cur != "" {
 		base := make(map[string]bool)
@@ -866,26 +882,35 @@ func WorkflowStepFinished(worktreePath, baseCommit, baseDirty string) bool {
 				base[p] = true
 			}
 		}
+		var leftover []string
 		for _, p := range strings.Split(cur, "\n") {
 			if !base[p] {
-				return false // the step left something uncommitted
+				leftover = append(leftover, p)
 			}
+		}
+		if len(leftover) > 0 {
+			shown := leftover
+			if len(shown) > 5 {
+				shown = append(shown[:5:5], fmt.Sprintf("… (%d more)", len(leftover)-5))
+			}
+			return "left uncommitted files: " + strings.Join(shown, ", ") +
+				" — commit them (or delete them) and the step will advance"
 		}
 	}
 
 	headOut, errH := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
 	if errH != nil {
-		return false
+		return "could not resolve the worktree's HEAD commit"
 	}
 	head := strings.TrimSpace(string(headOut))
 
-	// THE step must have produced a commit. A worktree that was just created — or whose
+	// The step must have produced a commit. A worktree that was just created — or whose
 	// agent ran and wrote nothing — is clean and sits at baseCommit, which is already
 	// reachable from origin. Without this check such a step reads as "finished" and the
 	// sweep silently marks it done before the agent has even started, dropping the step
 	// (and, worse, letting the DAG advance past unreviewed work).
 	if head == baseCommit {
-		return false
+		return fmt.Sprintf("no new commit since the step started (still at %.8s)", baseCommit)
 	}
 
 	// And that commit must be pushed: HEAD reachable from an origin ref. Checked by
@@ -894,14 +919,14 @@ func WorkflowStepFinished(worktreePath, baseCommit, baseDirty string) bool {
 	refs, errR := exec.Command("git", "-C", worktreePath, "branch", "-r", "--contains",
 		head, "--format=%(refname:short)").Output()
 	if errR != nil {
-		return false
+		return "could not check whether HEAD is pushed to origin"
 	}
 	for _, line := range strings.Split(strings.TrimSpace(string(refs)), "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "origin/") {
-			return true
+			return ""
 		}
 	}
-	return false
+	return fmt.Sprintf("commit %.8s is not pushed to any origin branch", head)
 }
 
 // teardownWorkflowStepSession kills the executor process and tmux window for a
@@ -1634,7 +1659,7 @@ func (e *Executor) executeTask(ctx context.Context, task *db.Task) {
 	// Setup worktree for isolated execution (symlinks claude config from project)
 	// SECURITY: We must have a valid worktree - never fall back to project directory
 	// to prevent Claude from accidentally writing to the main repo
-	workDir, err := e.setupWorktree(task)
+	workDir, createdWorktree, err := e.setupWorktree(task)
 	if err != nil {
 		e.logger.Error("Failed to setup worktree", "error", err)
 		e.logLine(task.ID, "error", fmt.Sprintf("Failed to setup worktree: %v", err))
@@ -1649,15 +1674,24 @@ func (e *Executor) executeTask(ctx context.Context, task *db.Task) {
 	// it started" — worktree setup (clone, bundle, migrations) can run for tens of
 	// seconds while the task is already 'processing', and without this the sweep marks
 	// the step done before its agent ever starts.
+	//
+	// Record only for a freshly-created worktree (or when no baseline exists yet). A
+	// retry that reuses the worktree must keep the ORIGINAL baseline: re-recording
+	// after the step already committed re-baselines base_commit to that pushed HEAD,
+	// making "produced a commit" permanently false — the step can then never
+	// auto-complete and the DAG stalls behind it.
 	if base := gitHeadCommit(workDir); base != "" {
-		if err := e.db.SetTaskBaseCommit(task.ID, base); err != nil {
-			e.logger.Warn("could not record worktree base commit", "task", task.ID, "error", err)
-		}
-		// Also snapshot what init already dirtied (bundle/migrate rewriting tracked files),
-		// so completion is judged on what THIS step left behind, not on that noise.
-		if dirty, ok := gitDirtyPaths(workDir); ok {
-			if err := e.db.SetTaskBaseDirty(task.ID, dirty); err != nil {
-				e.logger.Warn("could not record worktree base dirt", "task", task.ID, "error", err)
+		prevBase, _ := e.db.GetTaskBaseCommit(task.ID)
+		if createdWorktree || prevBase == "" {
+			if err := e.db.SetTaskBaseCommit(task.ID, base); err != nil {
+				e.logger.Warn("could not record worktree base commit", "task", task.ID, "error", err)
+			}
+			// Also snapshot what init already dirtied (bundle/migrate rewriting tracked files),
+			// so completion is judged on what THIS step left behind, not on that noise.
+			if dirty, ok := gitDirtyPaths(workDir); ok {
+				if err := e.db.SetTaskBaseDirty(task.ID, dirty); err != nil {
+					e.logger.Warn("could not record worktree base dirt", "task", task.ID, "error", err)
+				}
 			}
 		}
 	}
@@ -4067,8 +4101,10 @@ func (e *Executor) getConversationHistory(taskID int64) string {
 }
 
 // setupWorktree creates a git worktree for the task if the project is a git repo.
-// Returns the working directory to use (worktree path or project path).
-func (e *Executor) setupWorktree(task *db.Task) (string, error) {
+// Returns the working directory to use (worktree path or project path) and whether
+// this call created the worktree fresh (false when an existing or restored worktree
+// was reused — callers use this to keep, not re-record, per-run git baselines).
+func (e *Executor) setupWorktree(task *db.Task) (string, bool, error) {
 	// Ensure task has a project (default to 'personal' if empty)
 	if task.Project == "" {
 		task.Project = "personal"
@@ -4081,12 +4117,13 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 	projectDir := e.getProjectDir(task.Project)
 
 	if projectDir == "" {
-		return "", fmt.Errorf("project directory not found for project: %s", task.Project)
+		return "", false, fmt.Errorf("project directory not found for project: %s", task.Project)
 	}
 
 	// For non-worktree projects, all tasks share the project directory directly
 	if !e.config.ProjectUsesWorktrees(task.Project) {
-		return e.setupSharedWorkDir(task, projectDir, paths)
+		workDir, err := e.setupSharedWorkDir(task, projectDir, paths)
+		return workDir, false, err
 	}
 
 	// Check if project is a git repo, initialize one if not
@@ -4100,7 +4137,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 		cmd := exec.Command("git", "init")
 		cmd.Dir = projectDir
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("failed to initialize git repo: %v\n%s", err, string(output))
+			return "", false, fmt.Errorf("failed to initialize git repo: %v\n%s", err, string(output))
 		}
 
 		// Create initial commit so we have a branch to create worktrees from
@@ -4111,7 +4148,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 		cmd = exec.Command("git", "commit", "--allow-empty", "-m", "Initial commit for taskyou worktree support")
 		cmd.Dir = projectDir
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("failed to create initial commit: %v\n%s", err, string(output))
+			return "", false, fmt.Errorf("failed to create initial commit: %v\n%s", err, string(output))
 		}
 	} else {
 		// Git repo exists, but check if it has any commits
@@ -4129,7 +4166,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 			cmd = exec.Command("git", "commit", "--allow-empty", "-m", "Initial commit for taskyou worktree support")
 			cmd.Dir = projectDir
 			if output, err := cmd.CombinedOutput(); err != nil {
-				return "", fmt.Errorf("failed to create initial commit: %v\n%s", err, string(output))
+				return "", false, fmt.Errorf("failed to create initial commit: %v\n%s", err, string(output))
 			}
 		}
 	}
@@ -4143,7 +4180,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 			symlinkClaudeConfig(projectDir, task.WorktreePath)
 			symlinkMCPConfig(projectDir, task.WorktreePath)
 			copyMCPConfig(paths.configFile, projectDir, task.WorktreePath)
-			return task.WorktreePath, nil
+			return task.WorktreePath, false, nil
 		}
 		// Worktree path was set but directory doesn't exist, clear it and create fresh
 		task.WorktreePath = ""
@@ -4172,7 +4209,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 			symlinkClaudeConfig(projectDir, task.WorktreePath)
 			symlinkMCPConfig(projectDir, task.WorktreePath)
 			copyMCPConfig(paths.configFile, projectDir, task.WorktreePath)
-			return task.WorktreePath, nil
+			return task.WorktreePath, false, nil
 		}
 	}
 
@@ -4180,7 +4217,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 	// This allows Claude to inherit the project's MCP config and settings
 	worktreesDir := filepath.Join(projectDir, ".task-worktrees")
 	if err := os.MkdirAll(worktreesDir, 0755); err != nil {
-		return "", fmt.Errorf("create worktrees dir: %w", err)
+		return "", false, fmt.Errorf("create worktrees dir: %w", err)
 	}
 
 	// Ensure .task-worktrees is in .gitignore
@@ -4217,7 +4254,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 		symlinkMCPConfig(projectDir, worktreePath)
 		copyMCPConfig(paths.configFile, projectDir, worktreePath)
 		e.runWorktreeInitScript(projectDir, worktreePath, task)
-		return worktreePath, nil
+		return worktreePath, false, nil
 	}
 
 	// Check if task specifies an existing source branch to checkout
@@ -4226,7 +4263,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 		fetchCmd := exec.Command("git", "fetch", "origin")
 		fetchCmd.Dir = projectDir
 		if fetchOutput, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
-			return "", fmt.Errorf("fetch origin: %v\n%s", fetchErr, string(fetchOutput))
+			return "", false, fmt.Errorf("fetch origin: %v\n%s", fetchErr, string(fetchOutput))
 		}
 
 		// Create worktree from existing remote branch (no -b flag)
@@ -4235,7 +4272,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 		cmd.Dir = projectDir
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "", fmt.Errorf("create worktree from branch %s: %v\n%s", task.SourceBranch, err, string(output))
+			return "", false, fmt.Errorf("create worktree from branch %s: %v\n%s", task.SourceBranch, err, string(output))
 		}
 
 		// Use the source branch name as the branch name for the task
@@ -4285,12 +4322,12 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 						symlinkMCPConfig(projectDir, worktreePath)
 						copyMCPConfig(paths.configFile, projectDir, worktreePath)
 						e.runWorktreeInitScript(projectDir, worktreePath, task)
-						return worktreePath, nil
+						return worktreePath, false, nil
 					}
-					return "", fmt.Errorf("create worktree: %v\n%s\n%s", err, string(output), string(output2))
+					return "", false, fmt.Errorf("create worktree: %v\n%s\n%s", err, string(output), string(output2))
 				}
 			} else {
-				return "", fmt.Errorf("create worktree: %v\n%s", err, string(output))
+				return "", false, fmt.Errorf("create worktree: %v\n%s", err, string(output))
 			}
 		}
 
@@ -4326,7 +4363,7 @@ func (e *Executor) setupWorktree(task *db.Task) (string, error) {
 	// Run worktree init script if configured
 	e.runWorktreeInitScript(projectDir, worktreePath, task)
 
-	return worktreePath, nil
+	return worktreePath, true, nil
 }
 
 // setupSharedWorkDir sets up a task to use the project directory directly,

--- a/internal/pipeline/compose.go
+++ b/internal/pipeline/compose.go
@@ -113,6 +113,12 @@ func composeInstruction(def Definition, step Step) string {
 		b.WriteString("  (If you are on a detached HEAD, run `git checkout -B {{branch}}` first.)\n")
 	}
 
+	// Leftover untracked files are the top cause of a step that did its work but
+	// never hands off: WorkflowStepFinished refuses to auto-complete a worktree
+	// with uncommitted files the step created (fail-closed — they might be
+	// forgotten work), so scratch must be committed or removed.
+	b.WriteString("- Commit or delete every file you create — including fetched inputs and scratch. Leftover untracked files block the automatic handoff and stall the workflow.\n")
+
 	// PR: only the sink step opens it.
 	if len(def.dependents(step.Name)) == 0 {
 		b.WriteString("- You are the final step: open a pull request with `gh pr create` summarizing the change. The workflow then parks in 'blocked' for a human to merge.\n")


### PR DESCRIPTION
## What happened

A live 7-step review workflow (root prep → four parallel reviewers → verify → report) stalled twice at the Verify step and needed manual `ty retry`/`ty execute` kicks to finish. Forensics on `tasks.db` + the worktree traced it to three distinct defects — none of them in the DAG scheduler, which promoted dependents within 2 seconds every time.

## The three fixes

### 1. Retry re-baselines `base_commit`, making completion permanently unsatisfiable

`SetTaskBaseCommit` is documented "written once", but the executor start path recorded it unconditionally on every start. Retrying a step that had **already committed and pushed** re-baselined `base_commit` to that pushed HEAD — after which `WorkflowStepFinished`'s "must have produced a commit" check (`head != baseCommit`) could never pass. The step could never auto-complete, and neither the Stop hook nor the `reconcileFinishedWorkflowSteps` sweep (same check) could ever rescue it.

`setupWorktree` now returns whether it created the worktree fresh; the executor records `base_commit`/`base_dirty` only for a fresh worktree or when no baseline exists yet. A reused worktree keeps its original baseline; a recreated one is re-baselined (correct in both directions — a stale baseline on a fresh worktree would go wrong the *other* way and mark an unstarted step finished).

### 2. A step that failed the handoff parked with no reason

The observed shape: the Verify step fetched its four parallel inputs as untracked files, wrote and **committed and pushed** its own output — then parked as "Waiting for user input" because the own-dirt check (correctly, fail-closed) refused to complete a worktree with new untracked files. The message is indistinguishable from a question the agent never asked; the DAG just sits there.

- `WorkflowStepFinished` is now a thin wrapper around a new `WorkflowStepUnfinishedReason`, and the Stop hook logs the concrete blocker: `Step ended its turn without completing the handoff — left uncommitted files: peer-a.md, peer-b.md — commit them (or delete them) and the step will advance`.
- The composed step handoff instructions gain an explicit line: commit or delete every file you create, including fetched inputs and scratch.

The fail-closed behavior itself is deliberately unchanged — untracked leftovers still block completion, since they may be forgotten work. They just stop being silent.

### 3. `ty pipeline` / `ty execute` succeed cheerfully with no daemon running

The daemon had died earlier in the day; `ty pipeline` created the workflow, printed "Running — steps advance automatically", and the root step sat `queued` forever. Only the TUI (`runLocal`) ensured the daemon; CLI queueing paths never did.

`ty pipeline` (when executing), `ty execute` (and `ty run <id>` via its dispatch), and `ty bulk execute` now call a shared `ensureDaemonForQueuedWork()`: start the daemon exactly like the TUI does, or warn loudly on stderr that queued work will not execute.

## Tests

- New `TestWorkflowStepUnfinishedReason` reproduces the incident shape end-to-end (committed + pushed + untracked scratch → reason names the files; baseline dirt exonerated; finished ⇔ empty reason; bool wrapper agrees).
- Existing `TestWorkflowStepFinished` / baseline-dirt tests unchanged and green.
- `go test -race ./cmd/task/ ./internal/executor/ ./internal/pipeline/ ./internal/db/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
