### PR TITLE
Stop executors falsely reporting the taskyou MCP server as disconnected

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2101,13 +2101,17 @@ func (e *Executor) buildPrompt(task *db.Task, attachmentPaths []string) string {
 func (e *Executor) buildUniversalGuidance(task *db.Task) string {
 	var b strings.Builder
 
-	b.WriteString(`Project context:
+	b.WriteString(`Your taskyou_* tools (via the "taskyou" MCP server) are connected to this session, but your harness may DEFER them behind tool search instead of loading them upfront. If you do not see a taskyou_* tool in your active toolset, it is deferred, NOT missing — load it before use (e.g. ToolSearch "select:taskyou_complete") and then call it. Never conclude "the taskyou server isn't connected" or skip a required taskyou_* call without first trying to load the tool; the server is always present for a task you are executing.`)
+
+	b.WriteString(`
+
+Project context:
 - Before exploring or starting work, call taskyou_get_project_context first via MCP. If it returns context, use it and skip exploration. If it is empty, explore once and save a summary via taskyou_set_project_context so future tasks in this project can reuse it.`)
 
 	b.WriteString(`
 
 Completion signaling (REQUIRED — nothing else watches for completion):
-- When your work is finished, call taskyou_complete with a one-paragraph summary (PR link, files touched, follow-ups). Do NOT just print a summary and stop — without this call the task stalls forever and a human has to close it by hand.
+- When your work is finished, call taskyou_complete with a one-paragraph summary (PR link, files touched, follow-ups). Do NOT just print a summary and stop — without this call the task stalls forever and a human has to close it by hand. If taskyou_complete isn't in your active toolset, it is deferred behind tool search (see above) — load it and call it; do not stop with an apology that the tool is unavailable.
   - If you opened a PR: the task moves to 'blocked' and waits for a human to review and merge it. It is promoted to 'done' automatically once the PR is merged or closed — so calling taskyou_complete does NOT mean the work shipped, you must NOT wait for the merge yourself, and you must NOT call taskyou_complete more than once.
   - If the task produced no PR (e.g. a quick config change or moving a file): it moves straight to 'done'.
 - When you need clarification, call taskyou_needs_input with the question. This moves the task to 'blocked' so a human is notified. Do not prompt in the terminal — the task system can't see TTY prompts.`)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -2174,6 +2174,28 @@ func TestBuildPromptUniversalGuidance(t *testing.T) {
 			t.Error("worktree constraint should be omitted when project does not use worktrees")
 		}
 	})
+
+	// The taskyou_* tools are registered with alwaysLoad, but that flag is not
+	// honored in the project-scoped ~/.claude.json location on current Claude
+	// versions, so the harness defers them behind tool search. Without guidance,
+	// an executor sees no taskyou_complete in its active toolset and stops with an
+	// apology that "the taskyou server isn't connected" instead of loading and
+	// calling it — leaving the task uncompleted. The prompt must tell the agent the
+	// tools are deferred (not missing) and to load them before use.
+	t.Run("prompt warns taskyou tools may be deferred behind tool search", func(t *testing.T) {
+		exec, task := newExec(t, true)
+		task.Type = "code"
+		if err := exec.db.CreateTask(task); err != nil {
+			t.Fatal(err)
+		}
+		prompt := exec.buildPrompt(task, nil)
+		if !strings.Contains(prompt, "deferred") {
+			t.Error("prompt should tell the agent taskyou_* tools may be deferred behind tool search")
+		}
+		if !strings.Contains(prompt, "ToolSearch") {
+			t.Error("prompt should tell the agent how to load a deferred taskyou_* tool")
+		}
+	})
 }
 
 // TestBuildPromptUsesFileKindInstructions proves the convention bridge at run


### PR DESCRIPTION
## What

Executors periodically finish their work and then stop with a message like:

> The taskyou_complete MCP tool isn't present in this session's toolset (the taskyou server isn't connected here), so I can't call it — flagging that rather than faking it.

That message is a **deferred-tool false negative**, not a broken MCP connection. The taskyou server *is* wired into the session.

## Root cause

`writeWorkflowMCPConfig` registers the `taskyou_*` tools in the worktree's project-scoped `~/.claude.json` with `alwaysLoad: true`. That flag is **not honored** in that location on current Claude versions (documented at `executor.go:4894`), so the harness defers the tools behind tool search. The executor prompt (`executor.go:2110`) told the agent to *"call taskyou_complete when finished"* as if it were always loaded — so, not seeing it in its active toolset, the agent concluded the server wasn't connected and stopped instead of loading and calling it.

## Impact

- **Workflow tasks** — cosmetic only; `reconcileFinishedWorkflowSteps` already advances the DAG from commit+push.
- **PR-bearing single tasks** — cosmetic; they land in `blocked` (where a successful `taskyou_complete` would put them anyway) and the PR is discovered from the branch, so `reconcileReviewTasks` still promotes to `done` on merge.
- **No-PR single tasks** — the real hole: nothing marks them `done`, so they sit in `blocked` ("Waiting for user input") until closed by hand.

## Change

Prompt-only. Tell the agent up front that its `taskyou_*` tools may be **deferred (not missing)** and to load them via tool search (`ToolSearch "select:taskyou_complete"`) before use, reiterated at the completion step. No change to the git-based completion backstops.

This is a mitigation against a model false-negative, not a hard guarantee. Root-cause fixes (getting `alwaysLoad` honored, or a CLI completion fallback that needs no tool search) are follow-ups.

## Test plan

- New test asserts the prompt carries the deferred-tool guidance (`deferred` + `ToolSearch`).
- `go build`, `go vet`, and the full `internal/executor` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)