### PR TITLE
ty-chrome: mobile/touch select-mode annotations + collapsible executor panel

### DIFF
--- a/extensions/ty-chrome/content.js
+++ b/extensions/ty-chrome/content.js
@@ -7,6 +7,7 @@
 
   const TEAL = '#d05010'; // taskyou logo orange (accent)
   let mode = 'none'; // none | select | box | note
+  let selectDown = false; // a select-mode pointer press is in progress
   let annotations = []; // {kind,label,selector,tag,text,html,rect,styles,comment,els:[]}
   let nextLabel = 1;
 
@@ -86,7 +87,7 @@
     }
     .region { position: absolute; border: 2px dashed ${TEAL}; background: rgba(208,80,16,.12); border-radius: 2px; touch-action: none; }
     .dragrect { position: fixed; border: 2px dashed ${TEAL}; background: rgba(208,80,16,.12); display: none; }
-    .boxlayer { position: fixed; inset: 0; cursor: crosshair; touch-action: none; }
+    .boxlayer, .selectlayer { position: fixed; inset: 0; cursor: crosshair; touch-action: none; }
     /* The comment editor is a <dialog> opened with showModal() so it joins the
        top layer as the topmost modal — that makes any page-level modal dialog
        (and its focus trap) inert instead of us, so our textarea stays typeable.
@@ -166,6 +167,7 @@
   // --- Modes -----------------------------------------------------------------
   const boxLayer = el('div', 'boxlayer');
   const dragRect = el('div', 'dragrect');
+  const selectLayer = el('div', 'selectlayer');
 
   function setMode(m) {
     mode = m;
@@ -173,8 +175,11 @@
     btnBox.classList.toggle('active', m === 'box');
     btnNote.classList.toggle('active', m === 'note');
     hl.style.display = 'none';
+    selectDown = false;
     boxLayer.remove();
     dragRect.remove();
+    selectLayer.remove();
+    if (m === 'select') root.appendChild(selectLayer);
     if (m === 'box') {
       root.appendChild(boxLayer);
       root.appendChild(dragRect);
@@ -187,14 +192,27 @@
     }
   }
 
-  // Select mode: hover highlight + capture-phase click interception.
-  // Driven by pointer events so it also tracks under Chrome's mobile/touch
-  // emulation (where mouseover never fires). On touch the finger position is
-  // the "hover" target while pressed; a tap still resolves to a click below.
-  function onPointerHover(e) {
-    if (mode !== 'select') return;
-    const t = realTarget(e);
-    if (!t) return;
+  // Select mode runs on a full-viewport capture layer (like box mode) so one
+  // path serves both a mouse and Chrome's mobile/touch emulation. Touch only
+  // dispatches pointer events while pressed and never fires plain hover, so we
+  // preview on press-drag and commit on release; a mouse still previews on
+  // hover (pointermove fires with no button) and commits on click. The layer's
+  // touch-action:none stops the page from stealing the gesture to scroll, and
+  // it intercepts the click so the page never navigates.
+  //
+  // Hit-testing goes through elementsFromPoint (coordinate-based), not e.target:
+  // the layer is the event target, and on touch implicit pointer capture would
+  // otherwise pin e.target to the press element for the whole drag. We skip our
+  // own shadow host (surfaced by the shadow boundary) and take the topmost page
+  // element beneath it.
+  function pageElementAt(x, y) {
+    for (const node of document.elementsFromPoint(x, y)) {
+      if (node === host || host.contains(node)) continue;
+      return node.nodeType === 1 ? node : null;
+    }
+    return null;
+  }
+  function highlight(t) {
     const r = t.getBoundingClientRect();
     hl.style.display = 'block';
     hl.style.left = r.left - 2 + 'px';
@@ -202,25 +220,32 @@
     hl.style.width = r.width + 4 + 'px';
     hl.style.height = r.height + 4 + 'px';
   }
-  function onClick(e) {
-    if (mode !== 'select') return;
-    const t = realTarget(e);
-    if (!t) return;
+  selectLayer.addEventListener('pointermove', (e) => {
+    // Mouse previews on hover; touch only tracks while a finger is down.
+    if (e.pointerType !== 'mouse' && !selectDown) return;
+    const t = pageElementAt(e.clientX, e.clientY);
+    if (t) highlight(t);
+  });
+  selectLayer.addEventListener('pointerdown', (e) => {
     e.preventDefault();
-    e.stopPropagation();
+    selectLayer.setPointerCapture?.(e.pointerId);
+    selectDown = true;
+    const t = pageElementAt(e.clientX, e.clientY);
+    if (t) highlight(t);
+  });
+  selectLayer.addEventListener('pointerup', (e) => {
+    if (!selectDown) return;
+    selectDown = false;
+    const t = pageElementAt(e.clientX, e.clientY);
     hl.style.display = 'none';
+    if (!t) {
+      setMode('none');
+      return;
+    }
     const snap = snapshotElement(t);
     openPopover({ ...snap, anchorEl: t });
     setMode('none');
-  }
-  function realTarget(e) {
-    if (e.composedPath().includes(host)) return null;
-    const t = e.target;
-    return t && t.nodeType === 1 ? t : null;
-  }
-  document.addEventListener('pointermove', onPointerHover, true);
-  document.addEventListener('pointerover', onPointerHover, true);
-  document.addEventListener('click', onClick, true);
+  });
 
   // Focus shield. Many pages run a focus trap (modal <dialog> controllers, etc.)
   // that refocuses themselves whenever focus appears to leave them. Our UI lives

--- a/extensions/ty-chrome/sidepanel.css
+++ b/extensions/ty-chrome/sidepanel.css
@@ -193,8 +193,21 @@ button.primary:disabled kbd { background: rgba(15, 23, 42, 0.06); color: #94a3b8
 /* --- Terminal ------------------------------------------------------------ */
 
 .executor { flex: 1; display: flex; flex-direction: column; min-height: 220px; }
+/* Collapsed: shrink to the header, hide the live view + hint. State stays visible. */
+.executor.collapsed { flex: 0 0 auto; min-height: 0; }
+.executor.collapsed .term-wrap,
+.executor.collapsed .term-hint { display: none; }
 
-.term-head { margin-bottom: 8px; }
+.term-head { margin-bottom: 8px; cursor: pointer; }
+.term-head:has(.term-toggle) h2 { cursor: pointer; }
+.executor.collapsed .term-head { margin-bottom: 0; }
+
+.term-toggle {
+  background: none; border: 0; padding: 0 2px; margin: 0;
+  color: var(--muted); font-size: 12px; line-height: 1; cursor: pointer;
+  transition: transform 0.12s ease;
+}
+.executor.collapsed .term-toggle { transform: rotate(-90deg); }
 
 .term-state { font-size: 10px; white-space: nowrap; }
 .term-state.live { color: #22c55e; }

--- a/extensions/ty-chrome/sidepanel.html
+++ b/extensions/ty-chrome/sidepanel.html
@@ -79,7 +79,8 @@
   </section>
 
   <section class="card executor">
-    <div class="sec-head term-head">
+    <div class="sec-head term-head" id="term-head" title="Collapse / expand executor">
+      <button id="term-toggle" class="term-toggle" aria-expanded="true" aria-label="Collapse executor">▾</button>
       <h2>Executor</h2>
       <span id="executor-state" class="muted term-state"></span>
       <span id="bridge-status" class="muted bridge-status hidden"></span>

--- a/extensions/ty-chrome/sidepanel.js
+++ b/extensions/ty-chrome/sidepanel.js
@@ -669,6 +669,37 @@ $('auto-reload').addEventListener('change', (e) => {
   chrome.storage.local.set({ autoReload: e.target.checked });
 });
 
+// Collapsible executor panel. Collapsing hides the live terminal to give the
+// task/annotate cards more room; the header (with ● live state) stays visible.
+// The mirror keeps streaming while collapsed, so state stays current. Choice is
+// remembered like auto-reload.
+function setExecutorCollapsed(collapsed, persist = true) {
+  const section = document.querySelector('.executor');
+  if (!section) return;
+  section.classList.toggle('collapsed', collapsed);
+  const btn = $('term-toggle');
+  if (btn) {
+    btn.setAttribute('aria-expanded', String(!collapsed));
+    btn.setAttribute('aria-label', collapsed ? 'Expand executor' : 'Collapse executor');
+  }
+  // Re-fit once the terminal is visible again (belt-and-suspenders alongside the
+  // ResizeObserver, which also fires as the wrapper regains size).
+  if (!collapsed) requestAnimationFrame(() => { try { fit && fit.fit(); } catch {} });
+  if (persist) chrome.storage.local.set({ executorCollapsed: collapsed });
+}
+function toggleExecutor() {
+  const section = document.querySelector('.executor');
+  setExecutorCollapsed(!section.classList.contains('collapsed'));
+}
+$('term-head').addEventListener('click', (e) => {
+  // Let the auto-reload checkbox work without toggling the panel.
+  if (e.target.closest('.auto-reload')) return;
+  toggleExecutor();
+});
+chrome.storage.local.get('executorCollapsed').then(({ executorCollapsed }) => {
+  if (executorCollapsed) setExecutorCollapsed(true, false);
+});
+
 chrome.tabs.onActivated.addListener(refresh);
 chrome.tabs.onUpdated.addListener((tabId, info) => {
   if (tabId === activeTabId && info.status === 'complete') refresh();


### PR DESCRIPTION
Two related ty-chrome extension improvements.

## 1. Select-mode annotations work under Chrome mobile/responsive (touch emulation)

**Problem:** In device mode, entering **Select** and hovering showed no highlight ("no hover"), so element annotation was effectively broken.

**Root cause:** Select mode was mouse-only — highlight driven by document-level `pointermove`/`pointerover`, commit on `click`. Under touch emulation a pointer only exists *while pressed*, so plain cursor movement fires no events, and implicit pointer capture pins `e.target` to the press element during a drag. Box mode was already migrated to a touch-capable pattern (`ca1faf0b`); select mode was left behind.

**Fix:** Give select mode the same capture-layer pattern box mode uses:
- Full-viewport `selectLayer` (`touch-action:none`) owns the gesture — no page scroll, page never gets a stray click.
- Preview on **press-drag** (touch) *and* **hover** (mouse); commit on **pointerup**.
- Hit-test via `document.elementsFromPoint()` (coordinate-based, skipping our shadow host) so pointer capture can't pin the target.

**Verified in Chromium** (Playwright harness driving the real `content.js`):
- `elementsFromPoint` pierces the top-layer shadow host to the real page element.
- Mouse hover preview matches the target rect exactly.
- Touch press-drag-release previews on press and commits the correct element into the comment popover.

## 2. Collapsible executor panel

The live executor terminal (`flex:1`, ~220px min) crowds the task/annotate cards. Added a caret toggle in the Executor header (whole header is clickable, excluding the auto-reload checkbox) that collapses the terminal + hint down to just the header — the `● live`/busy state stays visible and the mirror keeps streaming. Default expanded; choice persists via `chrome.storage.local` like `auto-reload`. On expand the terminal re-fits.

Verified in Chromium: collapse shrinks the section from ~460px to ~39px (header only), hides terminal + hint, rotates the caret, keeps the live state visible; expand restores fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)