### PR TITLE
feat: extract completion into internal/completion; add 

### DIFF
--- a/cmd/task/complete.go
+++ b/cmd/task/complete.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bborn/workflow/internal/completion"
+	"github.com/bborn/workflow/internal/db"
+)
+
+// `ty close` is a plain status write. Finishing a task correctly is not: a step
+// may have an evidence gate that can REJECT the completion, a human-review gate
+// that must park instead of advancing the workflow, and a PR that must wait for
+// a human merge. Those rules lived only behind the taskyou_complete MCP tool, so
+// an agent whose MCP transport was down had no correct way to finish — and
+// reaching for `ty close` silently skipped every one of them.
+//
+// `ty complete` runs the exact same decision (internal/completion.Complete) over
+// the CLI. It is the completion twin of `ty artifact`.
+
+func newCompleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "complete [task-id]",
+		Short: "Complete a task the same way taskyou_complete does (gates, PR routing and all)",
+		Long: "Signal that a task is finished.\n\n" +
+			"Unlike `ty close` (a plain status write), this runs the full completion\n" +
+			"decision: any configured verify command must pass, a human-review gate parks\n" +
+			"for approval instead of advancing the workflow, and a task with a PR parks for\n" +
+			"a human merge. This is the CLI equivalent of the taskyou_complete MCP tool,\n" +
+			"for use when the MCP server is unavailable.\n\n" +
+			"The task defaults to WORKTREE_TASK_ID, so an agent can call it with no arguments\n" +
+			"inside its worktree.",
+		Args: cobra.MaximumNArgs(1),
+		// A rejected completion is a legitimate runtime outcome, not a usage error:
+		// without these, cobra dumps the full help text and re-prints the error on
+		// top of the detailed explanation below (root's Execute already prints it
+		// once and exits non-zero).
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var taskID int64
+			if len(args) == 1 {
+				parsed, err := strconv.ParseInt(strings.TrimPrefix(strings.TrimSpace(args[0]), "#"), 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid task id: %s", args[0])
+				}
+				taskID = parsed
+			} else if s := strings.TrimSpace(os.Getenv("WORKTREE_TASK_ID")); s != "" {
+				parsed, err := strconv.ParseInt(s, 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid WORKTREE_TASK_ID: %s", s)
+				}
+				taskID = parsed
+			}
+			if taskID == 0 {
+				return fmt.Errorf("task id is required (pass it, or set WORKTREE_TASK_ID)")
+			}
+
+			summary, _ := cmd.Flags().GetString("summary")
+			if strings.TrimSpace(summary) == "" {
+				return fmt.Errorf("--summary is required (one paragraph: what was done, PR link, follow-ups)")
+			}
+
+			database, err := openTaskDB(db.DefaultPath())
+			if err != nil {
+				return err
+			}
+			defer database.Close()
+
+			// A short-lived CLI process must generate the activity summary inline —
+			// a background goroutine would be killed when the process exits.
+			outcome, err := completion.Complete(database, taskID, summary, completion.Options{AsyncSummary: false})
+			if err != nil {
+				return err
+			}
+			waitForEventHooks()
+
+			switch outcome.Kind {
+			case completion.KindVerifyFailed:
+				// Exit non-zero: the task is deliberately still running, and a caller
+				// scripting this must be able to tell that completion was refused.
+				fmt.Fprintf(os.Stderr, "%s\n\n%s\n    %s\n",
+					errorStyle.Render("✗ Verification failed — this task is NOT complete."),
+					"The configured check exited non-zero, so completion was rejected:",
+					outcome.VerifyCommand)
+				// Only show the output section when the check actually printed something
+				// — an empty "--- verify output ---" block reads like truncation.
+				if out := strings.TrimSpace(outcome.VerifyOutput); out != "" {
+					fmt.Fprintf(os.Stderr, "\n--- verify output (tail) ---\n%s\n", out)
+				}
+				fmt.Fprintf(os.Stderr, "\n%s\n", dimStyle.Render("Fix the problem, then run ty complete again."))
+				return fmt.Errorf("completion rejected by verify command")
+			case completion.KindGateParked:
+				fmt.Println(successStyle.Render(fmt.Sprintf("Task #%d output saved.", taskID)))
+				fmt.Println("This is a human-review gate — it is now 'blocked' awaiting approval.")
+				fmt.Println(dimStyle.Render(fmt.Sprintf("Approve with: ty close %d   (releases the next phase)", taskID)))
+			case completion.KindPRReview:
+				fmt.Println(successStyle.Render(fmt.Sprintf("Task #%d finished — PR #%d is up for review.", taskID, outcome.PRNumber)))
+				if outcome.PRURL != "" {
+					fmt.Println(dimStyle.Render("  " + outcome.PRURL))
+				}
+				fmt.Println("It is now 'blocked' awaiting a human merge, and moves to 'done' automatically once the PR merges or closes.")
+			default:
+				fmt.Println(successStyle.Render(fmt.Sprintf("Task #%d marked done.", taskID)))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String("summary", "", "One-paragraph summary of what was accomplished (required)")
+	return cmd
+}

--- a/cmd/task/complete_test.go
+++ b/cmd/task/complete_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// buildTestRoot wires just the two commands whose names/aliases can collide.
+// Order matches main(): complete is registered before close.
+func buildTestRoot() *cobra.Command {
+	root := &cobra.Command{Use: "ty"}
+	root.AddCommand(newCompleteCmd())
+	root.AddCommand(&cobra.Command{
+		Use:     "close <task-id>",
+		Aliases: []string{"done"},
+		Short:   "Mark a task as done",
+		Run:     func(cmd *cobra.Command, args []string) {},
+	})
+	return root
+}
+
+// `ty complete` must resolve to the real completion command, never to `ty close`.
+// These are NOT interchangeable: close is a plain status write, while complete
+// runs the verify gate, parks human gates, and routes PRs. Cobra returns the
+// first name-or-alias match, so if `close` ever re-declares a "complete" alias
+// this silently starts depending on registration order — and an agent calling
+// `ty complete` would skip every gate.
+func TestCompleteResolvesToCompletionCommandNotClose(t *testing.T) {
+	root := buildTestRoot()
+
+	cmd, _, err := root.Find([]string{"complete"})
+	if err != nil {
+		t.Fatalf("find complete: %v", err)
+	}
+	if cmd.Name() != "complete" {
+		t.Fatalf("`ty complete` resolved to %q, want the completion command", cmd.Name())
+	}
+	if !strings.Contains(cmd.Short, "taskyou_complete") {
+		t.Errorf("resolved command is not the completion command: %q", cmd.Short)
+	}
+}
+
+// `ty close` and its remaining alias must still work — this change must not
+// break the human's way of approving a gate.
+func TestCloseAndDoneStillResolveToClose(t *testing.T) {
+	root := buildTestRoot()
+	for _, name := range []string{"close", "done"} {
+		cmd, _, err := root.Find([]string{name})
+		if err != nil {
+			t.Fatalf("find %s: %v", name, err)
+		}
+		if cmd.Name() != "close" {
+			t.Errorf("`ty %s` resolved to %q, want close", name, cmd.Name())
+		}
+	}
+}
+
+// The completion command must refuse to run without a summary — an empty
+// summary produces a useless activity log and, for a gate, gives the reviewing
+// human nothing to review.
+func TestCompleteRequiresSummary(t *testing.T) {
+	cmd := newCompleteCmd()
+	cmd.SetArgs([]string{"42"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "summary") {
+		t.Fatalf("expected a missing-summary error, got %v", err)
+	}
+}
+
+// With no argument and no WORKTREE_TASK_ID there is nothing to complete; it must
+// say so rather than defaulting to some arbitrary task.
+func TestCompleteRequiresTaskID(t *testing.T) {
+	t.Setenv("WORKTREE_TASK_ID", "")
+	cmd := newCompleteCmd()
+	cmd.SetArgs([]string{"--summary", "did the thing"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "task id is required") {
+		t.Fatalf("expected a missing-task-id error, got %v", err)
+	}
+}

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -533,6 +533,11 @@ Examples:
 	// and current position are readable without querying the DB by hand.
 	rootCmd.AddCommand(newWorkflowCmd())
 
+	// Completion over the CLI — runs the SAME decision as taskyou_complete
+	// (verify gate, human gate parking, PR routing), unlike `ty close` which is a
+	// plain status write that skips all of it.
+	rootCmd.AddCommand(newCompleteCmd())
+
 	// Alias: claudes -> sessions (for backwards compatibility)
 	claudesCmd := &cobra.Command{
 		Use:    "claudes",

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -2256,8 +2256,14 @@ Valid statuses: backlog, queued, processing, blocked, done, archived.`,
 	closeCmd := &cobra.Command{
 		Use:               "close <task-id>",
 		ValidArgsFunction: completeTaskIDs,
-		Aliases:           []string{"done", "complete"},
-		Short:             "Mark a task as done",
+		// "complete" is deliberately NOT an alias here: it belongs to the `ty
+		// complete` command, which runs the real completion decision (verify gate,
+		// human-gate parking, PR routing). Aliasing it onto this plain status write
+		// is precisely the trap that let finished-but-unverified work be marked done
+		// and human gates be skipped. Leaving both would also make resolution depend
+		// on registration order, since cobra returns the first name-or-alias match.
+		Aliases: []string{"done"},
+		Short:   "Mark a task as done",
 		Long: `Mark a task as completed.
 
 Examples:

--- a/internal/completion/complete.go
+++ b/internal/completion/complete.go
@@ -1,0 +1,181 @@
+// Package completion holds the one authoritative implementation of "this task is
+// finished".
+//
+// Completing a task is not a status write — it is a decision tree with real
+// consequences: an evidence gate that can REJECT the completion, a human-gate
+// step that must park for review instead of advancing the workflow DAG, and a
+// PR-bearing task that must wait for a human merge rather than being buried in
+// Done. That logic used to live inside the taskyou_complete MCP handler, which
+// made the MCP transport the only way to finish a task correctly — when it was
+// unavailable, agents reached for `ty close`, which is a plain status write and
+// silently skips every one of those rules.
+//
+// Both the MCP tool and the `ty complete` CLI now call Complete, so the two
+// cannot drift and neither can bypass a gate.
+package completion
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/github"
+	"github.com/bborn/workflow/internal/pipeline"
+	"github.com/bborn/workflow/internal/tasksummary"
+)
+
+// Kind is what completion actually did — the caller renders its own wording, but
+// the decision itself is made here, once.
+type Kind string
+
+const (
+	// KindVerifyFailed means the step's `verify:` command exited non-zero, so the
+	// completion was REJECTED and the task deliberately left running.
+	KindVerifyFailed Kind = "verify_failed"
+	// KindGateParked means a human-review gate finished and parked in 'blocked'
+	// awaiting approval, holding its dependents.
+	KindGateParked Kind = "gate_parked"
+	// KindPRReview means the task produced a PR and parked in 'blocked' awaiting a
+	// human merge (the daemon promotes it to 'done' once the PR closes).
+	KindPRReview Kind = "pr_review"
+	// KindDone means the task is genuinely finished and moved to 'done'.
+	KindDone Kind = "done"
+)
+
+// Outcome describes what Complete did, with the details a caller needs to
+// explain it.
+type Outcome struct {
+	Kind          Kind
+	VerifyCommand string // set when Kind == KindVerifyFailed
+	VerifyOutput  string // tail of the failing command's output
+	PRNumber      int    // set when Kind == KindPRReview
+	PRURL         string
+}
+
+// Options tunes side effects that differ between callers.
+type Options struct {
+	// AsyncSummary runs activity-summary generation in a background goroutine.
+	// The long-lived MCP server wants this (it must not block the agent); a
+	// short-lived CLI process must NOT, because the process exits and kills the
+	// goroutine before it can store anything.
+	AsyncSummary bool
+}
+
+// LookupPR returns the PR number and URL for a task's branch, or (0, "").
+//
+// It prefers a live `gh` lookup — an agent typically opens the PR moments before
+// completing, so the DB copy is stale — and persists a fresh result so the board
+// and the daemon reconciler both see it. Falls back to stored PR info.
+func LookupPR(database *db.DB, task *db.Task) (int, string) {
+	if task == nil {
+		return 0, ""
+	}
+	if task.BranchName != "" {
+		repoDir := task.WorktreePath
+		if repoDir == "" {
+			repoDir, _ = os.Getwd()
+		}
+		if info := github.NewPRCache().GetPRForBranch(repoDir, task.BranchName); info != nil {
+			_ = database.UpdateTaskPRInfo(task.ID, info.URL, info.Number, github.MarshalPRInfo(info))
+			return info.Number, info.URL
+		}
+	}
+	return task.PRNumber, task.PRURL
+}
+
+// Complete runs the full completion decision for a task and applies its effects.
+//
+// The order matters and is load-bearing:
+//  1. Evidence gate — a configured `verify:` command runs FIRST. Non-zero exit
+//     rejects the completion and leaves the task running so the agent can fix it.
+//     This is the backstop against completion-by-assertion; nothing below runs.
+//  2. A non-terminal human gate parks 'blocked' (its dependents stay held).
+//  3. A terminal task with a PR parks 'blocked' for the human merge.
+//  4. Otherwise the task is done.
+func Complete(database *db.DB, taskID int64, summary string, opts Options) (*Outcome, error) {
+	task, err := database.GetTask(taskID)
+	if err != nil || task == nil {
+		return nil, fmt.Errorf("task #%d not found", taskID)
+	}
+
+	// 1. Evidence gate. A step that registered a `verify:` command must pass it
+	// before completion is accepted — the agent's say-so alone is not trusted.
+	// Tasks with no verify row fall straight through.
+	if verifyCmd, _ := database.GetStepVerify(taskID); strings.TrimSpace(verifyCmd) != "" {
+		dir := strings.TrimSpace(task.WorktreePath)
+		if dir == "" {
+			if proj, err := database.GetProjectByName(task.Project); err == nil && proj != nil {
+				dir = proj.Path
+			}
+		}
+		if out, passed := pipeline.RunStepVerify(dir, verifyCmd); !passed {
+			database.AppendTaskLog(taskID, "system", "Verification failed — completion rejected; the step keeps running so the agent can fix it.")
+			return &Outcome{Kind: KindVerifyFailed, VerifyCommand: verifyCmd, VerifyOutput: out}, nil
+		}
+		database.AppendTaskLog(taskID, "system", "Verification passed: "+verifyCmd)
+	}
+
+	database.AppendTaskLog(taskID, "system", fmt.Sprintf("Task completed: %s", summary))
+
+	// A workflow step that still has dependents must ADVANCE the DAG, not park for
+	// review — only the terminal step opens a PR. The root step in particular owns
+	// the shared branch, which a PR lookup would otherwise mistake for "this task
+	// produced a PR", stalling the workflow at step one.
+	nonTerminalStep := false
+	if pipeline.IsWorkflowTask(task) {
+		if deps, err := database.GetBlockedBy(task.ID); err == nil && len(deps) > 0 {
+			nonTerminalStep = true
+		}
+	}
+
+	// 2. Human-review gate: park rather than advance. Leaving it 'blocked' (not
+	// 'done') keeps its dependents held until a human releases the chain.
+	if nonTerminalStep && pipeline.IsGateStep(task) {
+		if err := database.UpdateTaskStatus(taskID, db.StatusBlocked); err != nil {
+			return nil, fmt.Errorf("failed to park gate step for review: %w", err)
+		}
+		// Logged as a "question" so it lands in the blocked/needs-input lane and the
+		// daemon sweep leaves it for the human instead of auto-completing it.
+		database.AppendTaskLog(taskID, "question", pipeline.GateStepParkedLog)
+		return &Outcome{Kind: KindGateParked}, nil
+	}
+
+	// 3. PR-bearing terminal task: park for the human merge.
+	var prNumber int
+	var prURL string
+	if !nonTerminalStep {
+		prNumber, prURL = LookupPR(database, task)
+	}
+	if prNumber > 0 {
+		if err := database.UpdateTaskStatus(taskID, db.StatusBlocked); err != nil {
+			return nil, fmt.Errorf("failed to move task to review: %w", err)
+		}
+		reviewMsg := fmt.Sprintf("✅ PR #%d ready for review — merge or close it to complete this task.", prNumber)
+		if prURL != "" {
+			reviewMsg += " " + prURL
+		}
+		database.AppendTaskLog(taskID, "question", reviewMsg)
+		return &Outcome{Kind: KindPRReview, PRNumber: prNumber, PRURL: prURL}, nil
+	}
+
+	// 4. No PR — genuinely done.
+	if err := database.UpdateTaskStatus(taskID, db.StatusDone); err != nil {
+		return nil, fmt.Errorf("failed to mark task done: %w", err)
+	}
+
+	generate := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		_, _ = tasksummary.GenerateAndStore(ctx, database, taskID)
+	}
+	if opts.AsyncSummary {
+		go generate()
+	} else {
+		generate()
+	}
+
+	return &Outcome{Kind: KindDone}, nil
+}

--- a/internal/completion/complete_test.go
+++ b/internal/completion/complete_test.go
@@ -1,0 +1,258 @@
+package completion
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func testDB(t *testing.T) *db.DB {
+	t.Helper()
+	database, err := db.Open(filepath.Join(t.TempDir(), "tasks.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	if err := database.CreateProject(&db.Project{Name: "proj", Path: t.TempDir()}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	return database
+}
+
+func mkTask(t *testing.T, database *db.DB, title, status, tags, sourceBranch string) *db.Task {
+	t.Helper()
+	task := &db.Task{Title: title, Status: status, Project: "proj", Tags: tags, SourceBranch: sourceBranch}
+	if err := database.CreateTask(task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	return task
+}
+
+func statusOf(t *testing.T, database *db.DB, id int64) string {
+	t.Helper()
+	task, err := database.GetTask(id)
+	if err != nil || task == nil {
+		t.Fatalf("get task %d: %v", id, err)
+	}
+	return task.Status
+}
+
+// A failing verify command must REJECT the completion and leave the task
+// running. This is the backstop against completion-by-assertion: if it ever
+// regresses, agents can mark unbuilt work done.
+func TestVerifyFailureRejectsCompletion(t *testing.T) {
+	database := testDB(t)
+	task := mkTask(t, database, "build it", db.StatusProcessing, "", "")
+	if err := database.SetStepVerify(task.ID, "exit 1"); err != nil {
+		t.Fatalf("set verify: %v", err)
+	}
+
+	outcome, err := Complete(database, task.ID, "claimed done", Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Kind != KindVerifyFailed {
+		t.Fatalf("kind = %q, want %q", outcome.Kind, KindVerifyFailed)
+	}
+	// The crucial assertion: status is UNCHANGED, the task keeps running.
+	if got := statusOf(t, database, task.ID); got != db.StatusProcessing {
+		t.Errorf("status = %q, want it left at %q", got, db.StatusProcessing)
+	}
+	if outcome.VerifyCommand != "exit 1" {
+		t.Errorf("verify command = %q", outcome.VerifyCommand)
+	}
+}
+
+func TestVerifyPassAllowsCompletion(t *testing.T) {
+	database := testDB(t)
+	task := mkTask(t, database, "build it", db.StatusProcessing, "", "")
+	if err := database.SetStepVerify(task.ID, "true"); err != nil {
+		t.Fatalf("set verify: %v", err)
+	}
+
+	outcome, err := Complete(database, task.ID, "really done", Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Kind != KindDone {
+		t.Fatalf("kind = %q, want %q", outcome.Kind, KindDone)
+	}
+	if got := statusOf(t, database, task.ID); got != db.StatusDone {
+		t.Errorf("status = %q, want done", got)
+	}
+}
+
+// A human-review gate must PARK, never advance — and critically must not go to
+// 'done', because 'done' would release its dependents and skip the human.
+func TestGateStepParksAndHoldsDependents(t *testing.T) {
+	database := testDB(t)
+	branch := "pipeline/1-goal"
+	gate := mkTask(t, database, "[plan] goal", db.StatusProcessing, "pipeline,gate", branch)
+	next := mkTask(t, database, "[implement] goal", db.StatusBlocked, "pipeline", branch)
+	if err := database.AddDependency(gate.ID, next.ID, true); err != nil {
+		t.Fatalf("wire dependency: %v", err)
+	}
+
+	outcome, err := Complete(database, gate.ID, "planned", Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Kind != KindGateParked {
+		t.Fatalf("kind = %q, want %q", outcome.Kind, KindGateParked)
+	}
+	if got := statusOf(t, database, gate.ID); got != db.StatusBlocked {
+		t.Errorf("gate status = %q, want blocked (NOT done — done would release the chain)", got)
+	}
+	// The dependent must still be held.
+	if got := statusOf(t, database, next.ID); got != db.StatusBlocked {
+		t.Errorf("dependent status = %q, want it still blocked", got)
+	}
+}
+
+// A non-terminal, non-gate step must ADVANCE the DAG (go 'done'), even when it
+// carries a PR number — the root step owns the shared branch and can match a
+// spurious PR, which used to stall workflows at step one.
+func TestNonTerminalStepAdvancesDespitePR(t *testing.T) {
+	database := testDB(t)
+	branch := "pipeline/2-goal"
+	root := mkTask(t, database, "[research] goal", db.StatusProcessing, "pipeline", branch)
+	root.BranchName = branch
+	if err := database.UpdateTask(root); err != nil {
+		t.Fatalf("set branch: %v", err)
+	}
+	if err := database.UpdateTaskPRInfo(root.ID, "https://example.com/pull/7", 7, ""); err != nil {
+		t.Fatalf("seed spurious PR: %v", err)
+	}
+	next := mkTask(t, database, "[design] goal", db.StatusBlocked, "pipeline", branch)
+	if err := database.AddDependency(root.ID, next.ID, true); err != nil {
+		t.Fatalf("wire dependency: %v", err)
+	}
+
+	outcome, err := Complete(database, root.ID, "researched", Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Kind != KindDone {
+		t.Fatalf("kind = %q, want %q (must not park on a spurious PR)", outcome.Kind, KindDone)
+	}
+	if got := statusOf(t, database, root.ID); got != db.StatusDone {
+		t.Errorf("status = %q, want done", got)
+	}
+}
+
+// A terminal task carrying a PR parks for the human merge rather than being
+// buried in Done with an open PR.
+func TestTerminalTaskWithPRParksForReview(t *testing.T) {
+	database := testDB(t)
+	task := mkTask(t, database, "ship it", db.StatusProcessing, "", "")
+	task.BranchName = "feature/x"
+	if err := database.UpdateTask(task); err != nil {
+		t.Fatalf("set branch: %v", err)
+	}
+	if err := database.UpdateTaskPRInfo(task.ID, "https://example.com/pull/42", 42, ""); err != nil {
+		t.Fatalf("seed PR: %v", err)
+	}
+
+	outcome, err := Complete(database, task.ID, "opened a PR", Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Kind != KindPRReview {
+		t.Fatalf("kind = %q, want %q", outcome.Kind, KindPRReview)
+	}
+	if outcome.PRNumber != 42 {
+		t.Errorf("pr number = %d, want 42", outcome.PRNumber)
+	}
+	if got := statusOf(t, database, task.ID); got != db.StatusBlocked {
+		t.Errorf("status = %q, want blocked awaiting merge", got)
+	}
+}
+
+func TestPlainTaskGoesDone(t *testing.T) {
+	database := testDB(t)
+	task := mkTask(t, database, "move a file", db.StatusProcessing, "", "")
+
+	outcome, err := Complete(database, task.ID, "moved it", Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Kind != KindDone {
+		t.Fatalf("kind = %q, want done", outcome.Kind)
+	}
+	if got := statusOf(t, database, task.ID); got != db.StatusDone {
+		t.Errorf("status = %q, want done", got)
+	}
+}
+
+// The reason this package exists: `ty close` is a plain status write that skips
+// every rule above. Completing the SAME gate step through Complete must park it,
+// where a raw status write would wrongly mark it done and release the chain.
+func TestCompleteDoesNotBypassGateTheWayAStatusWriteDoes(t *testing.T) {
+	database := testDB(t)
+	branch := "pipeline/3-goal"
+
+	// Control: a raw status write (what `ty close` does) marks the gate done.
+	ctlGate := mkTask(t, database, "[plan] goal", db.StatusProcessing, "pipeline,gate", branch)
+	ctlNext := mkTask(t, database, "[implement] goal", db.StatusBlocked, "pipeline", branch)
+	if err := database.AddDependency(ctlGate.ID, ctlNext.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateTaskStatus(ctlGate.ID, db.StatusDone); err != nil {
+		t.Fatal(err)
+	}
+	if got := statusOf(t, database, ctlGate.ID); got != db.StatusDone {
+		t.Fatalf("control: raw status write should have marked it done, got %q", got)
+	}
+
+	// Complete() on an equivalent gate must NOT do that.
+	branch2 := "pipeline/4-goal"
+	gate := mkTask(t, database, "[plan] goal2", db.StatusProcessing, "pipeline,gate", branch2)
+	next := mkTask(t, database, "[implement] goal2", db.StatusBlocked, "pipeline", branch2)
+	if err := database.AddDependency(gate.ID, next.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Complete(database, gate.ID, "planned", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := statusOf(t, database, gate.ID); got == db.StatusDone {
+		t.Fatal("Complete() marked a human gate 'done' — it must park 'blocked' so the human still approves")
+	}
+}
+
+func TestCompleteUnknownTaskErrors(t *testing.T) {
+	database := testDB(t)
+	if _, err := Complete(database, 999999, "x", Options{}); err == nil {
+		t.Fatal("expected an error for an unknown task")
+	}
+}
+
+// The gate-parked log must be the shared constant so the daemon sweep and the
+// board recognise it and leave the step for the human.
+func TestGateParkedLogIsWritten(t *testing.T) {
+	database := testDB(t)
+	branch := "pipeline/5-goal"
+	gate := mkTask(t, database, "[plan] goal", db.StatusProcessing, "pipeline,gate", branch)
+	next := mkTask(t, database, "[implement] goal", db.StatusBlocked, "pipeline", branch)
+	if err := database.AddDependency(gate.ID, next.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Complete(database, gate.ID, "planned", Options{}); err != nil {
+		t.Fatal(err)
+	}
+
+	logs, err := database.GetTaskLogs(gate.ID, 50)
+	if err != nil {
+		t.Fatalf("get logs: %v", err)
+	}
+	var found bool
+	for _, l := range logs {
+		if l.LineType == "question" && strings.Contains(l.Content, "human review") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a 'question' log marking the gate parked for human review")
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2213,6 +2213,7 @@ Completion signaling (REQUIRED — nothing else watches for completion):
 - When your work is finished, call taskyou_complete with a one-paragraph summary (PR link, files touched, follow-ups). Do NOT just print a summary and stop — without this call the task stalls forever and a human has to close it by hand. If taskyou_complete isn't in your active toolset, it is deferred behind tool search (see above) — load it and call it; do not stop with an apology that the tool is unavailable.
   - If you opened a PR: the task moves to 'blocked' and waits for a human to review and merge it. It is promoted to 'done' automatically once the PR is merged or closed — so calling taskyou_complete does NOT mean the work shipped, you must NOT wait for the merge yourself, and you must NOT call taskyou_complete more than once.
   - If the task produced no PR (e.g. a quick config change or moving a file): it moves straight to 'done'.
+  - If taskyou_complete is genuinely uncallable after you tried to load it, finish with the CLI instead: ty complete --summary "<your summary>". It runs the IDENTICAL logic (same verify gate, same gate parking, same PR routing). Do NOT substitute 'ty close' — that is a plain status write which skips those rules and can mark work done that never passed its checks.
 - When you need clarification, call taskyou_needs_input with the question. This moves the task to 'blocked' so a human is notified. Do not prompt in the terminal — the task system can't see TTY prompts.`)
 
 	if e.taskUsesWorktrees(task) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,19 +5,16 @@ package mcp
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"sync"
-	"time"
 
+	"github.com/bborn/workflow/internal/completion"
 	"github.com/bborn/workflow/internal/db"
-	"github.com/bborn/workflow/internal/github"
 	"github.com/bborn/workflow/internal/pipeline"
-	"github.com/bborn/workflow/internal/tasksummary"
 )
 
 // Server is an MCP server that provides workflow tools to Claude.
@@ -52,27 +49,8 @@ func (s *Server) SetCallbacks(onComplete func(), onNeedsInput func(question stri
 	s.onNeedsInput = onNeedsInput
 }
 
-// lookupPR returns the PR number and URL associated with the task's branch, or
-// (0, "") if the task has no PR. It prefers a live `gh` lookup — the agent often
-// opens the PR moments before calling taskyou_complete, so the DB copy is stale —
-// and persists any fresh result so the board and the daemon reconciler both see
-// it. Falls back to whatever PR info is already stored on the task.
-func (s *Server) lookupPR(task *db.Task) (int, string) {
-	if task == nil {
-		return 0, ""
-	}
-	if task.BranchName != "" {
-		repoDir := task.WorktreePath
-		if repoDir == "" {
-			repoDir, _ = os.Getwd()
-		}
-		if info := github.NewPRCache().GetPRForBranch(repoDir, task.BranchName); info != nil {
-			_ = s.db.UpdateTaskPRInfo(task.ID, info.URL, info.Number, github.MarshalPRInfo(info))
-			return info.Number, info.URL
-		}
-	}
-	return task.PRNumber, task.PRURL
-}
+// PR lookup moved to internal/completion.LookupPR so the CLI completion path
+// resolves PRs identically (see completion.Complete).
 
 // JSON-RPC types
 type jsonRPCRequest struct {
@@ -382,35 +360,9 @@ func (s *Server) handleToolCall(id interface{}, params *toolCallParams) {
 
 		task, _ := s.db.GetTask(s.taskID)
 
-		// Evidence gate. If this step registered a `verify:` command, run it in the
-		// worktree BEFORE accepting completion. A non-zero exit means the agent called
-		// done on work that doesn't actually build/pass — reject the completion, hand
-		// the output back, and leave the step running so the agent fixes it and calls
-		// taskyou_complete again. This is the backstop for completion-by-assertion: the
-		// agent's say-so alone is not trusted. Non-workflow tasks and steps with no
-		// verify command have no row and fall straight through unchanged.
-		if task != nil {
-			if verifyCmd, _ := s.db.GetStepVerify(s.taskID); strings.TrimSpace(verifyCmd) != "" {
-				dir := strings.TrimSpace(task.WorktreePath)
-				if dir == "" {
-					if proj, err := s.db.GetProjectByName(task.Project); err == nil && proj != nil {
-						dir = proj.Path
-					}
-				}
-				if out, passed := pipeline.RunStepVerify(dir, verifyCmd); !passed {
-					s.db.AppendTaskLog(s.taskID, "system", "Verification failed — completion rejected; the step keeps running so the agent can fix it.")
-					s.sendResult(id, toolCallResult{
-						Content: []contentBlock{
-							{Type: "text", Text: fmt.Sprintf("❌ Verification failed — this step is NOT complete.\n\nThe configured check exited non-zero, so taskyou_complete was rejected:\n    %s\n\nFix the problem, then call taskyou_complete again.\n\n--- verify output (tail) ---\n%s", verifyCmd, out)},
-						},
-					})
-					return
-				}
-				s.db.AppendTaskLog(s.taskID, "system", "Verification passed: "+verifyCmd)
-			}
-		}
-
-		// Check if we should remind about saving project context
+		// Check if we should remind about saving project context. This is
+		// MCP-specific (it keys off session state), so it stays here and is appended
+		// to whatever the shared completion decision produces.
 		var contextReminder string
 		if s.contextWasEmpty && task != nil && task.Project != "" {
 			if ctx, err := s.db.GetProjectContext(task.Project); err == nil && ctx == "" {
@@ -418,111 +370,44 @@ func (s *Server) handleToolCall(id interface{}, params *toolCallParams) {
 			}
 		}
 
-		// Log the completion summary
-		s.db.AppendTaskLog(s.taskID, "system", fmt.Sprintf("Task completed: %s", summary))
-
-		// Decide where the finished task lands. A task that produced a PR is NOT
-		// truly done until a human merges/closes that PR — auto-marking it 'done'
-		// buries an open PR in the Done column where it gets overlooked. So PR-bearing
-		// tasks park in 'blocked' (the "human's turn" lane, alongside needs-input
-		// questions) and the daemon promotes them to 'done' once the PR merges/closes
-		// (see reconcileReviewTasks). Tasks with no PR (e.g. "move file X to Y") are
-		// genuinely complete the moment the agent signals it.
-		// A non-terminal workflow step must ADVANCE the DAG, not park for human
-		// review — only the terminal step (the one nothing depends on) opens a PR.
-		// The root step in particular owns the shared branch (branch_name set), which
-		// lookupPR would otherwise treat as "this task produced a PR to merge": it
-		// shells out to `gh` and can even match an unrelated PR, wrongly moving the
-		// step to 'blocked' and stalling the whole workflow at step one. So a workflow
-		// step that still has dependents skips the PR path entirely and is just 'done'.
-		nonTerminalStep := false
-		if pipeline.IsWorkflowTask(task) {
-			if deps, err := s.db.GetBlockedBy(task.ID); err == nil && len(deps) > 0 {
-				nonTerminalStep = true
-			}
+		// The whole decision — evidence gate, human gate, PR routing, done — lives in
+		// internal/completion so `ty complete` takes the identical path. Only the
+		// agent-facing wording and the session-teardown callback are MCP's job.
+		outcome, err := completion.Complete(s.db, s.taskID, summary, completion.Options{AsyncSummary: true})
+		if err != nil {
+			s.sendError(id, -32603, err.Error())
+			return
 		}
 
-		// A gate step is a human-in-the-loop boundary: instead of advancing the DAG
-		// when it finishes, it parks 'blocked' for human review. Its dependents are
-		// already held ('blocked' with an open blocker), so leaving the step 'blocked'
-		// rather than 'done' keeps them held — a human releases the chain by closing
-		// this step (`ty close`), which runs UpdateTaskStatus(done) → the normal
-		// ProcessCompletedBlocker cascade. Only non-terminal gate steps park here; a
-		// terminal step already parks for PR review below.
-		if nonTerminalStep && pipeline.IsGateStep(task) {
-			if err := s.db.UpdateTaskStatus(s.taskID, db.StatusBlocked); err != nil {
-				s.sendError(id, -32603, fmt.Sprintf("Failed to park gate step for review: %v", err))
-				return
-			}
-			// Log as a "question" so it surfaces in the blocked/needs-input lane and the
-			// daemon sweep leaves it for the human rather than auto-completing it.
-			s.db.AppendTaskLog(s.taskID, "question", pipeline.GateStepParkedLog)
-
-			// The agent's turn is over; let the executor tear down the session.
-			if s.onComplete != nil {
-				s.onComplete()
-			}
-
+		if outcome.Kind == completion.KindVerifyFailed {
+			// Completion was rejected: the step stays running so the agent can fix it.
+			// No teardown callback — the agent's turn is NOT over.
 			s.sendResult(id, toolCallResult{
 				Content: []contentBlock{
-					{Type: "text", Text: "Output saved. This is a human-review gate — the step is now 'blocked' awaiting a human to approve it (`ty close`), which releases the next phase. Do not call taskyou_complete again." + contextReminder},
+					{Type: "text", Text: fmt.Sprintf("❌ Verification failed — this step is NOT complete.\n\nThe configured check exited non-zero, so taskyou_complete was rejected:\n    %s\n\nFix the problem, then call taskyou_complete again.\n\n--- verify output (tail) ---\n%s", outcome.VerifyCommand, outcome.VerifyOutput)},
 				},
 			})
 			return
 		}
 
-		var prNumber int
-		var prURL string
-		if !nonTerminalStep {
-			prNumber, prURL = s.lookupPR(task)
-		}
-		if prNumber > 0 {
-			if err := s.db.UpdateTaskStatus(s.taskID, db.StatusBlocked); err != nil {
-				s.sendError(id, -32603, fmt.Sprintf("Failed to move task to review: %v", err))
-				return
-			}
-			// Surface it in the blocked lane like a needs-input item so it's easy to spot.
-			reviewMsg := fmt.Sprintf("✅ PR #%d ready for review — merge or close it to complete this task.", prNumber)
-			if prURL != "" {
-				reviewMsg += " " + prURL
-			}
-			s.db.AppendTaskLog(s.taskID, "question", reviewMsg)
-
-			// The agent's turn is over; let the executor tear down the session.
-			if s.onComplete != nil {
-				s.onComplete()
-			}
-
-			resultText := fmt.Sprintf("Work finished. PR #%d is up for review — the task is now 'blocked' awaiting a human merge, and will move to 'done' automatically once the PR is merged or closed. Do not call taskyou_complete again.", prNumber)
-			s.sendResult(id, toolCallResult{
-				Content: []contentBlock{
-					{Type: "text", Text: resultText + contextReminder},
-				},
-			})
-			return
-		}
-
-		// No PR — the task is genuinely done.
-		if err := s.db.UpdateTaskStatus(s.taskID, db.StatusDone); err != nil {
-			s.sendError(id, -32603, fmt.Sprintf("Failed to mark task done: %v", err))
-			return
-		}
-
-		// Generate a concise activity summary in the background (if possible)
-		go func(taskID int64) {
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-			defer cancel()
-			_, _ = tasksummary.GenerateAndStore(ctx, s.db, taskID)
-		}(s.taskID)
-
-		// Trigger callback so the executor can shut down the session
+		// The agent's turn is over; let the executor tear down the session.
 		if s.onComplete != nil {
 			s.onComplete()
 		}
 
+		var resultText string
+		switch outcome.Kind {
+		case completion.KindGateParked:
+			resultText = "Output saved. This is a human-review gate — the step is now 'blocked' awaiting a human to approve it (`ty close`), which releases the next phase. Do not call taskyou_complete again."
+		case completion.KindPRReview:
+			resultText = fmt.Sprintf("Work finished. PR #%d is up for review — the task is now 'blocked' awaiting a human merge, and will move to 'done' automatically once the PR is merged or closed. Do not call taskyou_complete again.", outcome.PRNumber)
+		default:
+			resultText = "Task marked done."
+		}
+
 		s.sendResult(id, toolCallResult{
 			Content: []contentBlock{
-				{Type: "text", Text: "Task marked done." + contextReminder},
+				{Type: "text", Text: resultText + contextReminder},
 			},
 		})
 


### PR DESCRIPTION
Closes the last MCP-only dependency in the workflow system.

## Problem

Completing a task is **not** a status write. It's a decision tree with real consequences:

- an **evidence gate** (`verify:`) that can **reject** the completion
- a **human-review gate** that must park for approval instead of advancing the DAG
- a **PR-bearing task** that must wait for a human merge, not get buried in Done

All of it lived inside the `taskyou_complete` MCP handler — so the MCP transport was the *only* correct way to finish a task. When it was unavailable (which happened repeatedly in production this week), agents reached for `ty close`: a plain status write that **silently skips every one of those rules**, including marking work done that never passed its verify check.

#669 gave agents a CLI path for artifacts. Completion was the remaining hole.

## Fix

Extract the decision into `internal/completion.Complete` and have **both** the MCP tool and a new `ty complete` CLI call it — so the two cannot drift and neither can bypass a gate. `lookupPR` moves along with it so PR resolution is identical.

The MCP handler keeps only what is genuinely MCP's: agent-facing wording, the project-context reminder, and the session-teardown callback. **Behaviour is unchanged — the existing MCP tests pass untouched.**

Two deliberate details:
- `Options.AsyncSummary` — the long-lived MCP server generates the activity summary in a goroutine (as before); a short-lived CLI process must run it inline or exiting kills the goroutine.
- `ty complete` exits **non-zero** on a rejected completion so scripts can detect it.

Agent guidance now points at `ty complete` as the fallback and explicitly warns against substituting `ty close`.

## Test

9 tests in `internal/completion/complete_test.go` covering every branch, including the two that matter most:

- **`TestVerifyFailureRejectsCompletion`** — a failing check leaves the status *unchanged* and the task running. This is the backstop against completion-by-assertion.
- **`TestCompleteDoesNotBypassGateTheWayAStatusWriteDoes`** — completes a control gate with a raw status write (what `ty close` does) and asserts it goes `done`, then asserts `Complete()` on an equivalent gate does **not**.

Plus: verify-pass, gate parks + dependents stay held, non-terminal step advances despite a spurious PR, terminal-with-PR parks, plain task done, unknown task errors, and the shared gate-parked log is written.

Full repo test suite green; `golangci-lint run` (v2.8.0, the pinned CI version) reports 0 issues.
