### PR TITLE
feat(cli): add `ty artifact` so workflow handoff never depends on MCP

### DIFF
--- a/cmd/task/artifact.go
+++ b/cmd/task/artifact.go
@@ -7,9 +7,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/pipeline"
-	"github.com/spf13/cobra"
 )
 
 // Workflow phases hand documents to each other through the pipeline artifact

--- a/cmd/task/artifact.go
+++ b/cmd/task/artifact.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+// Workflow phases hand documents to each other through the pipeline artifact
+// store. That store was reachable only through the taskyou_* MCP tools, so any
+// break in the MCP transport (a stale binary launched without --mcp-config, a
+// worktree project-key mismatch) left an executor with no sanctioned way to
+// finish its phase — agents resorted to hand-writing pipeline_artifacts rows
+// with sqlite3. These commands expose the same store over the CLI, which is
+// always on PATH and needs no session wiring, so a phase can always complete.
+//
+// Semantics deliberately mirror the MCP tools: the branch key is derived from
+// the task itself via pipeline.GroupKey (never client-supplied), and a missing
+// artifact reads as empty rather than erroring.
+
+// resolveArtifactTask loads the task an artifact command applies to, resolving
+// the ID from --task-id or the WORKTREE_TASK_ID env var that ty writes into
+// every worktree's .envrc, and returns it with its workflow branch key.
+func resolveArtifactTask(cmd *cobra.Command, database *db.DB) (*db.Task, string, error) {
+	taskID, _ := cmd.Flags().GetInt64("task-id")
+	if taskID == 0 {
+		if s := strings.TrimSpace(os.Getenv("WORKTREE_TASK_ID")); s != "" {
+			parsed, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return nil, "", fmt.Errorf("invalid WORKTREE_TASK_ID: %s", s)
+			}
+			taskID = parsed
+		}
+	}
+	if taskID == 0 {
+		return nil, "", fmt.Errorf("task-id is required (via --task-id flag or WORKTREE_TASK_ID env)")
+	}
+
+	task, err := database.GetTask(taskID)
+	if err != nil || task == nil {
+		return nil, "", fmt.Errorf("task #%d not found", taskID)
+	}
+
+	branch := pipeline.GroupKey(task)
+	if branch == "" {
+		return nil, "", fmt.Errorf("task #%d is not part of a workflow — artifacts are only available inside a pipeline", taskID)
+	}
+	return task, branch, nil
+}
+
+// readArtifactContent takes the content for `artifact set` from --content, from
+// --file, or from stdin. Stdin is the default so an agent can pipe a whole
+// document without hitting shell argument limits or quoting problems.
+func readArtifactContent(cmd *cobra.Command) (string, error) {
+	if content, _ := cmd.Flags().GetString("content"); content != "" {
+		return content, nil
+	}
+	if path, _ := cmd.Flags().GetString("file"); path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", path, err)
+		}
+		return string(data), nil
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return string(data), nil
+}
+
+func newArtifactCmd() *cobra.Command {
+	artifactCmd := &cobra.Command{
+		Use:   "artifact",
+		Short: "Read and write workflow phase documents (pipeline artifacts)",
+		Long: "Read and write the documents workflow phases hand to each other.\n\n" +
+			"This is the CLI equivalent of the taskyou_get_artifact / taskyou_set_artifact\n" +
+			"MCP tools, for use when the MCP server is unavailable. The artifact is scoped\n" +
+			"to the workflow branch of the task, resolved from --task-id or WORKTREE_TASK_ID.",
+	}
+
+	artifactGetCmd := &cobra.Command{
+		Use:   "get [name]",
+		Short: "Read a workflow artifact (omit name to list all with contents)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			database, err := openTaskDB(db.DefaultPath())
+			if err != nil {
+				return err
+			}
+			defer database.Close()
+
+			_, branch, err := resolveArtifactTask(cmd, database)
+			if err != nil {
+				return err
+			}
+
+			if len(args) == 1 && strings.TrimSpace(args[0]) != "" {
+				name := strings.TrimSpace(args[0])
+				content, err := database.GetPipelineArtifact(branch, name)
+				if err != nil {
+					return err
+				}
+				if content == "" {
+					return fmt.Errorf("no artifact named %q has been produced by this workflow yet", name)
+				}
+				fmt.Print(content)
+				if !strings.HasSuffix(content, "\n") {
+					fmt.Println()
+				}
+				return nil
+			}
+
+			artifacts, err := database.ListPipelineArtifacts(branch)
+			if err != nil {
+				return err
+			}
+			if len(artifacts) == 0 {
+				return fmt.Errorf("no artifacts have been produced by this workflow yet")
+			}
+			for i, a := range artifacts {
+				if i > 0 {
+					fmt.Println()
+				}
+				fmt.Printf("## Artifact: %s\n\n%s\n", a.Name, a.Content)
+			}
+			return nil
+		},
+	}
+
+	artifactSetCmd := &cobra.Command{
+		Use:   "set <name>",
+		Short: "Save a workflow artifact (content from --content, --file, or stdin)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+			if name == "" {
+				return fmt.Errorf("artifact name is required")
+			}
+
+			database, err := openTaskDB(db.DefaultPath())
+			if err != nil {
+				return err
+			}
+			defer database.Close()
+
+			task, branch, err := resolveArtifactTask(cmd, database)
+			if err != nil {
+				return err
+			}
+
+			content, err := readArtifactContent(cmd)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(content) == "" {
+				return fmt.Errorf("content is required (pass --content, --file, or pipe to stdin)")
+			}
+
+			if err := database.SetPipelineArtifact(branch, name, content); err != nil {
+				return err
+			}
+			// Mirror the MCP tool's log line so the activity feed reads the same
+			// whichever transport the phase used.
+			database.AppendTaskLog(task.ID, "system", fmt.Sprintf("Workflow artifact '%s' saved (%d bytes)", name, len(content)))
+			fmt.Printf("Artifact '%s' saved (%d bytes). Later phases can read it with: ty artifact get %s\n", name, len(content), name)
+			return nil
+		},
+	}
+
+	artifactListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List workflow artifact names and sizes",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			database, err := openTaskDB(db.DefaultPath())
+			if err != nil {
+				return err
+			}
+			defer database.Close()
+
+			_, branch, err := resolveArtifactTask(cmd, database)
+			if err != nil {
+				return err
+			}
+			artifacts, err := database.ListPipelineArtifacts(branch)
+			if err != nil {
+				return err
+			}
+			if len(artifacts) == 0 {
+				fmt.Println("No artifacts have been produced by this workflow yet.")
+				return nil
+			}
+			for _, a := range artifacts {
+				fmt.Printf("%-24s %8d bytes  %s\n", a.Name, len(a.Content), a.UpdatedAt.Format("2006-01-02 15:04:05"))
+			}
+			return nil
+		},
+	}
+
+	for _, c := range []*cobra.Command{artifactGetCmd, artifactSetCmd, artifactListCmd} {
+		c.Flags().Int64("task-id", 0, "Task ID (defaults to WORKTREE_TASK_ID)")
+	}
+	artifactSetCmd.Flags().String("content", "", "Artifact content (otherwise --file or stdin)")
+	artifactSetCmd.Flags().String("file", "", "Read artifact content from this file")
+
+	artifactCmd.AddCommand(artifactGetCmd, artifactSetCmd, artifactListCmd)
+	return artifactCmd
+}

--- a/cmd/task/artifact_test.go
+++ b/cmd/task/artifact_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// artifactTestEnv points the CLI at a temp DB (DefaultPath honors
+// WORKTREE_DB_PATH) holding one workflow task, and returns that task's ID.
+func artifactTestEnv(t *testing.T, task *db.Task) int64 {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "tasks.db")
+	t.Setenv("WORKTREE_DB_PATH", dbPath)
+
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	return task.ID
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+func runArtifact(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := newArtifactCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	return cmd.Execute()
+}
+
+func TestArtifactSetGetRoundTrip(t *testing.T) {
+	// A workflow step carries its shared branch as SourceBranch.
+	id := artifactTestEnv(t, &db.Task{
+		Title:        "[design] something",
+		Project:      "personal",
+		Tags:         "pipeline",
+		SourceBranch: "pipeline/100-shared",
+	})
+	t.Setenv("WORKTREE_TASK_ID", "")
+
+	body := "# Design\n\nThe full document.\n"
+	if err := runArtifact(t, "set", "design", "--task-id", itoa(id), "--content", body); err != nil {
+		t.Fatalf("artifact set: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runArtifact(t, "get", "design", "--task-id", itoa(id)); err != nil {
+			t.Fatalf("artifact get: %v", err)
+		}
+	})
+	if !strings.Contains(out, "The full document.") {
+		t.Errorf("get output missing content, got: %q", out)
+	}
+}
+
+func TestArtifactResolvesTaskIDFromEnv(t *testing.T) {
+	id := artifactTestEnv(t, &db.Task{
+		Title:        "[plan] something",
+		Project:      "personal",
+		Tags:         "pipeline",
+		SourceBranch: "pipeline/200-shared",
+	})
+	// No --task-id: the worktree's WORKTREE_TASK_ID must be picked up, which is
+	// what lets an agent call `ty artifact ...` with no arguments in its worktree.
+	t.Setenv("WORKTREE_TASK_ID", itoa(id))
+
+	if err := runArtifact(t, "set", "plan", "--content", "planned"); err != nil {
+		t.Fatalf("artifact set via env: %v", err)
+	}
+	out := captureStdout(t, func() {
+		if err := runArtifact(t, "get", "plan"); err != nil {
+			t.Fatalf("artifact get via env: %v", err)
+		}
+	})
+	if !strings.Contains(out, "planned") {
+		t.Errorf("expected content via env task id, got %q", out)
+	}
+}
+
+func TestArtifactSetOverwrites(t *testing.T) {
+	id := artifactTestEnv(t, &db.Task{
+		Title: "[design] x", Project: "personal", Tags: "pipeline",
+		SourceBranch: "pipeline/300-shared",
+	})
+	t.Setenv("WORKTREE_TASK_ID", itoa(id))
+
+	if err := runArtifact(t, "set", "design", "--content", "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runArtifact(t, "set", "design", "--content", "second"); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStdout(t, func() {
+		if err := runArtifact(t, "get", "design"); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if strings.Contains(out, "first") || !strings.Contains(out, "second") {
+		t.Errorf("expected overwrite to 'second', got %q", out)
+	}
+}
+
+func TestArtifactSetFromFile(t *testing.T) {
+	id := artifactTestEnv(t, &db.Task{
+		Title: "[research] x", Project: "personal", Tags: "pipeline",
+		SourceBranch: "pipeline/400-shared",
+	})
+	t.Setenv("WORKTREE_TASK_ID", itoa(id))
+
+	path := filepath.Join(t.TempDir(), "doc.md")
+	if err := os.WriteFile(path, []byte("from a file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runArtifact(t, "set", "research", "--file", path); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+	out := captureStdout(t, func() {
+		if err := runArtifact(t, "get", "research"); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "from a file") {
+		t.Errorf("expected file content, got %q", out)
+	}
+}
+
+func TestArtifactRejectsNonWorkflowTask(t *testing.T) {
+	// No SourceBranch/BranchName => not part of a workflow. Must fail loudly
+	// rather than silently writing to an empty branch key.
+	id := artifactTestEnv(t, &db.Task{Title: "plain task", Project: "personal"})
+	t.Setenv("WORKTREE_TASK_ID", itoa(id))
+
+	err := runArtifact(t, "set", "design", "--content", "x")
+	if err == nil || !strings.Contains(err.Error(), "not part of a workflow") {
+		t.Fatalf("expected not-a-workflow error, got %v", err)
+	}
+}
+
+func TestArtifactRequiresTaskID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "tasks.db")
+	t.Setenv("WORKTREE_DB_PATH", dbPath)
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database.Close()
+	t.Setenv("WORKTREE_TASK_ID", "")
+
+	err = runArtifact(t, "get", "design")
+	if err == nil || !strings.Contains(err.Error(), "task-id is required") {
+		t.Fatalf("expected task-id required error, got %v", err)
+	}
+}
+
+func TestArtifactGetMissingIsAnError(t *testing.T) {
+	id := artifactTestEnv(t, &db.Task{
+		Title: "[plan] x", Project: "personal", Tags: "pipeline",
+		SourceBranch: "pipeline/500-shared",
+	})
+	t.Setenv("WORKTREE_TASK_ID", itoa(id))
+
+	err := runArtifact(t, "get", "nope")
+	if err == nil || !strings.Contains(err.Error(), "no artifact named") {
+		t.Fatalf("expected missing-artifact error, got %v", err)
+	}
+}
+
+func TestArtifactIsScopedToItsOwnWorkflow(t *testing.T) {
+	// Two tasks on different pipeline branches must not see each other's docs.
+	dbPath := filepath.Join(t.TempDir(), "tasks.db")
+	t.Setenv("WORKTREE_DB_PATH", dbPath)
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &db.Task{Title: "a", Project: "personal", Tags: "pipeline", SourceBranch: "pipeline/aaa"}
+	b := &db.Task{Title: "b", Project: "personal", Tags: "pipeline", SourceBranch: "pipeline/bbb"}
+	if err := database.CreateTask(a); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.CreateTask(b); err != nil {
+		t.Fatal(err)
+	}
+	database.Close()
+
+	t.Setenv("WORKTREE_TASK_ID", itoa(a.ID))
+	if err := runArtifact(t, "set", "design", "--content", "A-only"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("WORKTREE_TASK_ID", itoa(b.ID))
+	if err := runArtifact(t, "get", "design"); err == nil {
+		t.Fatal("workflow B must not read workflow A's artifact")
+	}
+}
+
+func itoa(i int64) string { return strconv.FormatInt(i, 10) }

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -524,6 +524,11 @@ Examples:
 	// Plugins subcommand - inspect installed task plugins
 	rootCmd.AddCommand(newPluginsCmd())
 
+	// Workflow artifact store over the CLI — the transport-independent twin of the
+	// taskyou_get_artifact/taskyou_set_artifact MCP tools, so a workflow phase can
+	// always hand off even when the MCP server didn't attach to its session.
+	rootCmd.AddCommand(newArtifactCmd())
+
 	// Alias: claudes -> sessions (for backwards compatibility)
 	claudesCmd := &cobra.Command{
 		Use:    "claudes",

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2194,7 +2194,13 @@ func (e *Executor) buildPrompt(task *db.Task, attachmentPaths []string) string {
 func (e *Executor) buildUniversalGuidance(task *db.Task) string {
 	var b strings.Builder
 
-	b.WriteString(`Your taskyou_* tools (via the "taskyou" MCP server) are connected to this session, but your harness may DEFER them behind tool search instead of loading them upfront. If you do not see a taskyou_* tool in your active toolset, it is deferred, NOT missing — load it before use (e.g. ToolSearch "select:taskyou_complete") and then call it. Never conclude "the taskyou server isn't connected" or skip a required taskyou_* call without first trying to load the tool; the server is always present for a task you are executing.`)
+	b.WriteString(`Your taskyou_* tools (via the "taskyou" MCP server) are connected to this session, but your harness may DEFER them behind tool search instead of loading them upfront. If you do not see a taskyou_* tool in your active toolset, it is deferred, NOT missing — load it before use (e.g. ToolSearch "select:taskyou_complete") and then call it. Never skip a required taskyou_* call without first trying to load the tool.
+
+If a taskyou_* tool still is not callable after you tried to load it, the MCP transport is genuinely down — do NOT stall, do NOT wait for a human, and do NOT hand-edit ty's database. Fall back to the ` + "`ty`" + ` CLI, which is always on PATH and needs no MCP session:
+- Read a workflow document:  ty artifact get <name>
+- List them:                 ty artifact list
+- Save your phase's output:  ty artifact set <name> --file <path>   (or pipe the document to stdin)
+These are exact equivalents of taskyou_get_artifact / taskyou_set_artifact and write the same store, so a later phase reads your work normally. They resolve the task from WORKTREE_TASK_ID in your worktree, so no --task-id is needed.`)
 
 	b.WriteString(`
 


### PR DESCRIPTION
## Problem

The pipeline artifact store — how one workflow phase hands its document to the next — was reachable **only** through the `taskyou_*` MCP tools. Any break in the MCP transport left an executor with no sanctioned way to finish its phase.

Seen repeatedly in production today:
- A daemon binary built without `--mcp-config` (#665 regressed by a rebuild from a stale checkout) → executors had no `taskyou_*` tools at all.
- Claude 2.1's worktree project-key resolution silently ignoring the `~/.claude.json` injection.

The agent's only options were to **stall waiting for a human** (task 4905 sat idle asking to be pinged) or **hand-write `pipeline_artifacts` rows with sqlite3** (task 4891 did exactly that). Neither is acceptable for a workflow that should "just work."

## Fix

Add `ty artifact get|set|list` — the transport-independent twin of `taskyou_get_artifact`/`taskyou_set_artifact`. The CLI is always on PATH and needs no session wiring.

Semantics deliberately mirror the MCP tools:
- Branch key derived from the task via `pipeline.GroupKey` — **never client-supplied**, so an artifact stays scoped to its own workflow.
- Task resolves from `--task-id` or the `WORKTREE_TASK_ID` ty already writes into every worktree's `.envrc` (so an agent needs no arguments in its worktree).
- `db.DefaultPath()` honors `WORKTREE_DB_PATH`, so isolated instances hit the right DB.
- Content from `--content`, `--file`, or stdin (stdin avoids arg-limit/quoting problems for large documents).
- Emits the same `Workflow artifact 'x' saved` task log, so the activity feed reads identically whichever transport was used.

Also updates the universal agent guidance: rather than insisting the MCP server is always present, it now tells the agent to fall back to the CLI when a `taskyou_*` tool is genuinely uncallable — explicitly *"do not stall, do not wait for a human, do not hand-edit the database."*

## Scope note

`taskyou_complete` still runs the `verify:` evidence gate and the gate/DAG-advancement logic inside the MCP handler. Exposing that over the CLI is a **separate refactor** and is deliberately not done here — a bug in that path would silently skip human gates or corrupt pipeline state.

## Test

8 tests in `cmd/task/artifact_test.go` driving the real cobra commands against a temp DB: round-trip, env-var task resolution, overwrite, `--file`, non-workflow rejection, missing task-id, missing artifact, and cross-workflow scoping isolation. `go vet` clean; `cmd/task`, `internal/{executor,pipeline,db,mcp}` all pass.

Verified against live production data — `ty artifact list` correctly reads both stalled pipelines' real artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)