### PR TITLE
fix: preserve tracked Claude config in worktrees

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4890,6 +4890,13 @@ func symlinkClaudeConfig(projectDir, worktreePath string) error {
 		return fmt.Errorf("projectDir and worktreePath must be different (both resolve to %s)", mainClaudeDir)
 	}
 
+	// Preserve .claude content tracked in the worktree's branch.
+	cmd := exec.Command("git", "ls-files", "--", ".claude")
+	cmd.Dir = worktreePath
+	if output, err := cmd.Output(); err == nil && len(output) > 0 {
+		return nil
+	}
+
 	// If mainClaudeDir exists as a symlink (possibly broken/circular), remove it
 	// The main project's .claude should always be a real directory, never a symlink
 	if info, err := os.Lstat(mainClaudeDir); err == nil && info.Mode()&os.ModeSymlink != 0 {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4890,13 +4890,6 @@ func symlinkClaudeConfig(projectDir, worktreePath string) error {
 		return fmt.Errorf("projectDir and worktreePath must be different (both resolve to %s)", mainClaudeDir)
 	}
 
-	// Preserve .claude content tracked in the worktree's branch.
-	cmd := exec.Command("git", "ls-files", "--", ".claude")
-	cmd.Dir = worktreePath
-	if output, err := cmd.Output(); err == nil && len(output) > 0 {
-		return nil
-	}
-
 	// If mainClaudeDir exists as a symlink (possibly broken/circular), remove it
 	// The main project's .claude should always be a real directory, never a symlink
 	if info, err := os.Lstat(mainClaudeDir); err == nil && info.Mode()&os.ModeSymlink != 0 {
@@ -4906,6 +4899,13 @@ func symlinkClaudeConfig(projectDir, worktreePath string) error {
 	// Ensure main project has .claude directory
 	if err := os.MkdirAll(mainClaudeDir, 0755); err != nil {
 		return fmt.Errorf("create main .claude dir: %w", err)
+	}
+
+	// If the worktree's branch tracks content under .claude, the checkout owns that
+	// directory: replacing it with a symlink would show every tracked file as deleted.
+	// Merge the project's local-only config into it instead of swapping it out.
+	if claudeIsTracked(worktreePath) {
+		return mergeClaudeConfig(projectDir, worktreePath)
 	}
 
 	// Check if worktree .claude is already a symlink to the right place
@@ -4927,6 +4927,87 @@ func symlinkClaudeConfig(projectDir, worktreePath string) error {
 	// The .gitignore entry ".claude/" (with trailing slash) only matches directories, not symlinks.
 	// Use projectDir because worktree .git is a file pointing to the main repo's git dir.
 	ensureGitExclude(projectDir, ".claude")
+
+	return nil
+}
+
+// claudeIsTracked reports whether the worktree's branch tracks any content under
+// .claude. It reads the index rather than the working tree, so it still answers
+// true for a worktree whose .claude was already replaced by a symlink.
+func claudeIsTracked(worktreePath string) bool {
+	cmd := exec.Command("git", "ls-files", "--", ".claude")
+	cmd.Dir = worktreePath
+	output, err := cmd.Output()
+	return err == nil && len(output) > 0
+}
+
+// mergeClaudeConfig wires the project's .claude into a worktree that tracks .claude
+// content of its own. The checked-out files stay exactly as git left them; anything
+// present only in the main project (settings.local.json, local hooks, unshared
+// skills and agents) is symlinked in alongside them, so the executor still sees the
+// full config. Without this, a project that commits even one file under .claude
+// would silently lose all of its local-only configuration inside worktrees.
+func mergeClaudeConfig(projectDir, worktreePath string) error {
+	mainClaudeDir := filepath.Join(projectDir, ".claude")
+	worktreeClaudeDir := filepath.Join(worktreePath, ".claude")
+
+	// Heal a worktree left behind by the previous symlink-always behavior: the
+	// tracked files are still in the index but missing from the working tree.
+	if _, err := os.Readlink(worktreeClaudeDir); err == nil {
+		if err := os.Remove(worktreeClaudeDir); err != nil {
+			return fmt.Errorf("remove stale .claude symlink: %w", err)
+		}
+		restore := exec.Command("git", "checkout", "--", ".claude")
+		restore.Dir = worktreePath
+		if out, err := restore.CombinedOutput(); err != nil {
+			return fmt.Errorf("restore tracked .claude: %w: %s", err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	if err := os.MkdirAll(worktreeClaudeDir, 0755); err != nil {
+		return fmt.Errorf("create worktree .claude dir: %w", err)
+	}
+
+	return linkMissingClaudeEntries(projectDir, mainClaudeDir, worktreeClaudeDir, ".claude")
+}
+
+// linkMissingClaudeEntries symlinks every entry of mainDir that the worktree does not
+// already have into wtDir, recursing into directories the two share so local files can
+// sit beside tracked ones (a tracked .claude/skills/ still gets the local skills).
+// Whatever the worktree checked out always wins; only gaps are filled.
+func linkMissingClaudeEntries(projectDir, mainDir, wtDir, relDir string) error {
+	entries, err := os.ReadDir(mainDir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", mainDir, err)
+	}
+
+	for _, entry := range entries {
+		mainEntry := filepath.Join(mainDir, entry.Name())
+		wtEntry := filepath.Join(wtDir, entry.Name())
+		rel := relDir + "/" + entry.Name()
+
+		info, statErr := os.Lstat(wtEntry)
+		if statErr == nil {
+			// Both sides have a real directory: recurse so local-only children still land.
+			if info.IsDir() && entry.IsDir() {
+				if err := linkMissingClaudeEntries(projectDir, mainEntry, wtEntry, rel); err != nil {
+					return err
+				}
+			}
+			// Anything else already present in the worktree is left untouched.
+			continue
+		}
+		if !os.IsNotExist(statErr) {
+			return fmt.Errorf("stat %s: %w", wtEntry, statErr)
+		}
+
+		if err := os.Symlink(mainEntry, wtEntry); err != nil {
+			return fmt.Errorf("link %s: %w", rel, err)
+		}
+		// Exclude just this path, not all of .claude, so new files an agent adds
+		// under a tracked .claude are still visible to git.
+		ensureGitExclude(projectDir, "/"+rel)
+	}
 
 	return nil
 }

--- a/internal/executor/worktree_claude_config_test.go
+++ b/internal/executor/worktree_claude_config_test.go
@@ -1,0 +1,177 @@
+package executor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests cover symlinkClaudeConfig against a real git repo + worktree, because
+// the whole point of the function is how its filesystem layout interacts with git's
+// view of the worktree. The failure mode being guarded against is a worktree whose
+// branch tracks content under .claude: replacing that directory with a symlink to the
+// main project makes every tracked file show up as deleted, and agents then commit
+// the deletion.
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// newClaudeConfigRepo builds a project repo whose initial commit contains the given
+// tracked files, then adds a worktree on a fresh branch. Returns both paths.
+func newClaudeConfigRepo(t *testing.T, tracked map[string]string) (projectDir, worktreePath string) {
+	t.Helper()
+	root := t.TempDir()
+	projectDir = filepath.Join(root, "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	gitRun(t, projectDir, "init", "-b", "main")
+	gitRun(t, projectDir, "config", "user.email", "test@example.com")
+	gitRun(t, projectDir, "config", "user.name", "Test User")
+	gitRun(t, projectDir, "config", "commit.gpgsign", "false")
+
+	writeFile(t, filepath.Join(projectDir, "README.md"), "seed\n")
+	for rel, content := range tracked {
+		writeFile(t, filepath.Join(projectDir, rel), content)
+	}
+	gitRun(t, projectDir, "add", "-A")
+	gitRun(t, projectDir, "commit", "-m", "init")
+
+	worktreePath = filepath.Join(root, "wt")
+	gitRun(t, projectDir, "worktree", "add", worktreePath, "-b", "task/1")
+	return projectDir, worktreePath
+}
+
+// assertWorktreeClean fails if git reports any change in the worktree. A tracked
+// .claude file showing as deleted is exactly the bug under test.
+func assertWorktreeClean(t *testing.T, worktreePath string) {
+	t.Helper()
+	status := gitRun(t, worktreePath, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Errorf("worktree should be clean, got:\n%s", status)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("%s = %q, want %q", path, got, want)
+	}
+}
+
+// When the branch tracks nothing under .claude, the worktree keeps inheriting the
+// project's config wholesale via a symlink — the original behavior.
+func TestSymlinkClaudeConfigUntrackedUsesSymlink(t *testing.T) {
+	projectDir, worktreePath := newClaudeConfigRepo(t, nil)
+	writeFile(t, filepath.Join(projectDir, ".claude", "settings.local.json"), `{"local":true}`)
+
+	if err := symlinkClaudeConfig(projectDir, worktreePath); err != nil {
+		t.Fatalf("symlinkClaudeConfig: %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(worktreePath, ".claude"))
+	if err != nil {
+		t.Fatalf("worktree .claude should be a symlink: %v", err)
+	}
+	if want := filepath.Join(projectDir, ".claude"); target != want {
+		t.Errorf("symlink target = %q, want %q", target, want)
+	}
+	assertWorktreeClean(t, worktreePath)
+}
+
+// The bug this PR fixes: tracked .claude content must survive worktree setup.
+func TestSymlinkClaudeConfigPreservesTrackedContent(t *testing.T) {
+	projectDir, worktreePath := newClaudeConfigRepo(t, map[string]string{
+		".claude/skills/demo.md": "tracked skill\n",
+	})
+
+	if err := symlinkClaudeConfig(projectDir, worktreePath); err != nil {
+		t.Fatalf("symlinkClaudeConfig: %v", err)
+	}
+
+	if _, err := os.Readlink(filepath.Join(worktreePath, ".claude")); err == nil {
+		t.Fatal("worktree .claude was replaced by a symlink, deleting tracked content")
+	}
+	assertFileContent(t, filepath.Join(worktreePath, ".claude", "skills", "demo.md"), "tracked skill\n")
+	assertWorktreeClean(t, worktreePath)
+}
+
+// Partial tracking is the common case (".claude/*" plus "!.claude/settings.json").
+// Tracked files must survive AND the project's local-only config must still reach
+// the worktree, or the executor silently loses hooks, agents and local settings.
+func TestSymlinkClaudeConfigPartialTrackingLinksLocalEntries(t *testing.T) {
+	projectDir, worktreePath := newClaudeConfigRepo(t, map[string]string{
+		".claude/settings.json":    `{"tracked":true}`,
+		".claude/skills/shared.md": "tracked skill\n",
+	})
+	// Local-only config living alongside the tracked files in the main project.
+	writeFile(t, filepath.Join(projectDir, ".claude", "settings.local.json"), `{"local":true}`)
+	writeFile(t, filepath.Join(projectDir, ".claude", "skills", "private.md"), "local skill\n")
+
+	if err := symlinkClaudeConfig(projectDir, worktreePath); err != nil {
+		t.Fatalf("symlinkClaudeConfig: %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(worktreePath, ".claude", "settings.json"), `{"tracked":true}`)
+	assertFileContent(t, filepath.Join(worktreePath, ".claude", "skills", "shared.md"), "tracked skill\n")
+	// Local entries are reachable from the worktree, including inside a directory
+	// that also holds tracked files.
+	assertFileContent(t, filepath.Join(worktreePath, ".claude", "settings.local.json"), `{"local":true}`)
+	assertFileContent(t, filepath.Join(worktreePath, ".claude", "skills", "private.md"), "local skill\n")
+	// The links must not pollute git status.
+	assertWorktreeClean(t, worktreePath)
+}
+
+// A worktree already damaged by the previous behavior (.claude replaced by a symlink)
+// must heal on the next setup pass. git ls-files reads the index, so the tracked
+// files are still listed even though the working tree has lost them.
+func TestSymlinkClaudeConfigRepairsStaleSymlink(t *testing.T) {
+	projectDir, worktreePath := newClaudeConfigRepo(t, map[string]string{
+		".claude/skills/demo.md": "tracked skill\n",
+	})
+	writeFile(t, filepath.Join(projectDir, ".claude", "settings.local.json"), `{"local":true}`)
+
+	// Reproduce the damage the old code caused.
+	worktreeClaudeDir := filepath.Join(worktreePath, ".claude")
+	if err := os.RemoveAll(worktreeClaudeDir); err != nil {
+		t.Fatalf("remove worktree .claude: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(projectDir, ".claude"), worktreeClaudeDir); err != nil {
+		t.Fatalf("symlink worktree .claude: %v", err)
+	}
+
+	if err := symlinkClaudeConfig(projectDir, worktreePath); err != nil {
+		t.Fatalf("symlinkClaudeConfig: %v", err)
+	}
+
+	if _, err := os.Readlink(worktreeClaudeDir); err == nil {
+		t.Fatal("stale .claude symlink was left in place, tracked content still missing")
+	}
+	assertFileContent(t, filepath.Join(worktreeClaudeDir, "skills", "demo.md"), "tracked skill\n")
+	assertWorktreeClean(t, worktreePath)
+}


### PR DESCRIPTION
## Summary

- detect whether the worktree branch tracks content under `.claude`
- preserve the checked-out `.claude` directory when tracked instead of replacing it with a symlink
- retain the existing shared-config symlink behavior for projects that do not track `.claude`

This prevents TaskYou from marking tracked skill files as deleted when preparing a new worktree.

## Testing

Not run; this is a focused guard-only change.
