### PR TITLE
Soft-delete tasks: trash + restore + retention sweep, never destroy transcripts

### DIFF
--- a/cmd/task/bulk.go
+++ b/cmd/task/bulk.go
@@ -159,16 +159,16 @@ Examples:
 
 			var succeeded, failed int
 			for _, id := range ids {
-				if err := deleteTask(id); err != nil {
-					fmt.Fprintln(os.Stderr, errorStyle.Render(fmt.Sprintf("Error deleting task #%d: %v", id, err)))
+				if err := softDeleteTask(id); err != nil {
+					fmt.Fprintln(os.Stderr, errorStyle.Render(fmt.Sprintf("Error trashing task #%d: %v", id, err)))
 					failed++
 					continue
 				}
-				fmt.Println(successStyle.Render(fmt.Sprintf("Deleted task #%d", id)))
+				fmt.Println(successStyle.Render(fmt.Sprintf("Trashed task #%d", id)))
 				succeeded++
 			}
 
-			printBulkSummary("deletion", succeeded, failed)
+			printBulkSummary("trash", succeeded, failed)
 		},
 	}
 	bulkDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -524,10 +524,12 @@ Examples:
 	}
 	rootCmd.AddCommand(claudesCmd)
 
-	// Delete subcommand - delete a task, kill its agent session, and remove worktree
+	// Delete subcommand - trashes a task (soft delete) by default, keeping its
+	// worktree + Claude session recoverable until the daemon sweep hard-deletes it.
+	// --hard removes the worktree and row immediately (transcript is still kept).
 	deleteCmd := &cobra.Command{
 		Use:               "delete <task-id>",
-		Short:             "Delete a task, kill its agent session, and remove its worktree",
+		Short:             "Trash a task (recoverable with 'task restore'); --hard removes it now",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completeTaskIDs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -551,10 +553,16 @@ Examples:
 				os.Exit(1)
 			}
 
+			hard, _ := cmd.Flags().GetBool("hard")
+
 			// Confirm unless --force flag is set
 			force, _ := cmd.Flags().GetBool("force")
 			if !force {
-				fmt.Printf("Delete task #%d: %s? [y/N] ", taskID, task.Title)
+				verb := "Trash"
+				if hard {
+					verb = "PERMANENTLY delete"
+				}
+				fmt.Printf("%s task #%d: %s? [y/N] ", verb, taskID, task.Title)
 				reader := bufio.NewReader(os.Stdin)
 				response, _ := reader.ReadString('\n')
 				response = strings.TrimSpace(strings.ToLower(response))
@@ -564,15 +572,82 @@ Examples:
 				}
 			}
 
-			if err := deleteTask(taskID); err != nil {
+			if hard {
+				if err := hardDeleteTask(taskID); err != nil {
+					fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+					os.Exit(1)
+				}
+				fmt.Println(successStyle.Render(fmt.Sprintf("Permanently deleted task #%d", taskID)))
+				return
+			}
+
+			if err := softDeleteTask(taskID); err != nil {
 				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
 				os.Exit(1)
 			}
-			fmt.Println(successStyle.Render(fmt.Sprintf("Deleted task #%d", taskID)))
+			fmt.Println(successStyle.Render(fmt.Sprintf("Trashed task #%d — restore with 'task restore %d'", taskID, taskID)))
 		},
 	}
 	deleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+	deleteCmd.Flags().Bool("hard", false, "Permanently delete now (remove worktree + row) instead of trashing")
 	rootCmd.AddCommand(deleteCmd)
+
+	// Restore subcommand - bring a trashed task back to the board.
+	restoreCmd := &cobra.Command{
+		Use:   "restore <task-id>",
+		Short: "Restore a trashed (soft-deleted) task",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var taskID int64
+			if _, err := fmt.Sscanf(args[0], "%d", &taskID); err != nil {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Invalid task ID: "+args[0]))
+				os.Exit(1)
+			}
+			dbPath := db.DefaultPath()
+			database, err := openTaskDB(dbPath)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+				os.Exit(1)
+			}
+			defer database.Close()
+			if err := database.RestoreTask(taskID); err != nil {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+				os.Exit(1)
+			}
+			fmt.Println(successStyle.Render(fmt.Sprintf("Restored task #%d", taskID)))
+		},
+	}
+	rootCmd.AddCommand(restoreCmd)
+
+	// Trash subcommand - list soft-deleted tasks awaiting the sweep.
+	trashCmd := &cobra.Command{
+		Use:   "trash",
+		Short: "List trashed (soft-deleted) tasks still recoverable with 'task restore'",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			dbPath := db.DefaultPath()
+			database, err := openTaskDB(dbPath)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+				os.Exit(1)
+			}
+			defer database.Close()
+			trashed, err := database.ListTrashedTasks()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+				os.Exit(1)
+			}
+			if len(trashed) == 0 {
+				fmt.Println(dimStyle.Render("Trash is empty"))
+				return
+			}
+			for _, t := range trashed {
+				age := time.Since(t.DeletedAt).Round(time.Hour)
+				fmt.Printf("#%-5d %s  %s\n", t.ID, t.Title, dimStyle.Render(fmt.Sprintf("(trashed %s ago)", age)))
+			}
+		},
+	}
+	rootCmd.AddCommand(trashCmd)
 
 	// Create subcommand - create a new task from command line
 	createCmd := &cobra.Command{
@@ -6050,8 +6125,42 @@ func moveTask(database *db.DB, oldTask *db.Task, targetProject string) (int64, e
 }
 
 // deleteTask deletes a task, its agent session, and its worktree.
-func deleteTask(taskID int64) error {
-	// Open database
+// softDeleteTask trashes a task: it stops any running agent so the task no longer
+// consumes a session, but deliberately LEAVES the worktree and Claude transcript on
+// disk so the whole thing is recoverable with 'task restore'. The daemon trash
+// sweep hard-deletes it after the retention window (see Executor.sweepTrashedTasks).
+func softDeleteTask(taskID int64) error {
+	dbPath := db.DefaultPath()
+	database, err := openTaskDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer database.Close()
+
+	task, err := database.GetTask(taskID)
+	if err != nil {
+		return fmt.Errorf("get task: %w", err)
+	}
+	if task == nil {
+		return fmt.Errorf("task #%d not found", taskID)
+	}
+
+	// Stop the running agent so a trashed task isn't left executing, but keep the
+	// worktree + transcript intact. See killSessionAcrossDaemons note in hardDeleteTask.
+	killSessionAcrossDaemons(int(taskID))
+
+	if err := database.SoftDeleteTask(taskID); err != nil {
+		return fmt.Errorf("trash task: %w", err)
+	}
+	return nil
+}
+
+// hardDeleteTask permanently removes a task: it kills the agent, removes the
+// worktree, and deletes the row. It is invoked by 'delete --hard' and by the daemon
+// trash sweep once retention expires. It never removes the Claude transcript — those
+// .jsonl files are tiny and the single most valuable thing to recover, so they are
+// preserved even here (this is the deliberate change from the old destructive delete).
+func hardDeleteTask(taskID int64) error {
 	dbPath := db.DefaultPath()
 	database, err := openTaskDB(dbPath)
 	if err != nil {
@@ -6075,20 +6184,10 @@ func deleteTask(taskID int64) error {
 	// the window and leak the agent. See sessions_test.go for repro.
 	killSessionAcrossDaemons(int(taskID))
 
-	// Clean up worktree and agent sessions if they exist
+	// Clean up the worktree if it exists. Note: unlike the pre-soft-delete
+	// behaviour we do NOT call executor.CleanupClaudeSessions — the transcript is
+	// intentionally preserved so a conversation is never destroyed by a delete.
 	if task.WorktreePath != "" {
-		projectConfigDir := ""
-		if task.Project != "" {
-			if project, err := database.GetProjectByName(task.Project); err == nil && project != nil {
-				projectConfigDir = project.ClaudeConfigDir
-			}
-		}
-		// Clean up Claude session files first (before worktree is removed)
-		if err := executor.CleanupClaudeSessions(task.WorktreePath, projectConfigDir); err != nil {
-			fmt.Fprintln(os.Stderr, dimStyle.Render(fmt.Sprintf("Warning: could not remove Claude sessions: %v", err)))
-		}
-
-		// Clean up worktree
 		cfg := config.New(database)
 		exec := executor.New(database, cfg)
 		if err := exec.CleanupWorktree(task); err != nil {

--- a/cmd/task/sessions_test.go
+++ b/cmd/task/sessions_test.go
@@ -176,12 +176,12 @@ func TestDeleteTask_KillsAgentInForeignDaemonSession(t *testing.T) {
 
 	t.Setenv("WORKTREE_SESSION_ID", "")
 
-	if err := deleteTask(task.ID); err != nil {
-		t.Fatalf("deleteTask returned error: %v", err)
+	if err := hardDeleteTask(task.ID); err != nil {
+		t.Fatalf("hardDeleteTask returned error: %v", err)
 	}
 
 	if windowExists("task-daemon-"+otherSessionID, fmt.Sprintf("task-%d", task.ID)) {
-		t.Error("agent window still alive after deleteTask; agent leaked into orphan state")
+		t.Error("agent window still alive after hardDeleteTask; agent leaked into orphan state")
 	}
 
 	// And the DB row should be gone too.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,11 @@ const (
 	SettingIdleSuspendTimeout    = "idle_suspend_timeout"
 	SettingServerURL             = "server_url"
 	SettingWorktreeCleanupMaxAge = "worktree_cleanup_max_age"
+	// SettingTrashRetention is how long a soft-deleted (trashed) task stays
+	// recoverable before the daemon sweep hard-deletes it. Value is a Go duration
+	// string (e.g. "336h"); "0" or "disabled" turns the sweep off (trash kept
+	// forever). See DefaultTrashRetention.
+	SettingTrashRetention = "trash_retention"
 	// SettingHTTPAPIPort is the port the daemon-hosted HTTP API listens on.
 	SettingHTTPAPIPort = "http_api_port"
 	// SettingHTTPAPIDisabled, when "true", stops the daemon from hosting the

--- a/internal/db/soft_delete_test.go
+++ b/internal/db/soft_delete_test.go
@@ -1,0 +1,147 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// mkTask creates a minimal task and returns its id.
+func mkTask(t *testing.T, database *DB, title string) int64 {
+	t.Helper()
+	task := &Task{Title: title, Project: "personal", Type: TypeCode}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task %q: %v", title, err)
+	}
+	return task.ID
+}
+
+func listActiveIDs(t *testing.T, database *DB) map[int64]bool {
+	t.Helper()
+	tasks, err := database.ListTasks(ListTasksOptions{})
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	ids := map[int64]bool{}
+	for _, tk := range tasks {
+		ids[tk.ID] = true
+	}
+	return ids
+}
+
+func TestSoftDeleteHidesButKeepsTask(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	id := mkTask(t, database, "trash me")
+
+	if !listActiveIDs(t, database)[id] {
+		t.Fatal("task should be listed before soft-delete")
+	}
+
+	if err := database.SoftDeleteTask(id); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+
+	// Hidden from the default board/list...
+	if listActiveIDs(t, database)[id] {
+		t.Error("soft-deleted task should not appear in default ListTasks")
+	}
+	// ...but the row still exists and is fetchable.
+	if got, err := database.GetTask(id); err != nil || got == nil {
+		t.Fatalf("GetTask after soft-delete: got=%v err=%v (row must survive)", got, err)
+	}
+	// ...and shows up in the trash listing.
+	trashed, err := database.ListTrashedTasks()
+	if err != nil {
+		t.Fatalf("list trashed: %v", err)
+	}
+	if len(trashed) != 1 || trashed[0].ID != id {
+		t.Fatalf("expected task %d in trash, got %+v", id, trashed)
+	}
+	// ...and IncludeTrashed surfaces it in the normal query.
+	all, err := database.ListTasks(ListTasksOptions{IncludeTrashed: true})
+	if err != nil {
+		t.Fatalf("list incl trashed: %v", err)
+	}
+	found := false
+	for _, tk := range all {
+		if tk.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("IncludeTrashed should surface the trashed task")
+	}
+}
+
+func TestRestoreBringsTaskBack(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	id := mkTask(t, database, "restore me")
+	if err := database.SoftDeleteTask(id); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+	if err := database.RestoreTask(id); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if !listActiveIDs(t, database)[id] {
+		t.Error("restored task should reappear in default ListTasks")
+	}
+	trashed, _ := database.ListTrashedTasks()
+	if len(trashed) != 0 {
+		t.Errorf("trash should be empty after restore, got %+v", trashed)
+	}
+}
+
+func TestSweepableRespectsRetention(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	fresh := mkTask(t, database, "just trashed")
+	old := mkTask(t, database, "trashed long ago")
+	for _, id := range []int64{fresh, old} {
+		if err := database.SoftDeleteTask(id); err != nil {
+			t.Fatalf("soft-delete %d: %v", id, err)
+		}
+	}
+	// Backdate the "old" one well beyond any retention.
+	if _, err := database.Exec(
+		"UPDATE tasks SET deleted_at = ? WHERE id = ?",
+		time.Now().Add(-30*24*time.Hour).UTC(), old,
+	); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	sweepable, err := database.GetSweepableTrashedTasks(14 * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("sweepable: %v", err)
+	}
+	if len(sweepable) != 1 || sweepable[0].ID != old {
+		t.Fatalf("only the long-trashed task should be sweepable at 14d, got %+v", sweepable)
+	}
+}
+
+func TestSoftDeletedTaskFreesPort(t *testing.T) {
+	database := setupTestDB(t)
+	defer database.Close()
+
+	id := mkTask(t, database, "holds a port")
+	if _, err := database.Exec("UPDATE tasks SET port = 4242 WHERE id = ?", id); err != nil {
+		t.Fatalf("set port: %v", err)
+	}
+
+	ports, _ := database.GetActiveTaskPorts()
+	if !ports[4242] {
+		t.Fatal("port should be held while task is live")
+	}
+
+	if err := database.SoftDeleteTask(id); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+	ports, _ = database.GetActiveTaskPorts()
+	if ports[4242] {
+		t.Error("soft-deleted task must not keep its port reserved")
+	}
+}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -332,6 +332,12 @@ func (db *DB) migrate() error {
 		// never be the completion signal. What matters is that the step left nothing
 		// uncommitted that wasn't already dirty before it ran.
 		`ALTER TABLE tasks ADD COLUMN base_dirty TEXT DEFAULT ''`,
+		// Soft-delete timestamp. NULL = live task. Non-NULL = trashed (hidden from
+		// the board, still fully recoverable via 'task restore') until the daemon
+		// trash sweep hard-deletes it after the configured retention. Deleting a task
+		// no longer destroys its worktree or Claude transcript up front — that only
+		// happens when the sweep fires, and even then the transcript is preserved.
+		`ALTER TABLE tasks ADD COLUMN deleted_at DATETIME`,
 	}
 
 	for _, m := range alterMigrations {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -437,6 +437,7 @@ type ListTasksOptions struct {
 	Limit          int
 	Offset         int
 	IncludeClosed  bool // Include closed tasks even when Status is empty
+	IncludeTrashed bool // Include soft-deleted (trashed) tasks; by default they are hidden
 	OrderByRecency bool // Sort purely by recency, ignoring pinned-first ordering
 }
 
@@ -492,6 +493,13 @@ func (db *DB) ListTasks(opts ListTasksOptions) ([]*Task, error) {
 	// Exclude done and archived by default unless specifically querying for them or includeClosed is set
 	if opts.Status == "" && !opts.IncludeClosed {
 		query += " AND status NOT IN ('done', 'archived')"
+	}
+
+	// Soft-deleted (trashed) tasks are hidden everywhere by default — the board,
+	// CLI list, port allocation, review reconcile, etc. They only resurface via an
+	// explicit IncludeTrashed query ('task trash') or 'task restore'.
+	if !opts.IncludeTrashed {
+		query += " AND deleted_at IS NULL"
 	}
 
 	// Sort done/blocked tasks by completed_at (most recently closed first) and
@@ -649,7 +657,7 @@ func (db *DB) SearchTasks(query string, limit int) ([]*Task, error) {
 // CountTasksByStatus returns the count of tasks with a given status.
 func (db *DB) CountTasksByStatus(status string) (int, error) {
 	var count int
-	err := db.QueryRow("SELECT COUNT(*) FROM tasks WHERE status = ?", status).Scan(&count)
+	err := db.QueryRow("SELECT COUNT(*) FROM tasks WHERE status = ? AND deleted_at IS NULL", status).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("count tasks: %w", err)
 	}
@@ -1040,11 +1048,103 @@ func (db *DB) DeleteTask(id int64) error {
 	return nil
 }
 
+// SoftDeleteTask marks a task as trashed (deleted_at = now) instead of removing
+// it. The row, worktree and Claude transcript all stay intact and recoverable via
+// RestoreTask until the daemon trash sweep hard-deletes it after the retention
+// window (see Executor.sweepTrashedTasks). Trashed tasks are hidden from the board
+// and every default query. No-op if the task is already trashed.
+func (db *DB) SoftDeleteTask(id int64) error {
+	task, _ := db.GetTask(id)
+	title := ""
+	if task != nil {
+		title = task.Title
+	}
+
+	_, err := db.Exec("UPDATE tasks SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND deleted_at IS NULL", id)
+	if err != nil {
+		return fmt.Errorf("soft-delete task: %w", err)
+	}
+
+	// Reuse the delete event so listeners (board, web SSE) drop the task from view;
+	// a restore re-emits a normal task-updated event.
+	db.emitTaskDeleted(id, title)
+
+	return nil
+}
+
+// RestoreTask clears the trashed flag, returning a soft-deleted task to the board
+// with its original status, worktree and session intact.
+func (db *DB) RestoreTask(id int64) error {
+	_, err := db.Exec("UPDATE tasks SET deleted_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("restore task: %w", err)
+	}
+	if task, err := db.GetTask(id); err == nil && task != nil {
+		db.emitTaskUpdated(task, map[string]interface{}{"restored": true})
+	}
+	return nil
+}
+
+// TrashedTask is a lightweight view of a soft-deleted task for the trash listing
+// and the sweep — it deliberately avoids the full Task scan so new columns there
+// never need threading through here.
+type TrashedTask struct {
+	ID           int64
+	Title        string
+	Project      string
+	WorktreePath string
+	DeletedAt    time.Time
+}
+
+// ListTrashedTasks returns soft-deleted tasks, most recently trashed first.
+func (db *DB) ListTrashedTasks() ([]*TrashedTask, error) {
+	rows, err := db.Query(`
+		SELECT id, title, COALESCE(project, ''), COALESCE(worktree_path, ''), deleted_at
+		FROM tasks WHERE deleted_at IS NOT NULL
+		ORDER BY deleted_at DESC, id DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list trashed tasks: %w", err)
+	}
+	defer rows.Close()
+	return scanTrashedTasks(rows)
+}
+
+// GetSweepableTrashedTasks returns trashed tasks whose retention has expired —
+// i.e. deleted_at is older than maxAge — so the daemon can hard-delete them.
+func (db *DB) GetSweepableTrashedTasks(maxAge time.Duration) ([]*TrashedTask, error) {
+	cutoff := time.Now().Add(-maxAge).UTC()
+	rows, err := db.Query(`
+		SELECT id, title, COALESCE(project, ''), COALESCE(worktree_path, ''), deleted_at
+		FROM tasks WHERE deleted_at IS NOT NULL AND deleted_at < ?
+		ORDER BY deleted_at ASC, id ASC
+	`, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("list sweepable trashed tasks: %w", err)
+	}
+	defer rows.Close()
+	return scanTrashedTasks(rows)
+}
+
+func scanTrashedTasks(rows *sql.Rows) ([]*TrashedTask, error) {
+	var out []*TrashedTask
+	for rows.Next() {
+		var t TrashedTask
+		var deletedAt sql.NullTime
+		if err := rows.Scan(&t.ID, &t.Title, &t.Project, &t.WorktreePath, &deletedAt); err != nil {
+			return nil, fmt.Errorf("scan trashed task: %w", err)
+		}
+		t.DeletedAt = deletedAt.Time
+		out = append(out, &t)
+	}
+	return out, rows.Err()
+}
+
 // GetActiveTaskPorts returns all ports currently in use by active (non-done, non-archived) tasks.
 func (db *DB) GetActiveTaskPorts() (map[int]bool, error) {
 	rows, err := db.Query(`
 		SELECT port FROM tasks
-		WHERE port > 0 AND status NOT IN (?, ?)
+		WHERE port > 0 AND status NOT IN (?, ?) AND deleted_at IS NULL
 	`, StatusDone, StatusArchived)
 	if err != nil {
 		return nil, fmt.Errorf("query active ports: %w", err)
@@ -1124,7 +1224,7 @@ func (db *DB) GetNextQueuedTask() (*Task, error) {
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
 		       COALESCE(archive_worktree_path, ''), COALESCE(archive_branch_name, '')
 		FROM tasks
-		WHERE status = ?
+		WHERE status = ? AND deleted_at IS NULL
 		ORDER BY created_at ASC
 		LIMIT 1
 	`, StatusQueued).Scan(
@@ -1162,7 +1262,7 @@ func (db *DB) GetQueuedTasks() ([]*Task, error) {
 		       COALESCE(archive_ref, ''), COALESCE(archive_commit, ''),
 		       COALESCE(archive_worktree_path, ''), COALESCE(archive_branch_name, '')
 		FROM tasks
-		WHERE status = ?
+		WHERE status = ? AND deleted_at IS NULL
 		ORDER BY created_at ASC
 	`, StatusQueued)
 	if err != nil {
@@ -2219,6 +2319,7 @@ func (db *DB) GetStaleWorktreeTasks(maxAge time.Duration) ([]*Task, error) {
 		FROM tasks
 		WHERE worktree_path != ''
 		  AND status IN ('done', 'archived')
+		  AND deleted_at IS NULL
 		  AND completed_at IS NOT NULL
 		  AND completed_at < ?
 		ORDER BY completed_at ASC

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -92,6 +92,14 @@ const DoneTaskCleanupTimeout = 30 * time.Minute
 // outputs like MP4s), so an aggressive default is important to prevent disk fill.
 const DefaultWorktreeCleanupMaxAge = 24 * time.Hour // 1 day
 
+// DefaultTrashRetention is how long a soft-deleted (trashed) task stays recoverable
+// before the daemon sweep hard-deletes it (removes the worktree + row; the Claude
+// transcript is always preserved). Chosen so an accidental delete has a comfortable
+// window to be noticed — the incident that motivated soft-delete went unnoticed for
+// well over a week. Override with the trash_retention setting ("0"/"disabled" = keep
+// trash forever).
+const DefaultTrashRetention = 14 * 24 * time.Hour // 14 days
+
 const (
 	defaultExecutorSlug = "claude"
 	defaultExecutorName = "Claude"
@@ -1196,6 +1204,12 @@ func (e *Executor) worker(ctx context.Context) {
 			if tickCount%staleWorktreeInterval == 0 {
 				e.cleanupStaleWorktrees()
 			}
+
+			// Periodically hard-delete trashed tasks whose retention has expired
+			// (keeps their transcript; reclaims the worktree + row).
+			if tickCount%staleWorktreeInterval == 0 {
+				e.sweepTrashedTasks()
+			}
 		}
 	}
 }
@@ -1490,6 +1504,70 @@ func (e *Executor) cleanupStaleWorktrees() {
 		e.logLine(task.ID, "system",
 			fmt.Sprintf("Worktree auto-archived after %s (use 'unarchive' to restore)", age.Round(time.Hour)))
 	}
+}
+
+// sweepTrashedTasks hard-deletes soft-deleted tasks whose retention window has
+// expired: it removes the worktree and the DB row. It deliberately does NOT remove
+// the Claude transcript — those .jsonl files are tiny and are the single most
+// valuable thing to recover after an accidental delete, so they always survive.
+// Running tasks and non-worktree projects are handled defensively.
+func (e *Executor) sweepTrashedTasks() {
+	retention := e.getTrashRetention()
+	if retention <= 0 {
+		return // Disabled: trash is kept forever.
+	}
+
+	tasks, err := e.db.GetSweepableTrashedTasks(retention)
+	if err != nil {
+		e.logger.Debug("Failed to list sweepable trashed tasks", "error", err)
+		return
+	}
+
+	for _, t := range tasks {
+		// Never sweep a task that is somehow still running.
+		e.mu.RLock()
+		running := e.runningTasks[t.ID]
+		e.mu.RUnlock()
+		if running {
+			continue
+		}
+
+		age := time.Since(t.DeletedAt).Round(time.Hour)
+		e.logger.Info("Sweeping expired trashed task",
+			"task", t.ID, "project", t.Project, "trashedAge", age)
+
+		// Remove the worktree if the project uses them and it still exists. Fetch
+		// the full task so CleanupWorktree has branch/base info; if it's gone,
+		// proceed straight to the row delete.
+		if t.WorktreePath != "" && e.config.ProjectUsesWorktrees(t.Project) {
+			if _, statErr := os.Stat(t.WorktreePath); statErr == nil {
+				if full, err := e.db.GetTask(t.ID); err == nil && full != nil {
+					if err := e.CleanupWorktree(full); err != nil {
+						e.logger.Warn("Failed to remove worktree while sweeping trash",
+							"task", t.ID, "error", err)
+					}
+				}
+			}
+		}
+
+		if err := e.db.DeleteTask(t.ID); err != nil {
+			e.logger.Warn("Failed to hard-delete trashed task", "task", t.ID, "error", err)
+		}
+	}
+}
+
+// getTrashRetention returns the configured retention before trashed tasks are
+// hard-deleted. Returns 0 to disable the sweep (keep trash forever).
+func (e *Executor) getTrashRetention() time.Duration {
+	if val, err := e.db.GetSetting(config.SettingTrashRetention); err == nil && val != "" {
+		if val == "0" || val == "disabled" {
+			return 0
+		}
+		if duration, err := time.ParseDuration(val); err == nil {
+			return duration
+		}
+	}
+	return DefaultTrashRetention
 }
 
 // getWorktreeCleanupMaxAge returns the configured max age before stale worktrees are cleaned up.

--- a/internal/executor/trash_sweep_test.go
+++ b/internal/executor/trash_sweep_test.go
@@ -1,0 +1,89 @@
+package executor
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+// trashTask creates a task, soft-deletes it, and (optionally) backdates its
+// deleted_at so it looks older than the retention window.
+func trashTask(t *testing.T, database *db.DB, title string, trashedAge time.Duration) int64 {
+	t.Helper()
+	task := &db.Task{Title: title, Project: "personal", Type: db.TypeCode}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create %q: %v", title, err)
+	}
+	if err := database.SoftDeleteTask(task.ID); err != nil {
+		t.Fatalf("soft-delete %q: %v", title, err)
+	}
+	if trashedAge > 0 {
+		if _, err := database.Exec("UPDATE tasks SET deleted_at = ? WHERE id = ?",
+			time.Now().Add(-trashedAge).UTC(), task.ID); err != nil {
+			t.Fatalf("backdate %q: %v", title, err)
+		}
+	}
+	return task.ID
+}
+
+func rowExists(t *testing.T, database *db.DB, id int64) bool {
+	t.Helper()
+	task, err := database.GetTask(id)
+	if err != nil {
+		t.Fatalf("get task %d: %v", id, err)
+	}
+	return task != nil
+}
+
+func newSweepExecutor(t *testing.T) (*Executor, *db.DB) {
+	t.Helper()
+	tmp, err := os.CreateTemp("", "trash-sweep-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(tmp.Name()) })
+	tmp.Close()
+
+	database, err := db.Open(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return New(database, &config.Config{}), database
+}
+
+// TestSweepTrashedTasksRespectsRetention: only trash older than the retention is
+// hard-deleted; fresh trash survives.
+func TestSweepTrashedTasksRespectsRetention(t *testing.T) {
+	exec, database := newSweepExecutor(t)
+
+	old := trashTask(t, database, "old trash", 30*24*time.Hour)
+	fresh := trashTask(t, database, "fresh trash", 0)
+
+	exec.sweepTrashedTasks() // default 14d retention
+
+	if rowExists(t, database, old) {
+		t.Error("trash older than retention should be hard-deleted")
+	}
+	if !rowExists(t, database, fresh) {
+		t.Error("freshly trashed task must survive the sweep")
+	}
+}
+
+// TestSweepTrashedTasksDisabled: retention "0" turns the sweep off entirely.
+func TestSweepTrashedTasksDisabled(t *testing.T) {
+	exec, database := newSweepExecutor(t)
+	if err := database.SetSetting(config.SettingTrashRetention, "0"); err != nil {
+		t.Fatal(err)
+	}
+
+	old := trashTask(t, database, "ancient trash", 90*24*time.Hour)
+	exec.sweepTrashedTasks()
+
+	if !rowExists(t, database, old) {
+		t.Error("sweep must be a no-op when retention is disabled")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4465,14 +4465,14 @@ func (m *AppModel) unarchiveTask(id int64) tea.Cmd {
 	}
 }
 
+// deleteTask trashes a task (soft delete): it stops the running agent so the task
+// stops consuming a session, but leaves the worktree and Claude transcript on disk
+// so the task is fully recoverable ('task restore' / the daemon sweep hard-deletes
+// it only after the retention window). This is the deliberate replacement for the
+// old one-shot destructive delete that made incidents like the lost Creator Commerce
+// session unrecoverable.
 func (m *AppModel) deleteTask(id int64) tea.Cmd {
 	return func() tea.Msg {
-		// Get task to check for worktree
-		task, err := m.db.GetTask(id)
-		if err != nil {
-			return taskDeletedMsg{err: err}
-		}
-
 		// Kill Claude process to free memory
 		m.executor.KillClaudeProcess(id)
 
@@ -4480,23 +4480,8 @@ func (m *AppModel) deleteTask(id int64) tea.Cmd {
 		windowTarget := executor.TmuxSessionName(id)
 		osExec.Command("tmux", "kill-window", "-t", windowTarget).Run()
 
-		// Clean up worktree and Claude sessions if they exist
-		if task != nil && task.WorktreePath != "" {
-			projectConfigDir := ""
-			if task.Project != "" {
-				if project, err := m.db.GetProjectByName(task.Project); err == nil && project != nil {
-					projectConfigDir = project.ClaudeConfigDir
-				}
-			}
-			// Clean up Claude session files first (before worktree is removed)
-			executor.CleanupClaudeSessions(task.WorktreePath, projectConfigDir)
-
-			// Clean up worktree
-			m.executor.CleanupWorktree(task)
-		}
-
-		// Delete from database
-		err = m.db.DeleteTask(id)
+		// Trash the task — worktree + transcript are preserved for recovery.
+		err := m.db.SoftDeleteTask(id)
 		return taskDeletedMsg{err: err}
 	}
 }

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -287,7 +287,9 @@ func (s *Server) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.db.DeleteTask(id); err != nil {
+	// Soft-delete: trash the task (recoverable) rather than destroying it. The
+	// daemon sweep hard-deletes it after the retention window.
+	if err := s.db.SoftDeleteTask(id); err != nil {
 		jsonErr(w, "failed to delete task", http.StatusInternalServerError)
 		return
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -245,10 +245,21 @@ func TestHandleDeleteTask(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 
-	// Verify deleted
+	// Soft-delete: the row survives (recoverable) but is trashed and hidden from
+	// the default listing.
 	got, _ := database.GetTask(task.ID)
-	if got != nil {
-		t.Error("task should be deleted")
+	if got == nil {
+		t.Fatal("task row should survive a soft delete")
+	}
+	active, _ := database.ListTasks(db.ListTasksOptions{})
+	for _, tk := range active {
+		if tk.ID == task.ID {
+			t.Error("trashed task should not appear in default listing")
+		}
+	}
+	trashed, _ := database.ListTrashedTasks()
+	if len(trashed) != 1 || trashed[0].ID != task.ID {
+		t.Errorf("expected task in trash, got %+v", trashed)
 	}
 }
 


### PR DESCRIPTION
## Problem

`task delete` was destructive in a single step: it killed the session, **deleted the Claude transcript**, removed the worktree, and hard-deleted the row — no grace period, no recovery. An accidental delete took the task *and* its interactive Claude session with it. This is exactly how the Creator Commerce work got lost.

## Change

Delete is now a **soft delete** by default:

- Sets `deleted_at`, stops the running agent, but **keeps the worktree + transcript** on disk.
- Trashed tasks are hidden from the board and every default query; recover with `task restore <id>`.
- A daemon sweep hard-deletes the worktree + row after a **14-day** retention (setting `trash_retention`; `"0"`/`"disabled"` keeps trash forever).
- **Transcripts are never auto-deleted** — even `delete --hard` and the sweep preserve the `.jsonl`, since it's tiny and the single most valuable thing to recover.

Applied consistently across **CLI** (`delete`, bulk `delete`), **TUI** (`d` key), and the **web API** (`DELETE /api/tasks/{id}`). Trashed tasks are excluded from the queue pickers, port allocation, stale-worktree cleanup, and status counts, so a trashed `queued` task can't be silently re-run.

### New commands
- `task restore <id>` — bring a trashed task back
- `task trash` — list trashed tasks awaiting the sweep
- `task delete <id> --hard` — opt-in immediate delete (still keeps the transcript)

## Tests
- `internal/db/soft_delete_test.go` — hide/keep, restore, retention boundary, port release
- `internal/executor/trash_sweep_test.go` — sweep respects retention, disabled = no-op
- Updated `cmd/task/sessions_test.go` (→ `hardDeleteTask`) and `internal/web/server_test.go` (soft-delete semantics)

Build + vet + gofmt clean; all affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)