### PR TITLE
fix(executor): fall back to local branch when origin/<source-branch> is missing

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4471,20 +4471,35 @@ func (e *Executor) setupWorktree(task *db.Task) (string, bool, error) {
 
 	// Check if task specifies an existing source branch to checkout
 	if task.SourceBranch != "" {
-		// Fetch the latest from origin to ensure we have the branch
+		// Best-effort fetch so we pick up any pushed updates to the branch. A
+		// fetch failure must NOT be fatal: repos with no remote (or an offline
+		// remote) can still resolve the branch locally, and pipelines whose
+		// early steps are document phases build the shared branch locally and
+		// never push it.
 		fetchCmd := exec.Command("git", "fetch", "origin")
 		fetchCmd.Dir = projectDir
 		if fetchOutput, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
-			return "", false, fmt.Errorf("fetch origin: %v\n%s", fetchErr, string(fetchOutput))
+			e.logger.Warn("git fetch origin failed; will resolve source branch locally",
+				"task", task.ID, "branch", task.SourceBranch, "error", fetchErr, "output", string(fetchOutput))
 		}
 
-		// Create worktree from existing remote branch (no -b flag)
-		remoteBranch := "origin/" + task.SourceBranch
-		cmd := exec.Command("git", "worktree", "add", worktreePath, remoteBranch)
+		// Resolve the source branch to a checkout-able ref. Prefer the
+		// remote-tracking ref (origin/<branch>) so pushed updates win, but fall
+		// back to a local branch of the same name. Without the local fallback, a
+		// pipeline whose first steps are document phases fails here on the first
+		// code step with `fatal: invalid reference: origin/<branch>` (the shared
+		// branch exists only locally), and the task loops on spawn forever.
+		ref, resolveErr := e.resolveSourceBranchRef(projectDir, task.SourceBranch)
+		if resolveErr != nil {
+			return "", false, resolveErr
+		}
+
+		// Create worktree from the resolved branch ref (no -b flag).
+		cmd := exec.Command("git", "worktree", "add", worktreePath, ref)
 		cmd.Dir = projectDir
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "", false, fmt.Errorf("create worktree from branch %s: %v\n%s", task.SourceBranch, err, string(output))
+			return "", false, fmt.Errorf("create worktree from branch %s (ref %s): %v\n%s", task.SourceBranch, ref, err, string(output))
 		}
 
 		// Use the source branch name as the branch name for the task
@@ -5486,6 +5501,30 @@ func (e *Executor) ensureGitignore(projectDir, entry string) {
 		f.WriteString("\n")
 	}
 	f.WriteString(entry + "\n")
+}
+
+// resolveSourceBranchRef returns a git ref for an existing source branch that a
+// worktree can be created from. It prefers the remote-tracking ref
+// (origin/<branch>) so pushed updates win, then falls back to a local branch of
+// the same name. This local fallback is what keeps document-first pipelines
+// working: their early steps create the shared branch locally and never push
+// it, so origin/<branch> does not exist when the first code step sets up its
+// worktree. Returns an error only when the branch exists in neither place.
+func (e *Executor) resolveSourceBranchRef(projectDir, sourceBranch string) (string, error) {
+	refExists := func(ref string) bool {
+		cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref)
+		cmd.Dir = projectDir
+		return cmd.Run() == nil
+	}
+
+	remoteRef := "origin/" + sourceBranch
+	if refExists("refs/remotes/" + remoteRef) {
+		return remoteRef, nil
+	}
+	if refExists("refs/heads/" + sourceBranch) {
+		return sourceBranch, nil
+	}
+	return "", fmt.Errorf("source branch %s not found on origin or locally", sourceBranch)
 }
 
 // getDefaultBranch returns the default branch name for a git repo.

--- a/internal/executor/worktree_source_branch_test.go
+++ b/internal/executor/worktree_source_branch_test.go
@@ -1,0 +1,77 @@
+package executor
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// git runs a git command in dir and fails the test on error.
+func gitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+// initRepo creates a git repo with one commit on a `main` branch.
+func initRepo(t *testing.T, dir string) {
+	t.Helper()
+	gitIn(t, dir, "init", "-q", "-b", "main")
+	gitIn(t, dir, "config", "user.email", "test@example.com")
+	gitIn(t, dir, "config", "user.name", "Test")
+	gitIn(t, dir, "commit", "-q", "--allow-empty", "-m", "initial")
+}
+
+func TestResolveSourceBranchRef(t *testing.T) {
+	e := &Executor{}
+
+	t.Run("falls back to a local-only branch (document-first pipeline)", func(t *testing.T) {
+		dir := t.TempDir()
+		initRepo(t, dir)
+		// Shared pipeline branch exists locally but was never pushed to origin.
+		gitIn(t, dir, "branch", "pipeline/4887-shared")
+
+		ref, err := e.resolveSourceBranchRef(dir, "pipeline/4887-shared")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref != "pipeline/4887-shared" {
+			t.Errorf("ref = %q, want local branch %q", ref, "pipeline/4887-shared")
+		}
+	})
+
+	t.Run("prefers origin/<branch> when the remote-tracking ref exists", func(t *testing.T) {
+		remote := t.TempDir()
+		gitIn(t, remote, "init", "-q", "--bare", "-b", "main")
+
+		dir := t.TempDir()
+		initRepo(t, dir)
+		gitIn(t, dir, "remote", "add", "origin", remote)
+		// Push a branch and establish the remote-tracking ref, then also keep a
+		// local branch of the same name so both refs are resolvable.
+		gitIn(t, dir, "branch", "feature/pushed")
+		gitIn(t, dir, "push", "-q", "origin", "feature/pushed")
+		gitIn(t, dir, "fetch", "-q", "origin")
+
+		ref, err := e.resolveSourceBranchRef(dir, "feature/pushed")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref != "origin/feature/pushed" {
+			t.Errorf("ref = %q, want remote-tracking ref %q", ref, "origin/feature/pushed")
+		}
+	})
+
+	t.Run("errors when the branch exists nowhere", func(t *testing.T) {
+		dir := t.TempDir()
+		initRepo(t, dir)
+
+		if _, err := e.resolveSourceBranchRef(dir, "pipeline/does-not-exist"); err == nil {
+			t.Fatal("expected an error for a branch that exists neither on origin nor locally")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Pipelines whose **first steps are document phases** (research → design → structure-outline) build the shared `pipeline/<root-id>-…` branch **locally and never push it**. When the first `code` step sets up its worktree, `setupWorktree`'s `SourceBranch` path hard-coded `origin/<branch>` with no fallback:

```
Failed to setup worktree: create worktree from branch pipeline/4887-…: exit status 128
fatal: invalid reference: origin/pipeline/4887-…
```

Spawn fails, the daemon leaves the task `processing` with no live executor, restarts, stamps it `blocked`, and retries — an endless loop that **restarts Claude every round**. (Seen live on task #4891, pipeline root #4887; previously #4895/#4896.)

## Fix

- New helper `resolveSourceBranchRef` resolves the source branch to a checkout-able ref: **prefer `origin/<branch>`** (pushed updates still win), then **fall back to a local branch of the same name**. Errors only if the branch exists in neither place.
- The pre-checkout `git fetch origin` is now **non-fatal** — repos with no/offline remote can still resolve locally.

## Test

`internal/executor/worktree_source_branch_test.go` covers local-only fallback, origin preference, and not-found. Full `internal/executor` suite + `go vet` pass.

## Notes

- Live-stalled tasks still need the manual recovery (`git push -u origin <branch>` in the project repo, then `ty retry <id>`) until this ships in the running daemon binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)