### PR TITLE
Fix executor double-spawn race (two Claude sessions per task)

### DIFF
--- a/internal/executor/codex_executor.go
+++ b/internal/executor/codex_executor.go
@@ -171,7 +171,7 @@ func (c *CodexExecutor) runCodex(ctx context.Context, task *db.Task, workDir, pr
 		task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, resumeFlag, promptFile.Name())
 
 	// Create new window in task-daemon session
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, c.executor.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, c.executor.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		c.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
 		c.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bborn/workflow/internal/config"
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/events"
+	"github.com/bborn/workflow/internal/executorlock"
 	"github.com/bborn/workflow/internal/github"
 	"github.com/bborn/workflow/internal/hooks"
 	"github.com/bborn/workflow/internal/pipeline"
@@ -2733,11 +2734,32 @@ func ensureTmuxDaemon() (string, error) {
 
 // createTmuxWindow creates a new tmux window in the daemon session with retry logic.
 // If the session doesn't exist, it will re-create it and retry once.
+//
+// taskID keys the per-task spawn lock: this call serializes with EnsureTaskWindow
+// and any other spawner so two paths can't both create a window for the same task
+// (the double-spawn that leaves two executor sessions in one worktree with
+// clobbered pane ids). If a window for the task already exists when we acquire the
+// lock, we adopt it instead of creating a duplicate.
+//
 // SECURITY: workDir must be within a .task-worktrees directory, or match allowedProjectDir
 // for non-worktree projects. Pass empty allowedProjectDir to require worktree paths only.
-func createTmuxWindow(daemonSession, windowName, workDir, script, allowedProjectDir string) (string, error) {
+func createTmuxWindow(daemonSession, windowName, workDir, script, allowedProjectDir string, taskID int64) (string, error) {
 	if !isValidWorkDir(workDir, allowedProjectDir) {
 		return "", fmt.Errorf("security: refusing to create tmux window with invalid workDir: %s", workDir)
+	}
+
+	// Serialize check-then-create with the TUI/API spawn path (EnsureTaskWindow).
+	// Best-effort on timeout so a wedged holder can't block the daemon forever.
+	if release, lerr := executorlock.AcquireSpawn(executorSpawnLockDir(), taskID, spawnLockTimeout); lerr == nil {
+		defer release()
+	}
+	// Under the lock: adopt an existing window rather than spawning a second
+	// executor for this task.
+	checkCtx, checkCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	existing := findExistingTaskWindow(checkCtx, windowName)
+	checkCancel()
+	if existing != "" {
+		return strings.SplitN(existing, ":", 2)[0], nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -3006,7 +3028,7 @@ func (e *Executor) runClaude(ctx context.Context, task *db.Task, workDir, prompt
 	}
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		e.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
 		e.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))
@@ -3153,7 +3175,7 @@ func (e *Executor) runClaudeResume(ctx context.Context, task *db.Task, workDir, 
 		task.ID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, rcFlag, effort, model, claudeSessionID, promptArg)
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		e.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
 		e.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))
@@ -3310,7 +3332,7 @@ func (e *Executor) resumeClaudeDangerous(task *db.Task, workDir string) bool {
 		taskID, taskSessionID, task.Port, task.WorktreePath, envPrefix, claudeSessionID)
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		e.logger.Warn("tmux failed to create window", "error", tmuxErr, "session", daemonSession)
 		if cleanupHooks != nil {
@@ -3516,7 +3538,7 @@ func (e *Executor) resumeClaudeSafe(task *db.Task, workDir string) bool {
 		taskID, taskSessionID, task.Port, task.WorktreePath, envPrefix, permissionFlagForMode(safeMode), claudeSessionID)
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		e.logger.Warn("tmux failed to create window", "error", tmuxErr, "session", daemonSession)
 		if cleanupHooks != nil {
@@ -3635,7 +3657,7 @@ func (e *Executor) resumeCodexWithMode(task *db.Task, workDir string, dangerousM
 	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %scodex %s--resume %s`,
 		taskID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, sessionID)
 
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		e.logger.Warn("tmux failed to create window", "error", tmuxErr, "session", daemonSession)
 		return false
@@ -3743,7 +3765,7 @@ func (e *Executor) resumeGeminiWithMode(task *db.Task, workDir string, dangerous
 	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sgemini %s--resume %s`,
 		taskID, taskSessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, sessionID)
 
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		e.logger.Warn("tmux failed to create window", "error", tmuxErr, "session", daemonSession)
 		return false
@@ -5950,7 +5972,7 @@ func (e *Executor) runPi(ctx context.Context, task *db.Task, workDir, prompt str
 	}
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		e.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
 		e.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))
@@ -6058,7 +6080,7 @@ func (e *Executor) runPiResume(ctx context.Context, task *db.Task, workDir, prom
 		task.ID, taskSessionID, task.Port, task.WorktreePath, sessionPath, feedbackFile.Name())
 
 	// Create new window in task-daemon session (with retry logic for race conditions)
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, e.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		e.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
 		e.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))

--- a/internal/executor/gemini_executor.go
+++ b/internal/executor/gemini_executor.go
@@ -132,7 +132,7 @@ func (g *GeminiExecutor) runGemini(ctx context.Context, task *db.Task, workDir, 
 	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sgemini %s%s-i "$(cat %q)"`,
 		task.ID, sessionID, task.Port, task.WorktreePath, envPrefix, dangerousFlag, resumeFlag, promptFile.Name())
 
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, g.executor.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, g.executor.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		g.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
 		g.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))

--- a/internal/executor/openclaw_executor.go
+++ b/internal/executor/openclaw_executor.go
@@ -137,7 +137,7 @@ func (o *OpenClawExecutor) runOpenClaw(ctx context.Context, task *db.Task, workD
 	script := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q %sopenclaw tui --session %s %s--message "$(cat %q)"`,
 		task.ID, worktreeSessionID, task.Port, task.WorktreePath, envPrefix, sessionKey, thinkingFlag, promptFile.Name())
 
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, o.executor.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, o.executor.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		o.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
 		o.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))

--- a/internal/executor/opencode_executor.go
+++ b/internal/executor/opencode_executor.go
@@ -146,7 +146,7 @@ func (o *OpenCodeExecutor) runOpenCode(ctx context.Context, task *db.Task, workD
 			workDir, task.ID, worktreeSessionID, task.Port, task.WorktreePath, envPrefix, promptFile.Name(), promptFile.Name())
 	}
 
-	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, o.executor.getProjectDir(task.Project))
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, o.executor.getProjectDir(task.Project), task.ID)
 	if tmuxErr != nil {
 		o.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
 		o.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))

--- a/internal/executor/session.go
+++ b/internal/executor/session.go
@@ -5,11 +5,27 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/executorlock"
 )
+
+// spawnLockTimeout bounds how long a spawner waits for the per-task executor
+// spawn lock before proceeding best-effort. The critical section it guards (an
+// existing-window check plus a single tmux new-window) is fast, so a holder
+// should release well within this; the timeout only preserves liveness if a
+// spawner wedges.
+const spawnLockTimeout = 15 * time.Second
+
+// executorSpawnLockDir is the directory the per-task spawn lock files live in.
+// Co-located with the task DB so isolated instances (custom DB path) get their
+// own lock namespace and don't contend with the real daemon.
+func executorSpawnLockDir() string {
+	return filepath.Dir(db.DefaultPath())
+}
 
 // sessionValidator is an optional capability for executors that can verify
 // whether a stored session still exists. EnsureTaskWindow uses it to avoid
@@ -42,6 +58,22 @@ func (e *Executor) EnsureTaskWindow(ctx context.Context, task *db.Task, sessionI
 	// Reuse an existing window in any task-daemon session to avoid duplicates.
 	if target := findExistingTaskWindow(ctx, windowName); target != "" {
 		return target, false, nil
+	}
+
+	// Serialize the check-then-create against the daemon executor and any other
+	// caller so two spawners can't both observe "no window yet" and each create
+	// one — the double-spawn that leaves two executor sessions in one worktree with
+	// clobbered pane ids. Held only around the spawn decision; released as soon as
+	// the window (or shell pane) is created. Best-effort: on timeout we proceed
+	// rather than wedge the UI, but re-check under whatever lock we did get.
+	if release, lerr := executorlock.AcquireSpawn(executorSpawnLockDir(), task.ID, spawnLockTimeout); lerr == nil {
+		defer release()
+		// Another spawner may have created the window while we waited for the lock.
+		if target := findExistingTaskWindow(ctx, windowName); target != "" {
+			return target, false, nil
+		}
+	} else {
+		e.logger.Warn("could not acquire executor spawn lock; proceeding best-effort", "task", task.ID, "error", lerr)
 	}
 
 	daemonSession, err := findOrCreateDaemonSession(ctx)

--- a/internal/executorlock/executorlock.go
+++ b/internal/executorlock/executorlock.go
@@ -1,0 +1,70 @@
+// Package executorlock provides a per-task, cross-process "spawn lock" that
+// serializes the check-window-then-start-executor critical section shared by the
+// daemon executor and every ty TUI detail view.
+//
+// Without it, the daemon and a detail view can each observe "no tmux window yet"
+// and both spawn an executor for the same task — two Claude sessions in one
+// worktree with clobbered pane ids (the "executors mixed up" bug).
+//
+// This is deliberately distinct from the TUI's long-lived executor *ownership*
+// lock (internal/ui, acquireExecutorLock), which gates borrowing a live pane for
+// the whole life of a detail view. The spawn lock is held only around the spawn
+// decision and released immediately, so it never blocks a TUI from later joining
+// the daemon's live pane.
+package executorlock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// ErrSpawnLockTimeout is returned by AcquireSpawn when the lock could not be
+// taken before the timeout elapsed (another spawner is holding it).
+var ErrSpawnLockTimeout = errors.New("executorlock: timed out waiting for spawn lock")
+
+// spawnPollInterval is how often AcquireSpawn retries the non-blocking flock
+// while waiting for a concurrent holder to release.
+const spawnPollInterval = 25 * time.Millisecond
+
+// SpawnLockPath returns the lock-file path for a task's spawn lock in lockDir.
+// Exported so callers can reason about / clean up the file if needed.
+func SpawnLockPath(lockDir string, taskID int64) string {
+	return filepath.Join(lockDir, fmt.Sprintf("executor-spawn-%d.lock", taskID))
+}
+
+// AcquireSpawn takes an exclusive, cross-process lock serializing executor spawns
+// for taskID, blocking up to timeout for any concurrent holder to release. It
+// returns a release func that must be called once the spawn decision is made.
+//
+// lockDir is the directory the lock file lives in — co-locate it with the task
+// DB so isolated instances (custom DB path, e.g. QA harnesses) get their own lock
+// namespace and don't contend with the real daemon.
+//
+// The lock is tied to the open file description, so it is released automatically
+// if the holding process exits — a crashed spawner never leaves it stuck.
+func AcquireSpawn(lockDir string, taskID int64, timeout time.Duration) (func(), error) {
+	path := SpawnLockPath(lockDir, taskID)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open spawn lock file: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err == nil {
+			return func() {
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				_ = f.Close()
+			}, nil
+		}
+		if !time.Now().Before(deadline) {
+			_ = f.Close()
+			return nil, ErrSpawnLockTimeout
+		}
+		time.Sleep(spawnPollInterval)
+	}
+}

--- a/internal/executorlock/executorlock_test.go
+++ b/internal/executorlock/executorlock_test.go
@@ -1,0 +1,77 @@
+package executorlock
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAcquireSpawn_SerializesSameTask verifies that a second spawn-lock
+// acquisition for the same task blocks while the first is held (so a TUI and the
+// daemon cannot both spawn an executor at once), and succeeds once released.
+func TestAcquireSpawn_SerializesSameTask(t *testing.T) {
+	dir := t.TempDir()
+
+	rel1, err := AcquireSpawn(dir, 4847, time.Second)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// A second acquirer must NOT get the lock while the first holds it.
+	if rel, err := AcquireSpawn(dir, 4847, 50*time.Millisecond); err == nil {
+		rel()
+		t.Fatal("second acquire succeeded while first still held the lock")
+	}
+
+	rel1()
+
+	// Once released, a new acquirer succeeds.
+	rel2, err := AcquireSpawn(dir, 4847, time.Second)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	rel2()
+}
+
+// TestAcquireSpawn_DifferentTasksDoNotContend verifies the lock is per-task:
+// spawning executors for different tasks concurrently is allowed.
+func TestAcquireSpawn_DifferentTasksDoNotContend(t *testing.T) {
+	dir := t.TempDir()
+
+	r1, err := AcquireSpawn(dir, 1, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("acquire task 1: %v", err)
+	}
+	defer r1()
+
+	r2, err := AcquireSpawn(dir, 2, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("acquire task 2 should not contend with task 1: %v", err)
+	}
+	r2()
+}
+
+// TestAcquireSpawn_WaitsThenSucceeds verifies a blocked acquirer succeeds once
+// the holder releases within the timeout window.
+func TestAcquireSpawn_WaitsThenSucceeds(t *testing.T) {
+	dir := t.TempDir()
+
+	rel1, err := AcquireSpawn(dir, 7, time.Second)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		rel1()
+		close(released)
+	}()
+
+	// Generous timeout: should block ~80ms then succeed after release.
+	rel2, err := AcquireSpawn(dir, 7, time.Second)
+	if err != nil {
+		t.Fatalf("second acquire should succeed after holder releases: %v", err)
+	}
+	<-released
+	rel2()
+}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -46,8 +46,9 @@ const (
 	paneActionStartExecutor paneAction = iota
 	// paneActionSkip: don't start anything (backlog/done/archived tasks).
 	paneActionSkip
-	// paneActionWaitForExecutor: a freshly queued task with no worktree yet — the
-	// daemon's executor will create the window shortly; keep polling for it.
+	// paneActionWaitForExecutor: a daemon-owned task (queued/processing) whose
+	// window doesn't exist yet — the daemon's executor will create it shortly;
+	// keep polling for it instead of starting our own.
 	paneActionWaitForExecutor
 )
 
@@ -58,13 +59,39 @@ func pendingPaneAction(task *db.Task) paneAction {
 	if shouldSkipAutoExecutor(task) {
 		return paneActionSkip
 	}
-	// Queued tasks without a worktree are handled by the daemon's executor, which
-	// creates the window. Starting panes here would race it (project dir vs worktree
-	// dir), so we wait and let ensureTmuxPanesJoined pick the panes up.
-	if task.Status == db.StatusQueued && task.WorktreePath == "" {
+	// Queued and processing tasks belong to the daemon's executor, which creates
+	// the window. If we reach here the window doesn't exist yet, meaning the daemon
+	// is still spinning it up. Starting our own executor now races the daemon and
+	// double-spawns — two Claude sessions in the same worktree with clobbered pane
+	// ids (the "executors mixed up" bug). Wait and let ensureTmuxPanesJoined join
+	// the daemon's panes once they appear.
+	//
+	// This must hold regardless of WorktreePath: the worktree is created early in
+	// the daemon's spin-up, so a queued/processing task frequently already has one
+	// while its executor window is still pending. Gating the wait on
+	// WorktreePath == "" (as this once did) let exactly that window slip through to
+	// the start path. A daemon that never creates the window (e.g. it died, leaving
+	// the task stuck "processing") is handled downstream by a bounded wait that
+	// falls back to offering "Start session".
+	if task.Status == db.StatusQueued || task.Status == db.StatusProcessing {
 		return paneActionWaitForExecutor
 	}
 	return paneActionStartExecutor
+}
+
+// waitForExecutorTimeout bounds how long the detail view waits for the daemon to
+// create a daemon-owned task's executor window before giving up and starting one
+// itself. The daemon normally creates it within seconds; if it never does (e.g.
+// it died, leaving the task stuck "processing"), we fall back to the start path
+// so the view isn't wedged forever. The fallback is race-safe: it starts through
+// EnsureTaskWindow's spawn lock, which re-checks for an existing window.
+const waitForExecutorTimeout = 60 * time.Second
+
+// shouldFallBackToStart reports whether a view that has been passively waiting for
+// the daemon's executor (paneActionWaitForExecutor) should give up and start one
+// itself. It gives up only once the timeout has elapsed with no panes joined.
+func shouldFallBackToStart(waitingForExecutor, panesJoined bool, waited, timeout time.Duration) bool {
+	return waitingForExecutor && !panesJoined && waited >= timeout
 }
 
 // liveExecutorInPaneCommands reports whether any of the given tmux pane
@@ -553,6 +580,18 @@ func (m *DetailModel) Refresh() tea.Cmd {
 		m.lastPaneCheck = time.Now()
 		// Ensure tmux panes are joined if available (handles external close/detach)
 		m.ensureTmuxPanesJoined()
+
+		// Bounded wait: if we've been waiting for the daemon's executor window to
+		// appear past waitForExecutorTimeout and it still hasn't, the daemon isn't
+		// going to create it (e.g. it died, leaving the task stuck "processing").
+		// Start the executor ourselves rather than spin forever. Safe from the
+		// double-spawn this whole change prevents: startPanesAsync goes through
+		// EnsureTaskWindow's spawn lock, which re-checks for an existing window.
+		if shouldFallBackToStart(m.waitingForExecutor, m.claudePaneID != "", time.Since(m.paneLoadingStart), waitForExecutorTimeout) {
+			GetLogger().Info("Refresh: waited %s for daemon executor on task %d with no window; starting it ourselves", waitForExecutorTimeout, m.task.ID)
+			m.waitingForExecutor = false
+			return tea.Batch(cmd, m.startPanesAsync())
+		}
 	}
 
 	return cmd

--- a/internal/ui/detail_cache_test.go
+++ b/internal/ui/detail_cache_test.go
@@ -123,9 +123,13 @@ func TestPendingPaneAction(t *testing.T) {
 		{"backlog skips", &db.Task{Status: db.StatusBacklog}, paneActionSkip},
 		{"done skips", &db.Task{Status: db.StatusDone}, paneActionSkip},
 		{"archived skips", &db.Task{Status: db.StatusArchived}, paneActionSkip},
+		// Daemon-owned tasks (queued/processing) wait for the daemon's executor
+		// instead of starting their own — regardless of worktree. Starting here
+		// races the daemon and double-spawns two sessions with clobbered pane ids.
 		{"queued without worktree waits", &db.Task{Status: db.StatusQueued}, paneActionWaitForExecutor},
-		{"queued with worktree starts", &db.Task{Status: db.StatusQueued, WorktreePath: "/tmp/wt"}, paneActionStartExecutor},
-		{"processing starts", &db.Task{Status: db.StatusProcessing}, paneActionStartExecutor},
+		{"queued with worktree waits", &db.Task{Status: db.StatusQueued, WorktreePath: "/tmp/wt"}, paneActionWaitForExecutor},
+		{"processing waits", &db.Task{Status: db.StatusProcessing}, paneActionWaitForExecutor},
+		{"processing with worktree waits", &db.Task{Status: db.StatusProcessing, WorktreePath: "/tmp/wt"}, paneActionWaitForExecutor},
 		{"blocked starts", &db.Task{Status: db.StatusBlocked}, paneActionStartExecutor},
 	}
 

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/github"
@@ -610,6 +611,70 @@ func TestPathInsideDir(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := pathInsideDir(tc.dir, tc.path); got != tc.want {
 				t.Errorf("pathInsideDir(%q, %q) = %v, want %v", tc.dir, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPendingPaneAction_DaemonOwnedTasksWaitRegardlessOfWorktree verifies that a
+// task the daemon owns (queued OR processing) waits for the daemon's executor
+// instead of starting its own — even when its worktree already exists. Starting
+// an executor here races the daemon and double-spawns two Claude sessions with
+// clobbered pane ids (the "executors mixed up" bug). Previously the view only
+// waited for queued tasks with no worktree, so a queued/processing task whose
+// worktree was already created would wrongly take the start path.
+func TestPendingPaneAction_DaemonOwnedTasksWaitRegardlessOfWorktree(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   string
+		worktree string
+		want     paneAction
+	}{
+		{"queued without worktree", db.StatusQueued, "", paneActionWaitForExecutor},
+		{"queued with worktree", db.StatusQueued, "/wt/4847", paneActionWaitForExecutor},
+		{"processing without worktree", db.StatusProcessing, "", paneActionWaitForExecutor},
+		{"processing with worktree", db.StatusProcessing, "/wt/4847", paneActionWaitForExecutor},
+		{"blocked starts (user-driven resume, daemon does not run blocked)", db.StatusBlocked, "/wt/4847", paneActionStartExecutor},
+		{"backlog skips", db.StatusBacklog, "/wt/4847", paneActionSkip},
+		{"done skips", db.StatusDone, "/wt/4847", paneActionSkip},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &db.Task{ID: 4847, Status: tc.status, WorktreePath: tc.worktree}
+			if got := pendingPaneAction(task); got != tc.want {
+				t.Errorf("pendingPaneAction(status=%s worktree=%q) = %v, want %v",
+					tc.status, tc.worktree, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldFallBackToStart verifies the bounded-wait fallback: a detail view
+// passively waiting for the daemon's executor gives up and starts one itself only
+// after the timeout elapses with no panes joined. Without this, change A's "wait
+// for the daemon" would spin forever on a task stuck "processing" behind a dead
+// daemon. The fallback is race-safe because it starts through EnsureTaskWindow's
+// spawn lock.
+func TestShouldFallBackToStart(t *testing.T) {
+	const timeout = 60 * time.Second
+	cases := []struct {
+		name        string
+		waiting     bool
+		panesJoined bool
+		waited      time.Duration
+		want        bool
+	}{
+		{"waiting, no panes, past timeout -> start", true, false, 61 * time.Second, true},
+		{"waiting, no panes, before timeout -> keep waiting", true, false, 10 * time.Second, false},
+		{"waiting, panes joined -> no fallback", true, true, 120 * time.Second, false},
+		{"not waiting -> no fallback", false, false, 120 * time.Second, false},
+		{"waiting, no panes, exactly at timeout -> start", true, false, timeout, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldFallBackToStart(tc.waiting, tc.panesJoined, tc.waited, timeout); got != tc.want {
+				t.Errorf("shouldFallBackToStart(waiting=%v panes=%v waited=%v) = %v, want %v",
+					tc.waiting, tc.panesJoined, tc.waited, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What & why

A task could end up with **two executors** — the daemon's and a second one started by an open detail view — each with its own Claude session in the same worktree. The DB row went self-inconsistent: `claude_session_id` followed one session while `claude_pane_id` followed the other. Because the ty-chrome executor mirror screen-scrapes `tmux capture-pane` of `claude_pane_id` (`internal/web/terminal.go:41`) while the task detail reads `claude_session_id`, **every surface showed a different session** — the "executors mixed up" report (task 4847).

Observed: two live `claude` procs 12s apart (the detail-view duplicate started *first*), stale session `a3bb8ab9` vs live `06ab26e9`.

## Root cause

Opening a detail view while the daemon was still spinning the task up:

- `pendingPaneAction` only waited for the daemon when `Status==queued && WorktreePath==""`. The worktree is created **early**, so a queued/processing task that already had a worktree fell through to the start path.
- No daemon window was visible yet, so `setupPanesAsync` started its **own** executor.
- `EnsureTaskWindow` (TUI/API) and `createTmuxWindow` (daemon) each ran their existing-window check before the other's window appeared → **both created one**.
- Nothing serialized the two spawn paths (the `acquireExecutorLock` flock is TUI-only and gates *join*, not spawn; the daemon never took it).

## Fix — both the heuristic hole and the mechanism hole

**A. Heuristic.** `pendingPaneAction` now waits for the daemon's executor for any `queued`/`processing` task, regardless of worktree. A bounded 60s fallback (`shouldFallBackToStart`) still offers to start one if the daemon never creates the window (e.g. it died, leaving the task stuck `processing`), so the view is never wedged forever.

**B. Mechanism.** New `internal/executorlock`: a per-task, cross-process **spawn flock**, distinct from the TUI's long-lived ownership lock. Both spawn paths — `EnsureTaskWindow` and the daemon's `createTmuxWindow` — take it around a *check-window-then-create* critical section and **adopt an existing window instead of creating a duplicate**. This makes A's fallback race-safe: it re-checks under the lock. `createTmuxWindow` gained a `taskID` param (updated across executor.go + codex/gemini/openclaw/opencode executors).

## Live recovery (for reference)

Keep the growing session file (advancing mtime) as live; kill the stale duplicate `task-ui-*` session; `UPDATE tasks SET claude_pane_id/shell_pane_id` to the live daemon panes; reload the ty-chrome side panel (its WebSocket grabbed the old pane at attach and won't re-point on its own).

## Tests

- `internal/executorlock`: serialization / per-task isolation / wait-then-succeed (incl. `-race`).
- `pendingPaneAction`: wait-vs-start table across statuses × worktree.
- `shouldFallBackToStart`: bounded-fallback predicate.
- Full suite green (18 pkgs), `go vet` clean, `gofmt` clean, golangci-lint v2.8.0 → 0 issues.

## Reviewer note

`createTmuxWindow` now **adopts** an existing task window rather than always creating one. This mirrors `EnsureTaskWindow`'s pre-existing behavior (it already adopts without a liveness check), and the TUI's join-side `windowHasLiveExecutor`/`killStaleWindow` handles a dead adopted pane. Worth exercising under `scripts/qa/ty-qa-pipeline-stress.sh` (slow init + concurrency) since this touches the window-creation path for all executor types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)