### PR TITLE
Extension-first: ty-chrome create-task + first-run onboarding (+ Web Store brief)

### DIFF
--- a/docs/extension-first.md
+++ b/docs/extension-first.md
@@ -1,0 +1,154 @@
+# Extension-first: ty-chrome as a primary entry point
+
+**Status:** design brief + first implementation slice (create-task / first-run
+onboarding). See the companion PR touching `extensions/ty-chrome`.
+
+## Goal
+
+Make the [`ty-chrome`](../extensions/ty-chrome) extension a viable *primary*
+way to use TaskYou: something a brand-new user can install from the Chrome Web
+Store and get productive with, ideally without ever opening a terminal.
+
+## The one hard constraint
+
+The extension is a **thin client**. It has no backend of its own — everything
+it does is an HTTP call to `ty serve` (the daemon) on localhost. The daemon is
+what spawns Claude Code executors, runs tmux, manages git worktrees, and owns
+the SQLite DB.
+
+A Chrome extension is sandboxed. It **cannot**:
+
+- start `ty serve` or `ty daemon`,
+- run `git`, `tmux`, or spawn Claude Code,
+- read or write arbitrary files.
+
+So "install the extension and go, never touch a terminal" is **impossible via
+the extension alone**. *Something* has to run the daemon. The onboarding blocker
+is therefore **daemon bootstrap**, not the extension UI. Everything below is
+about closing that gap.
+
+Once a daemon is reachable, the extension is already close to a full client: it
+lists tasks, matches browser tabs to tasks by dev-server port, embeds a live
+xterm.js terminal into a task's tmux pane (Agent + Shell), annotates pages, and
+bridges the executor to the user's real browser tabs. What it lacked — and what
+this PR adds — is a way to **create** a task and a **first-run** experience when
+nothing is running yet.
+
+## Daemon-bootstrap options
+
+### (a) Native app runs `ty serve` as a managed background service — **recommended near-term**
+
+Ship the existing Tauri desktop app (`desktop/`) as the daemon host. It already
+supervises both sidecars: `desktop/src-tauri/src/supervisor.rs` spawns
+`ty serve --port <p>` and `ty daemon`, health-checks them, and adopts a
+pre-existing daemon instead of double-starting. The onboarding story becomes
+**"install two things"**:
+
+1. Install the TaskYou desktop app (a normal signed `.dmg` / `.msi`, no
+   terminal). It launches the daemon and keeps it alive.
+2. Install the ty-chrome extension from the Web Store. It auto-discovers the
+   daemon and you're working.
+
+**Remaining work to make this true "no-terminal":**
+
+- **Run the daemon as a real background service**, not just a GUI child.
+  Today the supervisor terminates its children on app exit
+  (`supervisor.rs:1-3`), so the daemon only lives while the window is open.
+  Promote it to a login item / managed service so it survives:
+  - macOS: a `launchd` LaunchAgent (`~/Library/LaunchAgents/…plist`, `RunAtLoad`
+    + `KeepAlive`).
+  - Linux: a `systemd --user` unit (`WantedBy=default.target`).
+  - Windows: a Scheduled Task at logon, or a Service via the app installer.
+  A `ty serve --install-service` / `--uninstall-service` subcommand that writes
+  and loads the platform unit is the clean home for this; the desktop app calls
+  it during first-run setup so the user never sees a shell.
+- **Align the discovery port.** The desktop app defaults to `8484`
+  (`supervisor.rs:11`), but the extension only probed `8080`/`8765`. This PR
+  adds `8484` to the extension's `CANDIDATE_SERVERS` so the desktop-managed
+  daemon is found out of the box.
+- **Bundle a `ty` binary** with the desktop app (or install one) so the user
+  doesn't need Homebrew/`go install` first.
+
+Why recommended: lowest new surface area, reuses code that already exists,
+keeps all execution local (the user's own machine, their own git checkouts,
+their own Claude auth), and needs no new trust boundary. The cost is that it's
+"two installs," not one.
+
+### (b) Cloud daemon (extension → HTTPS)
+
+Run `ty serve` on a hosted box; the extension points at
+`https://<user>.taskyou.cloud` instead of localhost. This is the only option
+that is *truly* zero-local-backend — install the extension, sign in, go.
+
+Serious caveats, all of which are new surface area we don't have today:
+
+- **Auth.** The extension would carry a bearer token / OAuth session to a
+  remote agent. The daemon's HTTP API is currently unauthenticated because it
+  binds to loopback; exposing it publicly requires real authn/authz on every
+  route.
+- **Driving the user's authenticated browser.** The killer feature is the
+  browser bridge: the executor sees and drives the user's *logged-in* tabs
+  (`sw.js` `browserExec`). With a cloud daemon, a remote agent is issuing
+  commands that run against the user's authenticated sessions (their email,
+  their bank, their admin panels). That is a large, sensitive trust boundary
+  and needs an explicit, revocable consent model and a tight command allowlist.
+- **Where does the code live / run?** Executors need a git checkout and a place
+  to run Claude Code. Cloud means cloud checkouts, cloud secrets, cloud compute
+  — a different product, not a config flag.
+
+Good north star, wrong near-term bet: it turns a local dev tool into a hosted
+multi-tenant service with a browser-driving remote agent. Revisit once the
+local story is proven.
+
+### (c) Native messaging host
+
+Chrome's Native Messaging lets an extension talk to a locally-installed helper
+binary over stdio. In principle the helper could start/stop `ty serve`.
+
+Why it's a weak fit here:
+
+- It **still requires a native install** (the messaging host manifest +
+  binary), so it does not remove the "install something native" step that
+  option (a) also has — but it delivers *less*, because…
+- The extension already speaks HTTP to the daemon perfectly well. Native
+  messaging would only be a bootstrap/launcher channel, duplicating what a
+  service manager or the desktop app does more robustly.
+- Native messaging hosts are **per-browser-profile** registered and famously
+  fiddly (manifest paths, allowed-origins keyed to the extension ID, no clean
+  cross-platform install). For a launcher, `launchd`/`systemd`/a login item is
+  simpler and more reliable.
+
+Net: it's a native install with none of the desktop app's benefits (no UI, no
+supervision, no bundled binary). Skip it unless we specifically need the
+extension to toggle the daemon on/off and refuse to ship any window.
+
+## Recommendation
+
+Ship **(a)**. Concretely:
+
+1. This PR: create-task + first-run onboarding in the extension, and add `8484`
+   to auto-discovery so the desktop-managed daemon is found.
+2. Next: `ty serve --install-service` (launchd/systemd/Task Scheduler) invoked
+   by the desktop app's first-run, so the daemon is a persistent background
+   service. Bundle a `ty` binary with the app.
+3. Later, as a separate product bet: evaluate (b) for a hosted offering, with a
+   real auth model and an explicit consent flow for browser driving.
+
+## Chrome Web Store readiness checklist
+
+| Item | Status / action |
+|---|---|
+| **Single purpose** | State it plainly: *"Create and drive TaskYou coding tasks — annotate the task's dev-server pages and run its Claude Code terminal — from a side panel connected to a locally-running TaskYou daemon."* Everything in the extension serves that one purpose. |
+| **Privacy policy** | Required (the store demands one for any extension with `host_permissions`). Key honest claim: the extension sends data **only** to the user-configured `ty serve` origin (localhost by default). No analytics, no third-party servers, no remote telemetry. Page content / screenshots / console logs are captured **on demand** and posted to the local daemon only. Publish it and link it in the listing. |
+| **`<all_urls>` host permission** | Currently requested so annotate + the browser bridge work on any dev-server host (`localhost:<port>`, `*.test`, plus whatever external site the executor is asked to look at). This is the hardest review item — broad host access on a screenshot-capable extension gets scrutiny. **Recommended narrowing:** drop `<all_urls>` from the manifest and switch to **`activeTab` + `optional_host_permissions: ["<all_urls>"]`**, requesting broad access only when the user actually starts the bridge / annotate on a page. `activeTab` covers "act on the tab the user just invoked me on" without a scary install-time prompt. |
+| **`scripting`** | Justified: injecting the annotate overlay and the command bridge into the matched tab is core function. Keep, and say so in the justification. Pairs with `activeTab` cleanly. |
+| **`tabs` / `tabGroups`** | Justified by the visible, user-revocable "ty #<id>" tab group that bounds what the executor can drive. Explain the boundary in the listing — it's a *privacy feature*, not a grab. |
+| **Remote code** | None. All JS is vendored in the package (`vendor/`), no CDN, no `eval`. Say so — it speeds review. |
+| **Data handling disclosures** | In the Web Store form, declare: handles "website content" (screenshots/DOM), sent only to the user's own local server; no data sold; no data used for unrelated purposes. |
+| **Precedent** | [nanobrowser](https://chromewebstore.google.com/detail/nanobrowser/…) is already in the Web Store and drives the user's *real authenticated browser* to complete tasks — a strictly broader capability than ours. It's concrete evidence that a browser-driving, `<all_urls>`-class extension is publishable when the purpose is clear and disclosed. Cite it if review pushes back on the bridge. |
+| **Screenshots / listing** | Show the side panel: matched task, embedded terminal, annotate flow, and the tab-group boundary. Make the "connects to a local daemon you run" model obvious so reviewers understand the architecture. |
+
+**Bottom line for the store:** narrow to `activeTab` + optional `<all_urls>`,
+ship a privacy policy that truthfully says "talks only to your local daemon,"
+and lead the single-purpose description with task creation + execution. The
+capability is publishable — nanobrowser is the proof.

--- a/extensions/ty-chrome/README.md
+++ b/extensions/ty-chrome/README.md
@@ -1,15 +1,22 @@
 # ty-chrome — TaskYou in Chrome
 
-Two things, both tied to a specific taskyou task, both in the Chrome side panel:
+Three things, all tied to a specific taskyou task, all in the Chrome side panel:
 
-1. **A full terminal.** A real xterm.js terminal wired straight into the task's
+1. **Create a task.** Pick a project/repo, describe the work, and hit
+   **New task** — the panel creates it via the daemon and binds the terminal to
+   it right away, execute-now optional. No terminal needed to get started.
+2. **A full terminal.** A real xterm.js terminal wired straight into the task's
    tmux session — the same Claude Code (Agent) pane the TUI/desktop app show,
    plus a workdir **Shell** pane. Type into it, run commands, drive Claude Code,
    do anything you want, without leaving the browser.
-2. **Live annotate.** Point, click, and annotate any page served by the task's
+3. **Live annotate.** Point, click, and annotate any page served by the task's
    dev server, and deliver that feedback — selectors, DOM excerpts, your
    comments, and a screenshot with numbered markers — straight into the task's
    executor.
+
+The extension is a thin client for a locally-running `ty serve` daemon; see
+[`docs/extension-first.md`](../../docs/extension-first.md) for the plan to make
+it a no-terminal primary entry point (and the Chrome Web Store checklist).
 
 | Annotate the live page | Side panel: task + embedded terminal |
 |---|---|

--- a/extensions/ty-chrome/sidepanel.css
+++ b/extensions/ty-chrome/sidepanel.css
@@ -102,6 +102,38 @@ body {
 .picker-row select { flex: 1; padding: 5px; border: 1px solid var(--border); border-radius: 6px; }
 .picker-row button { border: 1px solid var(--border); background: var(--card); border-radius: 6px; cursor: pointer; }
 
+/* --- New task form ------------------------------------------------------ */
+
+.link-btn {
+  border: 0; background: transparent; cursor: pointer; padding: 4px 0;
+  margin-top: 8px; color: var(--accent); font-weight: 600; font-size: 12px;
+}
+.link-btn:hover { color: var(--accent-dark); }
+
+.new-task { display: flex; flex-direction: column; gap: 7px; margin-top: 8px; }
+.new-task select,
+.new-task input,
+.new-task textarea {
+  width: 100%; padding: 6px 8px; border: 1px solid var(--border);
+  border-radius: 6px; font-family: inherit; font-size: 13px; outline-color: var(--accent);
+}
+.new-task textarea { resize: vertical; }
+.nt-execute {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 12px; color: var(--muted); cursor: pointer; user-select: none;
+}
+.nt-execute input { accent-color: var(--accent); margin: 0; }
+#nt-result { margin: 2px 0 0; font-size: 12px; }
+#nt-result:empty { display: none; }
+
+/* --- First-run empty state --------------------------------------------- */
+
+.empty-state p { margin: 6px 0; }
+.empty-state ul { margin: 6px 0; padding-left: 18px; }
+.empty-state li { margin: 3px 0; }
+.empty-state a { color: #92400e; font-weight: 700; }
+.empty-state .probing { font-size: 11px; margin-top: 8px; }
+
 /* --- Annotate section ---------------------------------------------------- */
 
 button.primary, button.secondary {

--- a/extensions/ty-chrome/sidepanel.html
+++ b/extensions/ty-chrome/sidepanel.html
@@ -6,8 +6,23 @@
   <link rel="stylesheet" href="sidepanel.css" />
 </head>
 <body>
-  <div id="no-connection" class="banner hidden">
-    Can't reach <code>ty serve</code> — probing common ports, retrying…
+  <div id="no-connection" class="banner empty-state hidden">
+    <strong>No TaskYou daemon reachable</strong>
+    <p>
+      This extension is a thin client — it needs <code>ty serve</code> (the
+      TaskYou daemon) running locally to create and drive tasks.
+    </p>
+    <ul>
+      <li>Have <code>ty</code> already? Run <code>ty serve</code> in a terminal.</li>
+      <li>
+        No terminal? Install the <strong>TaskYou desktop app</strong> — it runs
+        the daemon for you in the background.
+      </li>
+    </ul>
+    <a href="https://github.com/bborn/taskyou#readme" target="_blank" rel="noopener">
+      Get TaskYou →
+    </a>
+    <p class="probing muted">Probing common ports, retrying…</p>
   </div>
 
   <div id="settings" class="card hidden">
@@ -38,6 +53,17 @@
         <select id="task-select"></select>
         <button id="refresh-tasks" title="Refresh">↻</button>
       </div>
+      <button id="new-task-toggle" class="link-btn">＋ New task</button>
+      <form id="new-task-form" class="new-task hidden">
+        <select id="nt-project" title="Project / repo"></select>
+        <input id="nt-title" type="text" placeholder="Task title" />
+        <textarea id="nt-body" rows="3" placeholder="What should the agent do?"></textarea>
+        <label class="nt-execute">
+          <input type="checkbox" id="nt-execute" checked /> Execute now
+        </label>
+        <button id="nt-create" type="submit" class="primary">Create task</button>
+        <p id="nt-result" class="muted"></p>
+      </form>
     </div>
   </section>
 

--- a/extensions/ty-chrome/sidepanel.js
+++ b/extensions/ty-chrome/sidepanel.js
@@ -59,7 +59,10 @@ async function refresh() {
   renderTask();
   updateCount(state.annotationCount);
 
-  if (!currentTask && state.connected) loadCandidates();
+  if (!currentTask && state.connected) {
+    loadCandidates();
+    loadProjects();
+  }
   syncTerminal(state.connected);
   if (state.connected && currentTask) bridgeLoop();
 
@@ -98,6 +101,70 @@ async function loadCandidates() {
     o.textContent = `#${t.id} ${t.title} (${t.status}${t.port ? `, :${t.port}` : ''})`;
     sel.appendChild(o);
   }
+}
+
+// --- New task ------------------------------------------------------------------
+//
+// Create a task straight from the panel: pick a project/repo, describe the work,
+// choose execute-now, POST it via the daemon (through the SW's api() plumbing),
+// then bind the new task to this tab so the terminal attaches to it right away.
+
+let projectsLoaded = false;
+
+async function loadProjects() {
+  if (projectsLoaded) return; // only fill the select once, so it survives typing
+  const { projects, error } = await send({ type: 'listProjects' });
+  if (error) return; // stay silent; the no-connection banner already explains
+  const sel = $('nt-project');
+  sel.innerHTML = '';
+  if (!projects || !projects.length) {
+    const o = document.createElement('option');
+    o.value = '';
+    o.textContent = 'Default project';
+    sel.appendChild(o);
+  } else {
+    for (const p of projects) {
+      const o = document.createElement('option');
+      o.value = p.name;
+      o.textContent = p.task_count ? `${p.name} (${p.task_count})` : p.name;
+      sel.appendChild(o);
+    }
+  }
+  projectsLoaded = true;
+}
+
+async function createTask(e) {
+  e?.preventDefault();
+  const title = $('nt-title').value.trim();
+  const body = $('nt-body').value.trim();
+  if (!title && !body) {
+    $('nt-result').textContent = 'Enter a title or a description.';
+    return;
+  }
+  $('nt-create').disabled = true;
+  $('nt-result').textContent = 'Creating…';
+  const r = await send({
+    type: 'createTask',
+    tabId: activeTabId,
+    title,
+    body,
+    project: $('nt-project').value,
+    execute: $('nt-execute').checked,
+  });
+  $('nt-create').disabled = false;
+  if (r.error || !r.task) {
+    $('nt-result').textContent = r.error || 'Create failed';
+    return;
+  }
+  // Bind + attach exactly like picking an existing task.
+  currentTask = r.task;
+  $('nt-title').value = '';
+  $('nt-body').value = '';
+  $('nt-result').textContent = '';
+  $('new-task-form').classList.add('hidden');
+  renderTask();
+  syncTerminal(true);
+  bridgeLoop();
 }
 
 // --- Embedded terminal ---------------------------------------------------------
@@ -439,7 +506,21 @@ $('server-url').addEventListener('keydown', async (e) => {
   refresh();
 });
 
-$('refresh-tasks').addEventListener('click', loadCandidates);
+$('refresh-tasks').addEventListener('click', () => {
+  projectsLoaded = false;
+  loadCandidates();
+  loadProjects();
+});
+
+$('new-task-toggle').addEventListener('click', () => {
+  const form = $('new-task-form');
+  form.classList.toggle('hidden');
+  if (!form.classList.contains('hidden')) {
+    loadProjects();
+    $('nt-title').focus();
+  }
+});
+$('new-task-form').addEventListener('submit', createTask);
 
 $('task-select').addEventListener('change', async (e) => {
   const taskId = Number(e.target.value);

--- a/extensions/ty-chrome/sw.js
+++ b/extensions/ty-chrome/sw.js
@@ -19,6 +19,7 @@ async function getServerUrl() {
 const CANDIDATE_SERVERS = [
   'http://127.0.0.1:8080',
   'http://localhost:8080',
+  'http://127.0.0.1:8484', // TaskYou desktop app default port
   'http://127.0.0.1:8765', // isolated demo instance
 ];
 let probePromise = null;
@@ -326,6 +327,36 @@ const handlers = {
     matches.set(tabId, { task, manual: true });
     setBadge(tabId, task);
     return { ok: true, task };
+  },
+
+  // Projects the daemon knows about, for the "New task" repo picker.
+  async listProjects() {
+    try {
+      return { projects: await api('/api/projects') };
+    } catch (e) {
+      return { error: e.message, projects: [] };
+    }
+  },
+
+  // Create a task via the daemon, then bind it to this tab so the panel and
+  // terminal attach immediately. A just-created task is queued (or backlog)
+  // with no port yet, so the port-based matcher can't find it — pin it manually,
+  // exactly like pickTask does for an existing task.
+  async createTask({ tabId, title, body, project, execute }) {
+    try {
+      const task = await api('/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, body, project, execute: !!execute }),
+      });
+      if (tabId != null) {
+        matches.set(tabId, { task, manual: true });
+        setBadge(tabId, task);
+      }
+      return { task };
+    } catch (e) {
+      return { error: e.message };
+    }
   },
 
   async startAnnotate({ tabId }) {


### PR DESCRIPTION
Makes the `ty-chrome` extension a viable **primary entry point** for TaskYou: a first-run experience and a way to create tasks from the side panel, plus a committed plan for the daemon-bootstrap / Chrome Web Store path.

## What's here

### 1. Design brief — `docs/extension-first.md`
- Lays out the one hard constraint (the extension is a sandboxed thin client; *something* must run the `ty serve` daemon — that's the real onboarding blocker).
- Three daemon-bootstrap options with a recommendation:
  - **(a) Native app runs `ty serve` as a managed background service** — reuses the existing Tauri `desktop/` supervisor; **recommended near-term**. Names the concrete remaining work (launchd/systemd/Task Scheduler `--install-service`, bundle a `ty` binary, port alignment).
  - **(b) Cloud daemon** — true zero-local-backend, but flags the auth + "remote agent driving your authenticated browser" trust surface.
  - **(c) Native messaging host** — why it's a weak fit (still a native install, delivers less than the desktop app).
- **Chrome Web Store readiness checklist**: privacy policy, single-purpose justification, justifying `<all_urls>` + `scripting`, recommending a narrow to `activeTab` + optional host permissions, and citing **nanobrowser** (already in the store, drives the real authenticated browser) as precedent.

### 2. Create-task / first-run onboarding (the implementation slice)
- **New task UI** in the side panel: project/repo picker (from `GET /api/projects`), title/body, execute-now checkbox, create via `POST /api/tasks` — reusing the existing service-worker `api()` plumbing in `sw.js`.
- After creating, the task is **bound to the tab and the terminal attaches** to it immediately (same manual-pin path as `pickTask`, since a just-created task is queued/backlog with no port yet).
- **First-run empty state**: when no `ty serve` is reachable, the banner now explains the thin-client model and points at the desktop-app / installer path instead of the bare "probing ports" line.
- **Auto-discovery** now probes `:8484` (the desktop app's default port) so the desktop-managed daemon is found out of the box.

## No server changes
`POST /api/tasks` and `GET /api/projects` already exist and match the shapes the extension needs — no `internal/web` endpoint was added.

## Verification
- `node --check` passes on `sw.js` and `sidepanel.js`.
- Exercised the flow end-to-end against a live `ty serve` (isolated DB/port): `GET /api/projects` (returns `name`/`task_count`), `POST /api/tasks` with `execute:false` -> `backlog` (201) and `execute:true` -> `queued` (201), empty-project fallback to `personal`, and `terminal-info` returns a clean `window_exists:false` (panel shows "Start session") for the freshly-created task.

## Follow-ups (out of scope)
- The `ty serve --install-service` background-service work from option (a).
- A manually-pinned created task's card shows a snapshot status until it re-matches by port; the embedded terminal (bound by id) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
