### PR TITLE
fix: board keyword search finds older/done tasks (#4705)

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2364,9 +2364,37 @@ func (m *AppModel) applyFilter() {
 		queryLower = m.resolveProjectAliases(queryLower)
 	}
 
-	// Score all tasks using fuzzy matching
-	var scored []scoredTask
+	// Build the candidate set. Start with the in-memory tasks, then — when the
+	// user typed a keyword — also pull matches straight from the database. The
+	// board only loads active tasks plus the most recent maxDoneTasksInKanban
+	// done tasks, so without this a keyword search silently misses the thousands
+	// of older done tasks (e.g. searching "demo functionality" finds nothing
+	// even though "Go to Task" locates the done task by id). This mirrors the
+	// command palette, which already supplements its list via SearchTasks. See #4705.
+	candidates := make(map[int64]*db.Task, len(m.tasks))
+	ordered := make([]*db.Task, 0, len(m.tasks))
 	for _, task := range m.tasks {
+		if _, ok := candidates[task.ID]; !ok {
+			candidates[task.ID] = task
+			ordered = append(ordered, task)
+		}
+	}
+	if m.db != nil {
+		if _, keyword, _ := parseFilterProjects(queryLower); keyword != "" {
+			if results, err := m.db.SearchTasks(keyword, boardFilterDBSearchLimit); err == nil {
+				for _, task := range results {
+					if _, ok := candidates[task.ID]; !ok {
+						candidates[task.ID] = task
+						ordered = append(ordered, task)
+					}
+				}
+			}
+		}
+	}
+
+	// Score all candidates using fuzzy matching
+	var scored []scoredTask
+	for _, task := range ordered {
 		score := scoreTaskForFilter(task, queryLower)
 		if score >= 0 {
 			scored = append(scored, scoredTask{task: task, score: score})
@@ -4133,6 +4161,12 @@ type versionCheckMsg struct {
 }
 
 const maxDoneTasksInKanban = 20
+
+// boardFilterDBSearchLimit caps how many extra tasks a board keyword filter
+// pulls from the database to surface older/done tasks not loaded on the board.
+// Matches the command palette's SearchTasks limit for consistency.
+const boardFilterDBSearchLimit = 100
+
 const summaryRefreshAfter = 5 * time.Minute
 
 // refreshLatestActivity loads the most recent log line for each active task and

--- a/internal/ui/board_filter_db_search_test.go
+++ b/internal/ui/board_filter_db_search_test.go
@@ -1,0 +1,79 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// kanbanHasTask reports whether the board's task set contains the given id.
+func kanbanHasTask(k *KanbanBoard, id int64) bool {
+	for _, t := range k.allTasks {
+		if t.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestApplyFilterFindsUnloadedDoneTask is the core #4705 regression: the board
+// only loads active tasks plus the most recent done tasks, so a keyword filter
+// used to miss older done tasks even though "Go to Task" (which hits the DB)
+// found them. applyFilter must now supplement m.tasks with a DB search.
+func TestApplyFilterFindsUnloadedDoneTask(t *testing.T) {
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	// A done task that lives only in the database — never loaded onto the board.
+	doneTask := &db.Task{Title: "Build demo functionality", Project: "personal", Status: db.StatusDone}
+	if err := database.CreateTask(doneTask); err != nil {
+		t.Fatalf("create done task: %v", err)
+	}
+	// An active task that IS loaded onto the board.
+	activeTask := &db.Task{Title: "Something unrelated", Project: "personal", Status: db.StatusProcessing}
+	if err := database.CreateTask(activeTask); err != nil {
+		t.Fatalf("create active task: %v", err)
+	}
+
+	m := &AppModel{db: database, kanban: NewKanbanBoard(0, 0)}
+	// Simulate the board's loaded set: only the active task, not the done one.
+	m.tasks = []*db.Task{activeTask}
+
+	m.filterText = "demo functionality"
+	m.applyFilter()
+
+	if !kanbanHasTask(m.kanban, doneTask.ID) {
+		t.Errorf("filter %q did not surface unloaded done task #%d", m.filterText, doneTask.ID)
+	}
+	if kanbanHasTask(m.kanban, activeTask.ID) {
+		t.Errorf("filter %q should exclude non-matching active task #%d", m.filterText, activeTask.ID)
+	}
+}
+
+// TestApplyFilterNoKeywordSkipsDBSearch verifies a project-only filter still
+// works and doesn't error when there is no keyword to search the DB with.
+func TestApplyFilterNoKeywordSkipsDBSearch(t *testing.T) {
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	loaded := &db.Task{Title: "Loaded task", Project: "personal", Status: db.StatusProcessing}
+	if err := database.CreateTask(loaded); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	m := &AppModel{db: database, kanban: NewKanbanBoard(0, 0)}
+	m.tasks = []*db.Task{loaded}
+
+	m.filterText = "[personal]"
+	m.applyFilter()
+
+	if !kanbanHasTask(m.kanban, loaded.ID) {
+		t.Errorf("project-only filter dropped loaded task #%d", loaded.ID)
+	}
+}


### PR DESCRIPTION
## Problem

Searching the board for `demo functionality` returned nothing, but "Go to Task" (Ctrl+P) found `#4593 [ik] Build demo functionality` immediately.

## Root cause

The board loads **active tasks + only the most recent 20 done tasks** (`maxDoneTasksInKanban`), then `applyFilter` scored *only that in-memory `m.tasks` set*. `#4593` is one of the ~1,500 older done tasks that never get loaded, so the board filter could never match it.

"Go to Task" worked because the command palette already supplements its in-memory list with a `db.SearchTasks` query for exactly this reason.

## Fix

Bring the board filter in line with the command palette: when the filter contains a keyword, augment the candidate set with a bounded `db.SearchTasks` lookup (deduped by id) before scoring. Older/done tasks now surface in board search results.

- Project-only filters (`[project]`) skip the DB search — unchanged behavior.
- New constant `boardFilterDBSearchLimit = 100`, matching the palette's limit.

## Tests

- `TestApplyFilterFindsUnloadedDoneTask` — regression: a done task present only in the DB (not in `m.tasks`) is surfaced by a keyword filter.
- `TestApplyFilterNoKeywordSkipsDBSearch` — a project-only filter still works and doesn't hit the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)