### PR TITLE
Fix executor pane cross-wiring between tasks (shared tmux pane id)

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -700,6 +700,17 @@ func (db *DB) UpdateTaskStatus(id int64, status string) error {
 		return fmt.Errorf("update task status: %w", err)
 	}
 
+	// A finished task's executor pane is torn down; its tmux pane ID then becomes
+	// free for tmux to recycle onto another task. Drop the stale pane pointers so
+	// they can never resolve to a different task's live pane. Best-effort — the
+	// join-time ownership guard is the real safety net.
+	switch status {
+	case StatusDone, StatusArchived:
+		if clearErr := db.ClearTaskPaneIDs(id); clearErr != nil {
+			log.Printf("ClearTaskPaneIDs(%d): %v", id, clearErr)
+		}
+	}
+
 	// Emit status change event if status actually changed
 	if oldStatus != "" && oldStatus != status {
 		updatedTask, err := db.GetTask(id)
@@ -1024,6 +1035,23 @@ func (db *DB) ClearTaskTmuxIDs(taskID int64) error {
 	`, taskID)
 	if err != nil {
 		return fmt.Errorf("clear task tmux ids: %w", err)
+	}
+	return nil
+}
+
+// ClearTaskPaneIDs clears only the tmux pane IDs for a task, leaving the window
+// ID intact. Called when a task reaches a terminal state: its executor pane is
+// torn down, which frees the pane ID for tmux to recycle onto a *different*
+// task's pane. Leaving the stale ID in the DB is what let a finished task's
+// pane pointer resolve to another live task's pane. Window IDs are not recycled
+// as aggressively and are already staleness-checked on lookup, so we keep them.
+func (db *DB) ClearTaskPaneIDs(taskID int64) error {
+	_, err := db.Exec(`
+		UPDATE tasks SET claude_pane_id = '', shell_pane_id = '', updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?
+	`, taskID)
+	if err != nil {
+		return fmt.Errorf("clear task pane ids: %w", err)
 	}
 	return nil
 }

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -2894,3 +2894,72 @@ func TestListTasksTagFilterEscapesLikeWildcards(t *testing.T) {
 		t.Errorf("tag filter %q must match only the literal tag, got %d tasks", "gm:a_b", len(undTasks))
 	}
 }
+
+// TestUpdateTaskStatus_ClearsPaneIDsOnTerminal verifies that finishing a task
+// drops its tmux pane IDs (which tmux is now free to recycle onto another task)
+// while leaving the window ID intact. Guards the pane-ID reuse vector behind the
+// 4324/4822 cross-wiring incident.
+func TestUpdateTaskStatus_ClearsPaneIDsOnTerminal(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := Open(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.CreateProject(&Project{Name: "test", Path: tmpDir}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	assertCleared := func(t *testing.T, terminal string) {
+		task := &Task{Title: "t", Status: StatusProcessing, Type: TypeCode, Project: "test"}
+		if err := db.CreateTask(task); err != nil {
+			t.Fatalf("create task: %v", err)
+		}
+		if err := db.UpdateTaskWindowID(task.ID, "@42"); err != nil {
+			t.Fatalf("set window id: %v", err)
+		}
+		if err := db.UpdateTaskPaneIDs(task.ID, "%812", "%813"); err != nil {
+			t.Fatalf("set pane ids: %v", err)
+		}
+
+		if err := db.UpdateTaskStatus(task.ID, terminal); err != nil {
+			t.Fatalf("update status: %v", err)
+		}
+
+		got, err := db.GetTask(task.ID)
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if got.ClaudePaneID != "" || got.ShellPaneID != "" {
+			t.Errorf("%s: pane IDs not cleared: claude=%q shell=%q", terminal, got.ClaudePaneID, got.ShellPaneID)
+		}
+		if got.TmuxWindowID != "@42" {
+			t.Errorf("%s: window ID should be preserved, got %q", terminal, got.TmuxWindowID)
+		}
+	}
+
+	t.Run("done", func(t *testing.T) { assertCleared(t, StatusDone) })
+	t.Run("archived", func(t *testing.T) { assertCleared(t, StatusArchived) })
+
+	// A non-terminal transition must NOT clear pane IDs (resume relies on them).
+	t.Run("blocked keeps pane ids", func(t *testing.T) {
+		task := &Task{Title: "t2", Status: StatusProcessing, Type: TypeCode, Project: "test"}
+		if err := db.CreateTask(task); err != nil {
+			t.Fatalf("create task: %v", err)
+		}
+		if err := db.UpdateTaskPaneIDs(task.ID, "%900", "%901"); err != nil {
+			t.Fatalf("set pane ids: %v", err)
+		}
+		if err := db.UpdateTaskStatus(task.ID, StatusBlocked); err != nil {
+			t.Fatalf("update status: %v", err)
+		}
+		got, err := db.GetTask(task.ID)
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if got.ClaudePaneID != "%900" || got.ShellPaneID != "%901" {
+			t.Errorf("blocked should keep pane IDs, got claude=%q shell=%q", got.ClaudePaneID, got.ShellPaneID)
+		}
+	})
+}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -1486,6 +1487,64 @@ func (m *DetailModel) releaseExecutorLock() {
 	m.executorBusyElsewhere = false
 }
 
+// tmuxPaneOpMu serializes pane join/break operations across the whole process.
+//
+// join/break run a multi-step tmux sequence that mutates and reads global tmux
+// server state (the "current window", the set of panes in task-ui, the active
+// pane). Two of these interleaving — e.g. rapid task switching fires one task's
+// join concurrently with another's — corrupts that shared state: one join's
+// "kill leftover panes in task-ui" step can kill a pane a concurrent join just
+// moved in, and (before the source-id fix below) a `display-message` read of the
+// active pane could return the *other* task's pane. That is exactly how tasks
+// 4324 and 4822 ended up sharing pane %812. Serializing makes each sequence
+// atomic with respect to the others.
+var tmuxPaneOpMu sync.Mutex
+
+// paneCwdInWorktree reports whether the given tmux pane's current working
+// directory lives inside the task's worktree. It is the ownership check that
+// prevents a task from adopting another task's executor pane when a stored
+// pane ID is stale or has been reused by tmux for a different pane.
+//
+// Returns true when ownership can't be determined (no worktree recorded, or the
+// query fails) so we never reject a legitimate pane on a transient error — the
+// check only ever *rejects* on a definite worktree mismatch.
+func (m *DetailModel) paneCwdInWorktree(ctx context.Context, paneID string) bool {
+	if m.task == nil || m.task.WorktreePath == "" || paneID == "" {
+		return true
+	}
+	out, err := osExec.CommandContext(ctx, "tmux", "display-message",
+		"-t", paneID, "-p", "#{pane_current_path}").Output()
+	if err != nil {
+		return true // can't tell — don't reject
+	}
+	cwd := strings.TrimSpace(string(out))
+	if cwd == "" {
+		return true
+	}
+	return pathInsideDir(m.task.WorktreePath, cwd)
+}
+
+// pathInsideDir reports whether path is dir itself or nested within it, after
+// resolving symlinks on both sides so /tmp vs /private/tmp (and similar macOS
+// symlinked prefixes) don't produce false mismatches. Returns true when the
+// comparison can't be made, so callers only ever act on a definite mismatch.
+func pathInsideDir(dir, path string) bool {
+	if dir == "" || path == "" {
+		return true
+	}
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return true // unrelated volumes / can't compare — don't reject
+	}
+	return rel == "." || !strings.HasPrefix(rel, "..")
+}
+
 // joinTmuxPanes joins the task's Claude pane and creates a workdir shell pane.
 // Layout:
 //   - Top (configurable, default 20%): Task details (TUI)
@@ -1501,6 +1560,11 @@ func (m *DetailModel) joinTmuxPanes() {
 		return
 	}
 	log.Debug("joinTmuxPanes: windowTarget=%q", windowTarget)
+
+	// Serialize with any concurrent join/break so the shared tmux state this
+	// sequence depends on can't be mutated mid-flight by another task's view.
+	tmuxPaneOpMu.Lock()
+	defer tmuxPaneOpMu.Unlock()
 
 	// Granular executor lock: refuse to borrow this task's pane if another ty
 	// instance already owns it, rather than fighting over it and interrupt-looping
@@ -1612,6 +1676,27 @@ func (m *DetailModel) joinTmuxPanes() {
 		log.Debug("joinTmuxPanes: falling back to first daemon pane ID %q for Claude", claudeSourcePaneID)
 	}
 
+	// Ownership guard: never adopt a pane whose working directory isn't inside
+	// this task's worktree. tmux recycles pane IDs after a pane dies, and a
+	// window named task-<id> can end up holding another task's pane, so a pane
+	// simply "existing in the window" is not proof it is ours. Adopting a foreign
+	// pane is what cross-wired 4324 onto 4822's session. On mismatch, drop the
+	// stale IDs so we stop persisting and re-displaying the wrong session, then
+	// bail on the normal cooldown; a retry rebuilds the executor cleanly.
+	if !m.paneCwdInWorktree(ctx, claudeSourcePaneID) {
+		log.Error("joinTmuxPanes: candidate Claude pane %q is not in task %d's worktree %q; refusing to adopt (self-healing stale IDs)",
+			claudeSourcePaneID, m.task.ID, m.task.WorktreePath)
+		if m.database != nil {
+			m.database.ClearTaskTmuxIDs(m.task.ID)
+		}
+		m.task.ClaudePaneID = ""
+		m.task.ShellPaneID = ""
+		m.task.TmuxWindowID = ""
+		m.cachedWindowTarget = ""
+		m.joinPaneFailedUntil = time.Now().Add(5 * time.Second)
+		return
+	}
+
 	// Step 1: Join the Claude pane below the TUI pane (vertical split)
 	log.Info("joinTmuxPanes: joining Claude pane %q", claudeSourcePaneID)
 	joinCmd := osExec.CommandContext(ctx, "tmux", "join-pane",
@@ -1625,14 +1710,12 @@ func (m *DetailModel) joinTmuxPanes() {
 	}
 	log.Debug("joinTmuxPanes: join-pane succeeded")
 
-	// Get the Claude pane ID (it's now the active pane after join)
-	claudePaneCmd := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}")
-	claudePaneOut, err := claudePaneCmd.Output()
-	if err != nil {
-		log.Error("joinTmuxPanes: failed to get Claude pane ID: %v", err)
-		return
-	}
-	m.claudePaneID = strings.TrimSpace(string(claudePaneOut))
+	// A pane keeps its ID when moved between windows/sessions, so the pane we
+	// just joined is still claudeSourcePaneID. Use it directly rather than
+	// re-reading the globally-active pane via `display-message` — that read is
+	// not concurrency-safe (a simultaneous join for another task can flip the
+	// active pane) and was how task 4324 latched onto task 4822's pane %812.
+	m.claudePaneID = claudeSourcePaneID
 	log.Info("joinTmuxPanes: claudePaneID=%q", m.claudePaneID)
 
 	// Set Claude pane title with memory info
@@ -1693,10 +1776,9 @@ func (m *DetailModel) joinTmuxPanes() {
 				log.Error("joinTmuxPanes: join shell pane failed: %v", err)
 				m.workdirPaneID = ""
 			} else {
-				// Get the joined shell pane ID
-				workdirPaneCmd := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}")
-				workdirPaneOut, _ := workdirPaneCmd.Output()
-				m.workdirPaneID = strings.TrimSpace(string(workdirPaneOut))
+				// The joined shell pane keeps its source ID; use it directly
+				// instead of the non-concurrency-safe active-pane read.
+				m.workdirPaneID = shellSourcePaneID
 				log.Debug("joinTmuxPanes: joined shell pane, workdirPaneID=%q", m.workdirPaneID)
 				osExec.CommandContext(ctx, "tmux", "select-pane", "-t", m.workdirPaneID, "-T", "Shell").Run()
 				// Set environment variables in the shell pane (they should already be set from daemon, but ensure they're fresh)
@@ -2093,6 +2175,12 @@ func (m *DetailModel) breakTmuxPanes(saveHeight bool, resizeTUI bool) {
 	log.Info("breakTmuxPanes: starting for task %d, saveHeight=%v", m.task.ID, saveHeight)
 	log.Debug("breakTmuxPanes: claudePaneID=%q, workdirPaneID=%q, tuiPaneID=%q, daemonSessionID=%q",
 		m.claudePaneID, m.workdirPaneID, m.tuiPaneID, m.daemonSessionID)
+
+	// Serialize with any concurrent join/break (see tmuxPaneOpMu). A break moving
+	// a pane back to the daemon must not interleave with a join that reads/kills
+	// panes in task-ui, or they clobber each other's view of the shared tmux state.
+	tmuxPaneOpMu.Lock()
+	defer tmuxPaneOpMu.Unlock()
 
 	// Use timeout for all tmux operations to prevent blocking UI
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -580,3 +580,37 @@ func TestContainsSourceFiles(t *testing.T) {
 		})
 	}
 }
+
+// TestPathInsideDir covers the ownership check used to reject adopting another
+// task's executor pane. The bug it guards against: task A's stored pane ID
+// resolving to task B's live pane (cwd in B's worktree), which cross-wired
+// tasks 4324 and 4822 onto the same session.
+func TestPathInsideDir(t *testing.T) {
+	dir := t.TempDir() // real path, symlink-resolved by the helper
+	sub := filepath.Join(dir, "src", "pkg")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sibling := t.TempDir()
+
+	cases := []struct {
+		name string
+		dir  string
+		path string
+		want bool
+	}{
+		{"same dir", dir, dir, true},
+		{"nested path", dir, sub, true},
+		{"sibling worktree (foreign pane)", dir, sibling, false},
+		{"parent of worktree", sub, dir, false},
+		{"empty dir tolerated", "", sibling, true},
+		{"empty path tolerated", dir, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pathInsideDir(tc.dir, tc.path); got != tc.want {
+				t.Errorf("pathInsideDir(%q, %q) = %v, want %v", tc.dir, tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Task **4324**'s detail view, `ty output`, and executor dock all showed task **4822**'s Claude session (`a3d5bb1a` "Review order bump redesign") instead of its own `7c648774`. The DB was *not* scrambled — both tasks had the correct `claude_session_id`. The corruption was a **shared tmux pane id**: both rows had `claude_pane_id = %812`.

## Root cause

From `ui.log` at 07:23:02, two detail-view `joinTmuxPanes` goroutines (rapid task switching → two concurrent `setupPanesAsync`) interleaved:

1. `joinTmuxPanes` joins its known source pane, then re-discovers "the pane it got" via `tmux display-message -p '#{pane_id}'` — the **globally-active pane**, i.e. mutable shared state.
2. With two joins racing, 4324's read returned `%812`, the pane 4822's goroutine had just activated.
3. 4324 persisted `%812` (`saveDaemonPaneIDs`) → permanent cross-wire. Every later view re-read `%812` and showed 4822's session.

Aggravators: `findTaskWindow` matches by window **name** only, and stale pane ids were never cleared (tmux recycles `%NNN` after a pane dies).

## Fix

- **Deterministic pane identity** — a pane keeps its id across `join-pane`, so use the known source pane id directly instead of the non-concurrency-safe active-pane read (Claude + shell panes). This alone removes the cross-wire mechanism.
- **Serialize** join/break behind a process mutex (`tmuxPaneOpMu`) so the multi-step, global-state-dependent tmux sequences can't interleave (incl. the "kill leftover panes in task-ui" step killing a concurrent join's pane).
- **Ownership guard** (`paneCwdInWorktree` / `pathInsideDir`) — refuse to adopt a pane whose cwd isn't inside the task's worktree; clear the stale ids so already-corrupted rows self-heal on next view. Symlink-resolved for `/tmp`→`/private/tmp`.
- **Clear pane ids on terminal status** (done/archived) in `UpdateTaskStatus` (new `ClearTaskPaneIDs`, keeps `window_id`) so a torn-down pane's recycled id can't latch onto another task.

## Tests

- `TestPathInsideDir` — ownership-check cases (nested, sibling worktree = foreign pane, parent, tolerant defaults).
- `TestUpdateTaskStatus_ClearsPaneIDsOnTerminal` — pane ids cleared on done/archived, preserved on blocked, window id kept.

`go build`, `go vet`, and `internal/ui` + `internal/db` tests pass.

## Deploy note

The running daemon must be restarted (`ty restart`) to pick up the fix. The already-corrupted live state for 4324 was repaired by hand (killed the poisoned window, cleared its stale pointers, kept `claude_session_id`); the ownership guard would now self-heal any similar row automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)