### PR TITLE
fix(executor): always attach the worktree to the shared branch (was silently detaching)

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4490,23 +4490,16 @@ func (e *Executor) setupWorktree(task *db.Task) (string, bool, error) {
 				"task", task.ID, "branch", task.SourceBranch, "error", fetchErr, "output", string(fetchOutput))
 		}
 
-		// Resolve the source branch to a checkout-able ref. Prefer the
-		// remote-tracking ref (origin/<branch>) so pushed updates win, but fall
-		// back to a local branch of the same name. Without the local fallback, a
-		// pipeline whose first steps are document phases fails here on the first
-		// code step with `fatal: invalid reference: origin/<branch>` (the shared
-		// branch exists only locally), and the task loops on spawn forever.
-		ref, resolveErr := e.resolveSourceBranchRef(projectDir, task.SourceBranch)
-		if resolveErr != nil {
-			return "", false, resolveErr
-		}
-
-		// Create worktree from the resolved branch ref (no -b flag).
-		cmd := exec.Command("git", "worktree", "add", worktreePath, ref)
-		cmd.Dir = projectDir
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return "", false, fmt.Errorf("create worktree from branch %s (ref %s): %v\n%s", task.SourceBranch, ref, err, string(output))
+		// Create the worktree ATTACHED to the shared branch. This must not be a
+		// plain `git worktree add <path> <ref>`: when <ref> is origin/<branch> and a
+		// local branch of that name already exists, git cannot create the branch and
+		// silently checks out a DETACHED HEAD instead. A detached step still runs and
+		// still commits, but its commits never land on the shared branch — so the
+		// next step's worktree, built from that branch, sees none of the work and the
+		// whole phase is silently lost. addSourceBranchWorktree picks the form of the
+		// command that guarantees attachment.
+		if err := e.addSourceBranchWorktree(projectDir, worktreePath, task.SourceBranch); err != nil {
+			return "", false, err
 		}
 
 		// Use the source branch name as the branch name for the task
@@ -5510,28 +5503,87 @@ func (e *Executor) ensureGitignore(projectDir, entry string) {
 	f.WriteString(entry + "\n")
 }
 
-// resolveSourceBranchRef returns a git ref for an existing source branch that a
-// worktree can be created from. It prefers the remote-tracking ref
-// (origin/<branch>) so pushed updates win, then falls back to a local branch of
-// the same name. This local fallback is what keeps document-first pipelines
-// working: their early steps create the shared branch locally and never push
-// it, so origin/<branch> does not exist when the first code step sets up its
-// worktree. Returns an error only when the branch exists in neither place.
-func (e *Executor) resolveSourceBranchRef(projectDir, sourceBranch string) (string, error) {
-	refExists := func(ref string) bool {
-		cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref)
-		cmd.Dir = projectDir
-		return cmd.Run() == nil
+// addSourceBranchWorktree creates a worktree that is ATTACHED to sourceBranch.
+//
+// Why this is not one command: `git worktree add <path> origin/<branch>` only
+// creates and attaches the local branch when one does not already exist. If it
+// does, git falls back to a DETACHED checkout of the remote ref — silently. A
+// detached step commits into nothing the pipeline can see: the shared branch
+// never advances, and the next step's worktree (built from that branch) starts
+// from the base commit as if the phase never ran.
+//
+// So the branch state decides the form:
+//   - local branch exists  -> `worktree add <path> <branch>` attaches to it.
+//     If origin is strictly ahead, fast-forward it first so the step still
+//     starts from the newest pushed work (the old prefer-origin behaviour).
+//   - only origin exists   -> `worktree add -b <branch> <path> origin/<branch>`
+//     creates the local branch attached and tracking the remote.
+//   - neither              -> error.
+func (e *Executor) addSourceBranchWorktree(projectDir, worktreePath, sourceBranch string) error {
+	localExists := gitRefExists(projectDir, "refs/heads/"+sourceBranch)
+	remoteRef := "origin/" + sourceBranch
+	remoteExists := gitRefExists(projectDir, "refs/remotes/"+remoteRef)
+
+	var args []string
+	switch {
+	case localExists:
+		// Only fast-forward when the local branch is strictly behind — never when
+		// the two have diverged, since the local side carries this workflow's own
+		// commits and force-moving it would discard them.
+		if remoteExists && gitIsAncestor(projectDir, sourceBranch, remoteRef) &&
+			!gitIsAncestor(projectDir, remoteRef, sourceBranch) {
+			ff := exec.Command("git", "update-ref", "refs/heads/"+sourceBranch, remoteRef)
+			ff.Dir = projectDir
+			if out, err := ff.CombinedOutput(); err != nil {
+				// Not fatal: worst case the step starts from slightly older local work.
+				e.logger.Warn("could not fast-forward source branch to origin",
+					"branch", sourceBranch, "error", err, "output", string(out))
+			}
+		}
+		args = []string{"worktree", "add", worktreePath, sourceBranch}
+	case remoteExists:
+		args = []string{"worktree", "add", "-b", sourceBranch, worktreePath, remoteRef}
+	default:
+		return fmt.Errorf("source branch %s not found on origin or locally", sourceBranch)
 	}
 
-	remoteRef := "origin/" + sourceBranch
-	if refExists("refs/remotes/" + remoteRef) {
-		return remoteRef, nil
+	cmd := exec.Command("git", args...)
+	cmd.Dir = projectDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("create worktree on branch %s: %v\n%s", sourceBranch, err, string(output))
 	}
-	if refExists("refs/heads/" + sourceBranch) {
-		return sourceBranch, nil
+
+	// Belt and braces: if git still handed back a detached HEAD, fail loudly here
+	// rather than letting a step run and quietly throw its commits away.
+	if head, err := gitCurrentBranch(worktreePath); err == nil && head != sourceBranch {
+		return fmt.Errorf("worktree for branch %s came up detached (HEAD=%q); refusing to run a step whose commits would not land on the shared branch", sourceBranch, head)
 	}
-	return "", fmt.Errorf("source branch %s not found on origin or locally", sourceBranch)
+	return nil
+}
+
+// gitRefExists reports whether a fully-qualified ref resolves in projectDir.
+func gitRefExists(projectDir, ref string) bool {
+	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref)
+	cmd.Dir = projectDir
+	return cmd.Run() == nil
+}
+
+// gitIsAncestor reports whether ancestor is reachable from descendant.
+func gitIsAncestor(projectDir, ancestor, descendant string) bool {
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", ancestor, descendant)
+	cmd.Dir = projectDir
+	return cmd.Run() == nil
+}
+
+// gitCurrentBranch returns the checked-out branch name, or "HEAD" when detached.
+func gitCurrentBranch(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // getDefaultBranch returns the default branch name for a git repo.

--- a/internal/executor/worktree_source_branch_test.go
+++ b/internal/executor/worktree_source_branch_test.go
@@ -2,10 +2,12 @@ package executor
 
 import (
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// git runs a git command in dir and fails the test on error.
+// gitIn runs a git command in dir and fails the test on error.
 func gitIn(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -23,55 +25,204 @@ func initRepo(t *testing.T, dir string) {
 	gitIn(t, dir, "init", "-q", "-b", "main")
 	gitIn(t, dir, "config", "user.email", "test@example.com")
 	gitIn(t, dir, "config", "user.name", "Test")
-	gitIn(t, dir, "commit", "-q", "--allow-empty", "-m", "initial")
+	gitIn(t, dir, "commit", "-q", "--allow-empty", "-m", "base")
 }
 
-func TestResolveSourceBranchRef(t *testing.T) {
+// initRepoWithRemote creates a repo with a bare "origin" it can push to.
+func initRepoWithRemote(t *testing.T) (repo string) {
+	t.Helper()
+	root := t.TempDir()
+	bare := filepath.Join(root, "origin.git")
+	gitIn(t, root, "init", "-q", "--bare", "-b", "main", bare)
+	repo = filepath.Join(root, "repo")
+	gitIn(t, root, "init", "-q", "-b", "main", repo)
+	gitIn(t, repo, "config", "user.email", "test@example.com")
+	gitIn(t, repo, "config", "user.name", "Test")
+	gitIn(t, repo, "commit", "-q", "--allow-empty", "-m", "base")
+	gitIn(t, repo, "remote", "add", "origin", bare)
+	gitIn(t, repo, "push", "-q", "origin", "main")
+	return repo
+}
+
+// headBranch returns the checked-out branch of a worktree, or "HEAD" if detached.
+func headBranch(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse in %s: %v", dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// THE REGRESSION TEST. With BOTH a local branch and origin/<branch> present,
+// `git worktree add <path> origin/<branch>` silently produces a DETACHED HEAD:
+// git will not move an existing branch, so it checks out the remote ref instead.
+// A detached step still runs and commits, but its commits never land on the
+// shared branch, so the next step sees none of the work. Observed in production
+// on the Lumen pipeline, where every step worktree was detached and the shared
+// branch never advanced past its base commit.
+func TestSourceBranchWorktreeAttachesWhenLocalAndRemoteBothExist(t *testing.T) {
+	repo := initRepoWithRemote(t)
+	gitIn(t, repo, "branch", "shared")
+	gitIn(t, repo, "push", "-q", "origin", "shared")
+	gitIn(t, repo, "fetch", "-q", "origin")
+
 	e := &Executor{}
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := e.addSourceBranchWorktree(repo, wt, "shared"); err != nil {
+		t.Fatalf("addSourceBranchWorktree: %v", err)
+	}
 
-	t.Run("falls back to a local-only branch (document-first pipeline)", func(t *testing.T) {
-		dir := t.TempDir()
-		initRepo(t, dir)
-		// Shared pipeline branch exists locally but was never pushed to origin.
-		gitIn(t, dir, "branch", "pipeline/4887-shared")
+	if got := headBranch(t, wt); got != "shared" {
+		t.Fatalf("worktree HEAD = %q, want branch %q — a detached worktree throws its commits away", got, "shared")
+	}
+}
 
-		ref, err := e.resolveSourceBranchRef(dir, "pipeline/4887-shared")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if ref != "pipeline/4887-shared" {
-			t.Errorf("ref = %q, want local branch %q", ref, "pipeline/4887-shared")
-		}
-	})
+// A commit made in the worktree must actually advance the shared branch — the
+// property the pipeline depends on to hand work forward.
+func TestSourceBranchWorktreeCommitsLandOnSharedBranch(t *testing.T) {
+	repo := initRepoWithRemote(t)
+	gitIn(t, repo, "branch", "shared")
+	gitIn(t, repo, "push", "-q", "origin", "shared")
+	gitIn(t, repo, "fetch", "-q", "origin")
 
-	t.Run("prefers origin/<branch> when the remote-tracking ref exists", func(t *testing.T) {
-		remote := t.TempDir()
-		gitIn(t, remote, "init", "-q", "--bare", "-b", "main")
+	e := &Executor{}
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := e.addSourceBranchWorktree(repo, wt, "shared"); err != nil {
+		t.Fatalf("addSourceBranchWorktree: %v", err)
+	}
 
-		dir := t.TempDir()
-		initRepo(t, dir)
-		gitIn(t, dir, "remote", "add", "origin", remote)
-		// Push a branch and establish the remote-tracking ref, then also keep a
-		// local branch of the same name so both refs are resolvable.
-		gitIn(t, dir, "branch", "feature/pushed")
-		gitIn(t, dir, "push", "-q", "origin", "feature/pushed")
-		gitIn(t, dir, "fetch", "-q", "origin")
+	gitIn(t, wt, "config", "user.email", "test@example.com")
+	gitIn(t, wt, "config", "user.name", "Test")
+	gitIn(t, wt, "commit", "-q", "--allow-empty", "-m", "step output")
 
-		ref, err := e.resolveSourceBranchRef(dir, "feature/pushed")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if ref != "origin/feature/pushed" {
-			t.Errorf("ref = %q, want remote-tracking ref %q", ref, "origin/feature/pushed")
-		}
-	})
+	// The shared branch in the main repo must now point at that commit.
+	wtHead := strings.TrimSpace(gitIn(t, wt, "rev-parse", "HEAD"))
+	branchHead := strings.TrimSpace(gitIn(t, repo, "rev-parse", "shared"))
+	if wtHead != branchHead {
+		t.Fatalf("shared branch is at %s but the step committed %s — the next step would not see this work", branchHead[:7], wtHead[:7])
+	}
+}
 
-	t.Run("errors when the branch exists nowhere", func(t *testing.T) {
-		dir := t.TempDir()
-		initRepo(t, dir)
+// Only a local branch (the document-first pipeline case from #668): the shared
+// branch is built locally and never pushed, so origin/<branch> does not exist.
+func TestSourceBranchWorktreeAttachesToLocalOnlyBranch(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+	gitIn(t, repo, "branch", "pipeline/1-local-only")
 
-		if _, err := e.resolveSourceBranchRef(dir, "pipeline/does-not-exist"); err == nil {
-			t.Fatal("expected an error for a branch that exists neither on origin nor locally")
-		}
-	})
+	e := &Executor{}
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := e.addSourceBranchWorktree(repo, wt, "pipeline/1-local-only"); err != nil {
+		t.Fatalf("addSourceBranchWorktree: %v", err)
+	}
+	if got := headBranch(t, wt); got != "pipeline/1-local-only" {
+		t.Fatalf("worktree HEAD = %q, want the local branch", got)
+	}
+}
+
+// Only origin has the branch: the local branch must be created AND attached,
+// not checked out detached.
+func TestSourceBranchWorktreeCreatesLocalBranchFromRemoteOnly(t *testing.T) {
+	repo := initRepoWithRemote(t)
+	gitIn(t, repo, "branch", "remote-only")
+	gitIn(t, repo, "push", "-q", "origin", "remote-only")
+	gitIn(t, repo, "fetch", "-q", "origin")
+	// Delete the local branch so ONLY origin/remote-only remains.
+	gitIn(t, repo, "branch", "-D", "remote-only")
+
+	e := &Executor{}
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := e.addSourceBranchWorktree(repo, wt, "remote-only"); err != nil {
+		t.Fatalf("addSourceBranchWorktree: %v", err)
+	}
+	if got := headBranch(t, wt); got != "remote-only" {
+		t.Fatalf("worktree HEAD = %q, want branch remote-only", got)
+	}
+}
+
+// A local branch strictly behind origin is fast-forwarded, so the step starts
+// from the newest pushed work (preserving the old prefer-origin behaviour).
+func TestSourceBranchWorktreeFastForwardsBehindLocalBranch(t *testing.T) {
+	repo := initRepoWithRemote(t)
+	gitIn(t, repo, "branch", "shared")
+	gitIn(t, repo, "push", "-q", "origin", "shared")
+
+	// Advance origin/shared beyond the local branch via a second clone.
+	otherRoot := t.TempDir()
+	other := filepath.Join(otherRoot, "other")
+	remote := strings.TrimSpace(gitIn(t, repo, "remote", "get-url", "origin"))
+	gitIn(t, otherRoot, "clone", "-q", remote, other)
+	gitIn(t, other, "config", "user.email", "test@example.com")
+	gitIn(t, other, "config", "user.name", "Test")
+	gitIn(t, other, "checkout", "-q", "shared")
+	gitIn(t, other, "commit", "-q", "--allow-empty", "-m", "pushed elsewhere")
+	gitIn(t, other, "push", "-q", "origin", "shared")
+
+	gitIn(t, repo, "fetch", "-q", "origin")
+	ahead := strings.TrimSpace(gitIn(t, repo, "rev-parse", "origin/shared"))
+
+	e := &Executor{}
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := e.addSourceBranchWorktree(repo, wt, "shared"); err != nil {
+		t.Fatalf("addSourceBranchWorktree: %v", err)
+	}
+	if got := headBranch(t, wt); got != "shared" {
+		t.Fatalf("worktree HEAD = %q, want branch shared", got)
+	}
+	if got := strings.TrimSpace(gitIn(t, wt, "rev-parse", "HEAD")); got != ahead {
+		t.Errorf("worktree at %s, want fast-forwarded to origin %s", got[:7], ahead[:7])
+	}
+}
+
+// A DIVERGED local branch must NOT be force-moved — it carries this workflow's
+// own commits, and discarding them would lose a completed step's work.
+func TestSourceBranchWorktreeDoesNotClobberDivergedLocalBranch(t *testing.T) {
+	repo := initRepoWithRemote(t)
+	gitIn(t, repo, "branch", "shared")
+	gitIn(t, repo, "push", "-q", "origin", "shared")
+
+	// origin/shared gains a commit...
+	otherRoot := t.TempDir()
+	other := filepath.Join(otherRoot, "other")
+	remote := strings.TrimSpace(gitIn(t, repo, "remote", "get-url", "origin"))
+	gitIn(t, otherRoot, "clone", "-q", remote, other)
+	gitIn(t, other, "config", "user.email", "test@example.com")
+	gitIn(t, other, "config", "user.name", "Test")
+	gitIn(t, other, "checkout", "-q", "shared")
+	gitIn(t, other, "commit", "-q", "--allow-empty", "-m", "theirs")
+	gitIn(t, other, "push", "-q", "origin", "shared")
+	gitIn(t, repo, "fetch", "-q", "origin")
+
+	// ...while the local branch gains a DIFFERENT one (this workflow's work).
+	tmpWt := filepath.Join(t.TempDir(), "seed")
+	gitIn(t, repo, "worktree", "add", "-q", tmpWt, "shared")
+	gitIn(t, tmpWt, "config", "user.email", "test@example.com")
+	gitIn(t, tmpWt, "config", "user.name", "Test")
+	gitIn(t, tmpWt, "commit", "-q", "--allow-empty", "-m", "ours")
+	ours := strings.TrimSpace(gitIn(t, tmpWt, "rev-parse", "HEAD"))
+	gitIn(t, repo, "worktree", "remove", "--force", tmpWt)
+
+	e := &Executor{}
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := e.addSourceBranchWorktree(repo, wt, "shared"); err != nil {
+		t.Fatalf("addSourceBranchWorktree: %v", err)
+	}
+	if got := strings.TrimSpace(gitIn(t, repo, "rev-parse", "shared")); got != ours {
+		t.Fatalf("diverged local branch moved to %s, want it left at our commit %s", got[:7], ours[:7])
+	}
+}
+
+func TestSourceBranchWorktreeErrorsWhenBranchMissingEverywhere(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+
+	e := &Executor{}
+	wt := filepath.Join(t.TempDir(), "wt")
+	err := e.addSourceBranchWorktree(repo, wt, "pipeline/does-not-exist")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected a not-found error, got %v", err)
+	}
 }


### PR DESCRIPTION
## The bug

`git worktree add <path> origin/<branch>` only creates and attaches the local branch when one **does not already exist**. When it does — the normal state for a pipeline whose earlier steps have run — git will not move the existing branch, so it silently checks out a **detached HEAD** at the remote ref instead.

A detached step still runs, still commits, and still reports success. But its commits never land on the shared branch, so the next step's worktree (built from that branch) starts from the base commit **as if the phase never happened**. The phase is lost with no error anywhere.

![detach](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-07-20/672-672-detach.png)

**Seen in production** on the Lumen pipeline: every step worktree was detached and the shared branch never advanced past its base commit, stranding the implement step's work on an unreferenced commit. It was only visible because I went looking at `git status` in the worktree — nothing in ty reported a problem.

This is worse than the spawn failures fixed in #668/#665: those fail loudly and stall. This one **succeeds quietly and silently discards work.**

## The fix

Replace the single `worktree add <path> <ref>` with `addSourceBranchWorktree`, which picks the form that guarantees attachment:

| branch state | command | result |
|---|---|---|
| local exists | `worktree add <path> <branch>` | attached to local |
| only origin | `worktree add -b <branch> <path> origin/<branch>` | local branch created, attached, tracking |
| neither | error | — |

When the local branch is **strictly behind** origin it's fast-forwarded first, preserving the old prefer-origin behaviour — but **never when diverged**, since the local side carries this workflow's own commits and force-moving would discard a completed step.

It then verifies `HEAD` is genuinely on the branch and **fails loudly** otherwise, rather than letting a step run and throw its commits away.

`resolveSourceBranchRef` (#668) is superseded and removed; its local-fallback behaviour is now a branch of the above, still covered.

## Test

7 tests in `internal/executor/worktree_source_branch_test.go`, driving real git repos with a real bare remote:

- **`…AttachesWhenLocalAndRemoteBothExist`** — the exact production trigger.
- **`…CommitsLandOnSharedBranch`** — commits in the worktree actually advance the branch, i.e. the property the pipeline depends on.
- `…AttachesToLocalOnlyBranch` (the #668 document-first case), `…CreatesLocalBranchFromRemoteOnly`, `…FastForwardsBehindLocalBranch`, `…DoesNotClobberDivergedLocalBranch`, and missing-everywhere errors.

**Both regression tests were confirmed to FAIL against the previous implementation** (`worktree HEAD = "HEAD", want branch "shared"` and `shared branch is at 3baae7b but the step committed 4c27d84`) and pass with this one — so they genuinely pin the bug rather than merely passing.

Full repo suite green; `golangci-lint run` (v2.8.0, the pinned CI version) — 0 issues.

## Note

The already-stranded Lumen worktree still needs manual repair (attach the branch to its commit); this fix prevents recurrence, it doesn't retroactively re-attach existing worktrees.
