### PR TITLE
feat(plugins): plugins can ship routines (routines/<name>/prompt.md)

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/bborn/workflow/internal/hooks"
 	"github.com/bborn/workflow/internal/mcp"
 	"github.com/bborn/workflow/internal/pipeline"
+	"github.com/bborn/workflow/internal/routine"
 	"github.com/bborn/workflow/internal/ui"
 	"github.com/bborn/workflow/internal/web"
 )
@@ -114,6 +115,13 @@ func main() {
 	// workflows surface everywhere built-in and on-disk workflows do.
 	pipeline.PluginWorkflowDirs = func() []string {
 		return hooks.PluginWorkflowDirs(hooks.DefaultPluginsDir())
+	}
+
+	// Same, for routines: an installed plugin's routines/ become resolvable by
+	// `ty run <name>` and visible in `ty routines`. Wired here so the routine
+	// package needn't import hooks.
+	routine.PluginRoutineDirs = func() []string {
+		return hooks.PluginRoutineDirs(hooks.DefaultPluginsDir())
 	}
 
 	var dangerous bool

--- a/cmd/task/plugins.go
+++ b/cmd/task/plugins.go
@@ -249,6 +249,9 @@ func listPlugins() {
 		for _, w := range p.Workflows {
 			fmt.Printf("    workflow %-16s (ty pipeline -d %s \"<goal>\")\n", w, w)
 		}
+		for _, r := range p.Routines {
+			fmt.Printf("    routine  %-16s (ty run %s)\n", r, r)
+		}
 		fmt.Println()
 	}
 }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -104,6 +104,38 @@ Actions are reachable from every surface, all running the same command:
   /api/plugins/actions/run` (`{plugin, action, task_id?}`) runs one. The desktop
   app and any agent use these.
 
+## Workflows and routines (by convention)
+
+Two capabilities need no manifest entry — a plugin ships them by *convention*, just
+by having the right subdirectory:
+
+- **`workflows/*.yaml`** — each file is a workflow definition, resolvable by
+  `ty pipeline -d <name>` once the plugin is installed.
+- **`routines/<name>/prompt.md`** — each subdirectory is a routine: a
+  named, unattended agent run, resolvable by `ty run <name>` and listed by
+  `ty routines` (frontmatter for `model`/`project`/`timeout`/… works exactly as it
+  does for a user routine under `~/.config/task/routines/`).
+
+```
+my-plugin/
+├── plugin.yaml
+├── workflows/
+│   └── review.yaml            # ty pipeline -d review "<goal>"
+└── routines/
+    └── linear-poll/
+        └── prompt.md          # ty run linear-poll   (+ ty routine schedule --every 2m)
+```
+
+A user routine of the same name **shadows** a plugin's (your
+`~/.config/task/routines/` wins), so a plugin routine is a sensible default you can
+override. Scheduling stays a separate step (`ty routine schedule <name> --every … |
+--cron …`) — the plugin ships the *what*, you choose the cadence.
+
+**Routine vs. service:** ship a **routine** for periodic, run-to-completion work (a
+poller, a digest, a nightly sweep) — the daemon records each run, enforces a timeout,
+and keeps cross-run state in `ROUTINE_STATE_DIR`. Ship a **service** (where available)
+only for a process that must stay *up* (a socket connection, a listening port).
+
 ## Behavior & guarantees
 
 - **Fan-out**: for each event, the legacy single-script hook *and* every plugin

--- a/internal/hooks/plugin_routines_test.go
+++ b/internal/hooks/plugin_routines_test.go
@@ -1,0 +1,72 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writePluginRoutine drops a routines/<name>/prompt.md into a plugin dir.
+func writePluginRoutine(t *testing.T, pluginDir, name, prompt string) {
+	t.Helper()
+	rdir := filepath.Join(pluginDir, "routines", name)
+	if err := os.MkdirAll(rdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "prompt.md"), []byte(prompt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A plugin that ships ONLY a routine (no hooks/actions/workflows) is still usable.
+func TestPlugin_RoutinesOnlyIsUsable(t *testing.T) {
+	root := t.TempDir()
+	dir := writePlugin(t, root, "linear", "name: linear\ndescription: Linear integration\n", nil)
+	writePluginRoutine(t, dir, "linear-poll", "poll linear")
+
+	plugins, warnings := LoadPlugins(root)
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(plugins) != 1 {
+		t.Fatalf("got %d plugins, want 1 (routines-only plugin must load)", len(plugins))
+	}
+	p := plugins[0]
+	if len(p.Routines) != 1 || p.Routines[0] != "linear-poll" {
+		t.Errorf("p.Routines = %v, want [linear-poll]", p.Routines)
+	}
+	if p.RoutinesDir() != filepath.Join(dir, "routines") {
+		t.Errorf("RoutinesDir() = %q, want %q", p.RoutinesDir(), filepath.Join(dir, "routines"))
+	}
+}
+
+// A routines/ subdir without a prompt.md is not a routine and doesn't count.
+func TestPlugin_RoutineWithoutPromptIgnored(t *testing.T) {
+	root := t.TempDir()
+	dir := writePlugin(t, root, "empty", "name: empty\n", nil)
+	if err := os.MkdirAll(filepath.Join(dir, "routines", "nope"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	plugins, _ := LoadPlugins(root)
+	// No prompt.md → no routine → nothing usable → plugin skipped entirely.
+	if len(plugins) != 0 {
+		t.Fatalf("got %d plugins, want 0 (routine dir without prompt.md is not usable)", len(plugins))
+	}
+}
+
+// PluginRoutineDirs returns the routines/ subdir of every plugin that ships one.
+func TestPluginRoutineDirs(t *testing.T) {
+	root := t.TempDir()
+	withRt := writePlugin(t, root, "hasrt", "name: hasrt\ndescription: d\n", nil)
+	writePluginRoutine(t, withRt, "poll", "do the poll")
+	// A hooks-only plugin must NOT contribute a routines dir.
+	writePlugin(t, root, "hooksonly", "name: hooksonly\nhooks:\n  task.done: d.sh\n",
+		map[string]string{"d.sh": "#!/bin/sh\n"})
+
+	dirs := PluginRoutineDirs(root)
+	want := filepath.Join(withRt, "routines")
+	if len(dirs) != 1 || dirs[0] != want {
+		t.Errorf("PluginRoutineDirs = %v, want [%s]", dirs, want)
+	}
+}

--- a/internal/hooks/plugins.go
+++ b/internal/hooks/plugins.go
@@ -39,11 +39,23 @@ type Plugin struct {
 	// workflows/*.yaml. Populated for display; the definitions themselves are loaded
 	// by the pipeline registry via PluginWorkflowDirs.
 	Workflows []string `yaml:"-"`
+	// Routines holds the names of the routine definitions this plugin ships in its
+	// routines/ subdir (each a <name>/prompt.md). Discovered by convention, like
+	// workflows. Populated for display; the routine package resolves the definitions
+	// via PluginRoutineDirs. A routine is the right home for a plugin's periodic job
+	// (a poller, a digest): the daemon-supervised alternative, a service, is for
+	// processes that must stay up, not run-to-completion on a schedule.
+	Routines []string `yaml:"-"`
 }
 
 // WorkflowsDir returns the plugin's workflows subdir, whether or not it exists.
 func (p Plugin) WorkflowsDir() string {
 	return filepath.Join(p.Dir, "workflows")
+}
+
+// RoutinesDir returns the plugin's routines subdir, whether or not it exists.
+func (p Plugin) RoutinesDir() string {
+	return filepath.Join(p.Dir, "routines")
 }
 
 // Action is a user-triggered plugin command.
@@ -178,11 +190,13 @@ func loadPlugin(dir string) (*Plugin, string) {
 	if p.Name == "" {
 		return nil, fmt.Sprintf("plugin %s: manifest is missing a name", filepath.Base(dir))
 	}
-	// Workflows are discovered by convention: any workflows/*.yaml makes the plugin
-	// workflow cargo, no manifest declaration needed.
+	// Workflows and routines are discovered by convention: any workflows/*.yaml or
+	// routines/<name>/prompt.md makes the plugin cargo for them, no manifest
+	// declaration needed.
 	p.Workflows = discoverPluginWorkflows(dir)
-	if len(p.Hooks) == 0 && len(p.Actions) == 0 && len(p.Workflows) == 0 {
-		return nil, fmt.Sprintf("plugin %q: manifest declares no hooks, actions, or workflows; skipping", p.Name)
+	p.Routines = discoverPluginRoutines(dir)
+	if len(p.Hooks) == 0 && len(p.Actions) == 0 && len(p.Workflows) == 0 && len(p.Routines) == 0 {
+		return nil, fmt.Sprintf("plugin %q: manifest declares no hooks, actions, workflows, or routines; skipping", p.Name)
 	}
 
 	// Drop hooks and actions whose script is missing or not a regular file,
@@ -207,8 +221,8 @@ func loadPlugin(dir string) (*Plugin, string) {
 	}
 	p.Actions = kept
 
-	if len(p.Hooks) == 0 && len(p.Actions) == 0 && len(p.Workflows) == 0 {
-		return nil, fmt.Sprintf("plugin %q: no usable hook, action, or workflow found; skipping", p.Name)
+	if len(p.Hooks) == 0 && len(p.Actions) == 0 && len(p.Workflows) == 0 && len(p.Routines) == 0 {
+		return nil, fmt.Sprintf("plugin %q: no usable hook, action, workflow, or routine found; skipping", p.Name)
 	}
 	if len(dropped) > 0 {
 		sort.Strings(dropped)
@@ -254,6 +268,43 @@ func PluginWorkflowDirs(pluginsDir string) []string {
 	for _, p := range plugins {
 		if len(p.Workflows) > 0 {
 			dirs = append(dirs, p.WorkflowsDir())
+		}
+	}
+	return dirs
+}
+
+// discoverPluginRoutines returns the names of every routine a plugin ships in its
+// routines/ subdir — a subdirectory is a routine when it contains a prompt.md (the
+// same shape a routine has under ~/.config/task/routines/). Sorted for stable display.
+func discoverPluginRoutines(dir string) []string {
+	rdir := filepath.Join(dir, "routines")
+	entries, err := os.ReadDir(rdir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(rdir, e.Name(), "prompt.md")); err != nil {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	return names
+}
+
+// PluginRoutineDirs returns the routines/ subdir of every installed plugin that
+// ships one. The routine package folds these into its search path, so a plugin's
+// routines become resolvable by `ty run <name>` and visible in `ty routines`.
+func PluginRoutineDirs(pluginsDir string) []string {
+	plugins, _ := LoadPlugins(pluginsDir)
+	var dirs []string
+	for _, p := range plugins {
+		if len(p.Routines) > 0 {
+			dirs = append(dirs, p.RoutinesDir())
 		}
 	}
 	return dirs

--- a/internal/routine/plugin_routines_test.go
+++ b/internal/routine/plugin_routines_test.go
@@ -1,0 +1,81 @@
+package routine
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// A routine shipped by a plugin (contributed via PluginRoutineDirs) is
+// resolvable by Load/Exists and shows up in List, just like a user routine.
+func TestPluginRoutine_Resolves(t *testing.T) {
+	userDir := setupRoutinesDir(t)
+	pluginDir := t.TempDir()
+	writeRoutine(t, pluginDir, "linear-poll", "poll linear for new issues")
+
+	prev := PluginRoutineDirs
+	PluginRoutineDirs = func() []string { return []string{pluginDir} }
+	t.Cleanup(func() { PluginRoutineDirs = prev })
+
+	if !Exists("linear-poll") {
+		t.Fatal("Exists: plugin routine not found")
+	}
+	r, err := Load("linear-poll")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if r.Dir != filepath.Join(pluginDir, "linear-poll") {
+		t.Errorf("Dir = %q, want the plugin dir", r.Dir)
+	}
+
+	// A user routine coexists and both appear in List.
+	writeRoutine(t, userDir, "scout", "scout the feedback")
+	routines, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	got := map[string]bool{}
+	for _, rt := range routines {
+		got[rt.Name] = true
+	}
+	if !got["linear-poll"] || !got["scout"] {
+		t.Fatalf("List missing routines; got %v", got)
+	}
+}
+
+// A user routine shadows a plugin routine of the same name (user dir wins).
+func TestPluginRoutine_UserShadows(t *testing.T) {
+	userDir := setupRoutinesDir(t)
+	pluginDir := t.TempDir()
+	writeRoutine(t, pluginDir, "dup", "PLUGIN version")
+	writeRoutine(t, userDir, "dup", "USER version")
+
+	prev := PluginRoutineDirs
+	PluginRoutineDirs = func() []string { return []string{pluginDir} }
+	t.Cleanup(func() { PluginRoutineDirs = prev })
+
+	r, err := Load("dup")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if r.Prompt != "USER version" {
+		t.Errorf("Prompt = %q, want the user routine to shadow the plugin one", r.Prompt)
+	}
+	if r.Dir != filepath.Join(userDir, "dup") {
+		t.Errorf("Dir = %q, want the user dir", r.Dir)
+	}
+
+	// List must return "dup" exactly once (the user's), not both.
+	routines, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	n := 0
+	for _, rt := range routines {
+		if rt.Name == "dup" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("List returned %d 'dup' routines, want 1 (deduped, user wins)", n)
+	}
+}

--- a/internal/routine/routine.go
+++ b/internal/routine/routine.go
@@ -67,6 +67,36 @@ func StateDir(name string) string {
 	return filepath.Join(home, ".local", "share", "task", "routines", name)
 }
 
+// PluginRoutineDirs, when set, returns extra directories that hold routine
+// definitions contributed by installed plugins (each a routines/ subdir whose
+// children are <name>/prompt.md). Wired up in main so this package needn't
+// import the hooks/plugins package. Read paths (Load, Exists, List) search the
+// user's RoutinesDir first, then these — so a user routine shadows a plugin one
+// of the same name, and plugins extend the set the same way they do workflows.
+var PluginRoutineDirs func() []string
+
+// searchDirs returns every base directory routine definitions may live in: the
+// user's dir first (it wins on name collisions), then plugin-contributed dirs.
+func searchDirs() []string {
+	dirs := []string{RoutinesDir()}
+	if PluginRoutineDirs != nil {
+		dirs = append(dirs, PluginRoutineDirs()...)
+	}
+	return dirs
+}
+
+// resolveDir returns the directory holding routine <name> — the first base dir
+// (user first, then plugins) that contains <name>/prompt.md — or "" if none does.
+func resolveDir(name string) string {
+	for _, base := range searchDirs() {
+		dir := filepath.Join(base, name)
+		if _, err := os.Stat(filepath.Join(dir, promptFile)); err == nil {
+			return dir
+		}
+	}
+	return ""
+}
+
 // ValidateName rejects names that aren't safe as path components.
 func ValidateName(name string) error {
 	if !nameRe.MatchString(name) {
@@ -75,13 +105,12 @@ func ValidateName(name string) error {
 	return nil
 }
 
-// Exists reports whether a routine directory with a prompt.md exists.
+// Exists reports whether a routine with a prompt.md exists in any search dir.
 func Exists(name string) bool {
 	if ValidateName(name) != nil {
 		return false
 	}
-	_, err := os.Stat(filepath.Join(RoutinesDir(), name, promptFile))
-	return err == nil
+	return resolveDir(name) != ""
 }
 
 // Load reads a routine definition from disk.
@@ -89,12 +118,12 @@ func Load(name string) (*Routine, error) {
 	if err := ValidateName(name); err != nil {
 		return nil, err
 	}
-	dir := filepath.Join(RoutinesDir(), name)
+	dir := resolveDir(name)
+	if dir == "" {
+		return nil, fmt.Errorf("routine %q not found (expected %s)", name, filepath.Join(RoutinesDir(), name, promptFile))
+	}
 	raw, err := os.ReadFile(filepath.Join(dir, promptFile))
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("routine %q not found (expected %s)", name, filepath.Join(dir, promptFile))
-		}
 		return nil, fmt.Errorf("read routine %q: %w", name, err)
 	}
 
@@ -149,27 +178,41 @@ func Load(name string) (*Routine, error) {
 // without a prompt.md are skipped; unparseable routines are returned as an
 // error so a typo doesn't silently hide a routine from the list.
 func List() ([]*Routine, error) {
-	entries, err := os.ReadDir(RoutinesDir())
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read routines dir: %w", err)
-	}
-
+	seen := map[string]bool{}
 	var routines []*Routine
-	for _, entry := range entries {
-		if !entry.IsDir() || ValidateName(entry.Name()) != nil {
-			continue
-		}
-		if _, err := os.Stat(filepath.Join(RoutinesDir(), entry.Name(), promptFile)); err != nil {
-			continue
-		}
-		r, err := Load(entry.Name())
+	// User dir first (index 0): a parse error there is fatal so a typo can't
+	// silently hide a routine. Plugin dirs are forgiving — one broken plugin
+	// routine must not break `ty routines` — matching how plugins load.
+	for i, base := range searchDirs() {
+		userDir := i == 0
+		entries, err := os.ReadDir(base)
 		if err != nil {
-			return nil, err
+			if os.IsNotExist(err) {
+				continue
+			}
+			if userDir {
+				return nil, fmt.Errorf("read routines dir: %w", err)
+			}
+			continue
 		}
-		routines = append(routines, r)
+		for _, entry := range entries {
+			name := entry.Name()
+			if !entry.IsDir() || ValidateName(name) != nil || seen[name] {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(base, name, promptFile)); err != nil {
+				continue
+			}
+			r, err := Load(name)
+			if err != nil {
+				if userDir {
+					return nil, err
+				}
+				continue
+			}
+			seen[name] = true
+			routines = append(routines, r)
+		}
 	}
 	sort.Slice(routines, func(i, j int) bool { return routines[i].Name < routines[j].Name })
 	return routines, nil


### PR DESCRIPTION
Lets a plugin ship a **routine** by convention — the twin of shipping a workflow. Drop `routines/<name>/prompt.md` in a plugin and it becomes resolvable by `ty run <name>` and shows up in `ty routines`, exactly like a user routine under `~/.config/task/routines/`.

## Why
This is the right representation for a plugin's **periodic job** (a poller, a digest, a nightly sweep). A routine is run-to-completion: the daemon records each run, enforces a timeout (default 30m so a hung run can't wedge), and gives it cross-run state via `ROUTINE_STATE_DIR` (a poll cursor, seen-IDs). That's strictly better than cron'ing a bare script — and better than forcing periodic work into an always-up `service:` loop, which has a worse failure mode (a wedged loop under a no-restart supervisor runs forever).

Clean split: **routine** = runs periodically to completion; **service** = must stay up (socket/port). ty already owns cadence via `ty routine schedule --every … | --cron …`, so no new `timers:` capability is needed.

## What's here
- **`internal/routine`**: a search-path indirection. Read paths (`Load`/`Exists`/`List`) search the user dir first, then plugin-contributed dirs via a `PluginRoutineDirs` var (wired in main so the package needn't import hooks). A user routine **shadows** a plugin one of the same name; `List` dedupes and is forgiving of a broken plugin routine (a parse error is fatal only for the user's own dir).
- **`internal/hooks`**: routines discovered by convention (`discoverPluginRoutines` — a subdir with a `prompt.md`); `Plugin.RoutinesDir()`; `PluginRoutineDirs()`; a routine-only plugin is usable. Mirrors the existing `discoverPluginWorkflows`/`PluginWorkflowDirs`.
- **`cmd/task`**: wires `routine.PluginRoutineDirs`; `ty plugins list` shows routines.
- **`docs/plugins.md`**: a workflows-and-routines-by-convention section + routine-vs-service guidance.
- Tests on both sides (resolve, user-shadows-plugin, dedupe, routine-only-usable, dir-without-prompt-ignored, `PluginRoutineDirs`).

## Verified
Build + `internal/routine` + `internal/hooks` + `cmd/task` suites green, gofmt clean. Smoke-tested with the real binary: a plugin-shipped `linear-poll` appears in both `ty plugins list` (`routine  linear-poll  (ty run linear-poll)`) and `ty routines` (`● linear-poll (sonnet) — never run`).

## Context
This unblocks migrating taskyou-os's `linear-poll` (today a cron'd script) to a plugin-shipped routine instead of a rewrite-as-service. Independent of the `services:` capability PR (#664) — they touch the same plugin struct so expect a trivial merge conflict there.