### PR TITLE
fix(worktree-guard): always allow writes to system temp dirs

### DIFF
--- a/internal/executor/worktree_guard.go
+++ b/internal/executor/worktree_guard.go
@@ -20,7 +20,12 @@ import (
 //   - Reads are always allowed — legitimate cross-tree access (reference code in
 //     main, prod over ssh, shared configs) is overwhelmingly reads.
 //   - ANY write whose destination resolves outside the worktree asks the user
-//     (main repo, sibling worktrees, $HOME, /tmp — all the same rule).
+//     (main repo, sibling worktrees, $HOME — all the same rule), EXCEPT the system
+//     temp dirs (/tmp, /private/tmp, /var/tmp, $TMPDIR), which are always allowed.
+//     Temp dirs are shared, ephemeral scratch space; a write there can't corrupt
+//     the main checkout or a sibling worktree (the boundary this guard protects),
+//     and agents legitimately stage scratch files there — prompting on every /tmp
+//     write is pure friction that stalls otherwise-fine work.
 //   - In bypassPermissions mode (--dangerously-skip-permissions) there is no human
 //     to answer, so the guard fails closed and denies instead of asking.
 //   - Only taskyou-managed worktrees are guarded. "Shared dir" projects opted out
@@ -130,7 +135,7 @@ func externalWriteTargets(in WorktreeGuardInput, root string, allowExternal []st
 	var escapes []string
 	for _, p := range raw {
 		abs := cleanPath(p, in.Cwd)
-		if abs == "" || isIgnorableSink(abs) {
+		if abs == "" || isIgnorableSink(abs) || isAllowedTempDir(abs) {
 			continue
 		}
 		if pathWithin(root, abs) || allowlisted(abs, allowExternal) {
@@ -311,6 +316,31 @@ func allowlisted(abs string, allow []string) bool {
 	}
 	return false
 }
+
+// isAllowedTempDir reports whether abs is inside a system temp directory. Writes
+// there are always allowed: temp dirs are shared, ephemeral scratch and can't
+// corrupt the main checkout or a sibling worktree, which is all this guard exists
+// to protect. Symlinks are resolved (macOS /tmp → /private/tmp) so both spellings
+// match.
+func isAllowedTempDir(abs string) bool {
+	for _, root := range tempWriteRoots {
+		if pathWithin(root, abs) {
+			return true
+		}
+	}
+	return false
+}
+
+// tempWriteRoots is the set of system temp directories writes are exempted into.
+// os.TempDir() covers $TMPDIR (macOS per-user /var/folders/.../T); the fixed roots
+// cover the conventional locations agents reach for directly.
+var tempWriteRoots = func() []string {
+	roots := []string{"/tmp", "/private/tmp", "/var/tmp"}
+	if td := strings.TrimSpace(os.TempDir()); td != "" {
+		roots = append(roots, td)
+	}
+	return roots
+}()
 
 // isIgnorableSink reports whether abs is a non-file write sink (e.g. /dev/null)
 // that should never count as escaping the worktree.

--- a/internal/executor/worktree_guard_test.go
+++ b/internal/executor/worktree_guard_test.go
@@ -208,7 +208,9 @@ func TestWorktreeWriteGuardBash(t *testing.T) {
 	}{
 		{"read-only grep allowed", "grep -r foo .", ""},
 		{"read-only cat allowed", "cat /etc/hosts", ""},
-		{"redirect to /tmp asks", "echo data > /tmp/scratch", "ask"},
+		{"redirect to /tmp allowed", "echo data > /tmp/scratch", ""},
+		{"redirect to /private/tmp allowed", "echo data > /private/tmp/scratch", ""},
+		{"redirect to /var/tmp allowed", "echo data > /var/tmp/scratch", ""},
 		{"redirect to /dev/null allowed", "ls -la > /dev/null", ""},
 		{"stderr to /dev/null allowed", "rails test 2>/dev/null", ""},
 		{"redirect inside worktree allowed", "echo hi > out.txt", ""},
@@ -231,6 +233,34 @@ func TestWorktreeWriteGuardBash(t *testing.T) {
 			}
 			if gotDecision != c.want {
 				t.Errorf("command %q: decision = %q, want %q", c.command, gotDecision, c.want)
+			}
+		})
+	}
+}
+
+// System temp directories are shared, ephemeral scratch space — writing there
+// can't corrupt the main checkout or a sibling worktree (the boundary the guard
+// exists to protect), and agents legitimately stage temp files there. So writes
+// under /tmp, /private/tmp, /var/tmp, and the OS temp dir are always allowed,
+// like /dev/null — never a permission prompt.
+func TestWorktreeWriteGuardAllowsTempDirs(t *testing.T) {
+	tmpFile := filepath.Join(os.TempDir(), "review_a.md")
+	cases := []struct {
+		name string
+		in   WorktreeGuardInput
+	}{
+		{"Write to /tmp", WorktreeGuardInput{ToolName: "Write", Cwd: wt,
+			ToolInput: toolInput(t, map[string]any{"file_path": "/tmp/review_a.md"})}},
+		{"Write to os.TempDir", WorktreeGuardInput{ToolName: "Write", Cwd: wt,
+			ToolInput: toolInput(t, map[string]any{"file_path": tmpFile})}},
+		{"Bash redirect to /tmp in bypass mode", WorktreeGuardInput{ToolName: "Bash", Cwd: wt,
+			PermissionMode: "bypassPermissions",
+			ToolInput:      toolInput(t, map[string]any{"command": "echo x > /tmp/scratch"})}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := EvaluateWorktreeWriteGuard(wt, nil, c.in); got != nil {
+				t.Errorf("temp-dir write should be allowed, got %q (%s)", got.Decision, got.Reason)
 			}
 		})
 	}


### PR DESCRIPTION
## What & why

The worktree write-guard prompted for permission on **any** write resolving outside a task's worktree — including `/tmp`. Agents routinely stage scratch files there, so a pipeline step stalled on a permission prompt for a harmless temp write:

> `git show …:PLAN_REVIEW_A.md > /tmp/review_a.md` → "would write outside your isolated worktree… the user must approve it."

Worse, in `bypassPermissions` mode the guard **denies** out-of-worktree writes (no human to ask), so an autonomous step would be trapped retrying a `/tmp` write it can never make.

## Fix

Exempt the system temp dirs — `/tmp`, `/private/tmp`, `/var/tmp`, and `$TMPDIR` (`os.TempDir()`) — from the guard, resolved through symlinks so macOS `/tmp` == `/private/tmp`. Same mechanism as the existing `/dev/null` exemption.

This doesn't weaken the guard's actual threat model: temp dirs are shared, ephemeral scratch space, and a write there can't corrupt the main checkout or a sibling worktree — the only boundary this guard exists to protect. Reads were, and remain, always allowed.

## Tests
- `TestWorktreeWriteGuardAllowsTempDirs` — structured `Write` to `/tmp` and to `os.TempDir()`, and a Bash redirect to `/tmp` in bypass mode, are all allowed.
- Updated `TestWorktreeWriteGuardBash` — `/tmp`, `/private/tmp`, `/var/tmp` redirects now allowed; main-checkout / `$HOME` / sibling-worktree writes still ask.

Full suite green (18 packages), clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)