### PR TITLE
fix: sweep orphaned 'processing' tasks periodically, not just at startup

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -259,8 +259,9 @@ func (e *Executor) Start(ctx context.Context) {
 
 	// Reconcile tasks left in 'processing' with no live executor (e.g. after a
 	// daemon restart killed the executor panes). Without this they stay stuck in
-	// 'processing' forever and the board lies about them still running.
-	e.reconcileOrphanedTasks()
+	// 'processing' forever and the board lies about them still running. The
+	// worker loop repeats this periodically to catch executors that die later.
+	e.reconcileOrphanedTasks(true)
 
 	// Run stale worktree cleanup on startup (and then periodically in worker loop)
 	go e.cleanupStaleWorktrees()
@@ -312,16 +313,28 @@ func (e *Executor) recoverStaleTmuxRefs() {
 	}
 }
 
+// orphanSpawnGrace is how long a task is left alone after it starts before the
+// periodic sweep will consider it orphaned. A freshly spawned executor needs a
+// moment before its tmux window is visible, and tasks started by the TUI never
+// enter this executor's runningTasks set - without this grace period the sweep
+// would blocked-out a task that is in the middle of coming up.
+const orphanSpawnGrace = 90 * time.Second
+
 // reconcileOrphanedTasks moves tasks that are stuck in 'processing' but have no
 // live executor window back to 'blocked' so the board reflects reality. This
-// happens when the daemon is restarted (or crashes) while tasks are executing:
-// the executor tmux windows/processes are killed, but nothing transitions the
-// task out of 'processing', so it appears to be running forever.
+// happens when the daemon is restarted (or crashes) while tasks are executing,
+// and also when an executor dies mid-run under a healthy daemon: the executor
+// tmux window/process is gone, but nothing transitions the task out of
+// 'processing', so it appears to be running forever.
+//
+// It runs both at startup (startup=true, when every executor pane is known dead)
+// and periodically from the worker loop, which is what catches an executor that
+// dies while the daemon keeps running.
 //
 // Tasks are moved to 'blocked' (rather than silently re-queued) so the failure
 // is visible and the user can retry, which resumes the saved Claude session.
 // Uncommitted work in the worktree is left untouched.
-func (e *Executor) reconcileOrphanedTasks() {
+func (e *Executor) reconcileOrphanedTasks(startup bool) {
 	tasks, err := e.db.ListTasks(db.ListTasksOptions{Status: db.StatusProcessing, Limit: 1000})
 	if err != nil {
 		e.logger.Error("Failed to list processing tasks for orphan reconciliation", "error", err)
@@ -339,6 +352,13 @@ func (e *Executor) reconcileOrphanedTasks() {
 			continue
 		}
 
+		// Give a just-started task time to bring its window up before declaring
+		// it dead. Only on the periodic pass: at startup the panes really are
+		// gone no matter how recently the task started.
+		if !startup && task.StartedAt != nil && time.Since(task.StartedAt.Time) < orphanSpawnGrace {
+			continue
+		}
+
 		// A processing task with a live executor window is genuinely still
 		// running (e.g. the tmux server survived a daemon restart) - leave it.
 		windowExists := tmuxWindowExistsForTask
@@ -350,18 +370,21 @@ func (e *Executor) reconcileOrphanedTasks() {
 		}
 
 		msg := "Executor terminated (daemon restart) - task was 'processing' with no live executor. Moved to blocked; retry to resume."
+		if !startup {
+			msg = "Executor died - task was 'processing' with no live executor. Moved to blocked; retry to resume."
+		}
 		if err := e.updateStatus(task.ID, db.StatusBlocked); err != nil {
 			e.logger.Error("Failed to reconcile orphaned task", "id", task.ID, "error", err)
 			continue
 		}
 		e.logLine(task.ID, "error", msg)
 		e.hooks.OnStatusChange(task, db.StatusBlocked, msg)
-		e.logger.Info("Reconciled orphaned processing task", "id", task.ID, "title", task.Title)
+		e.logger.Info("Reconciled orphaned processing task", "id", task.ID, "title", task.Title, "startup", startup)
 		reconciled++
 	}
 
 	if reconciled > 0 {
-		e.logger.Info("Reconciled orphaned processing tasks", "count", reconciled)
+		e.logger.Info("Reconciled orphaned processing tasks", "count", reconciled, "startup", startup)
 	}
 }
 
@@ -1199,6 +1222,7 @@ func (e *Executor) worker(ctx context.Context) {
 	const reviewReconcileInterval = 30  // 60 seconds at 2 second ticks
 	const prDisplayRefreshInterval = 45 // 90 seconds at 2 second ticks
 	const readyTasksInterval = 8        // 16 seconds at 2 second ticks
+	const orphanReconcileInterval = 30  // 60 seconds at 2 second ticks
 
 	for {
 		select {
@@ -1229,6 +1253,13 @@ func (e *Executor) worker(ctx context.Context) {
 			// once their PR has merged or closed.
 			if tickCount%reviewReconcileInterval == 0 {
 				e.reconcileReviewTasks()
+			}
+
+			// Safety net for executors that die mid-run while the daemon stays up:
+			// without this the task sits in 'processing' with no pane until the
+			// next daemon restart, and the board lies about it still running.
+			if tickCount%orphanReconcileInterval == 0 {
+				e.reconcileOrphanedTasks(false)
 			}
 
 			// Safety net for the auto-advance of workflow DAGs: re-queue any step

--- a/internal/executor/reconcile_test.go
+++ b/internal/executor/reconcile_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bborn/workflow/internal/config"
 	"github.com/bborn/workflow/internal/db"
@@ -56,7 +57,7 @@ func TestReconcileOrphanedTasksMovesDeadTasksToBlocked(t *testing.T) {
 	// No live executor window for any task.
 	exec.windowExistsFn = func(taskID int64) bool { return false }
 
-	exec.reconcileOrphanedTasks()
+	exec.reconcileOrphanedTasks(true)
 
 	got, err := database.GetTask(orphan.ID)
 	if err != nil {
@@ -93,7 +94,7 @@ func TestReconcileOrphanedTasksLeavesLiveTasksAlone(t *testing.T) {
 	// The executor window exists for this task - it's genuinely running.
 	exec.windowExistsFn = func(taskID int64) bool { return true }
 
-	exec.reconcileOrphanedTasks()
+	exec.reconcileOrphanedTasks(true)
 
 	got, err := database.GetTask(live.ID)
 	if err != nil {
@@ -117,7 +118,7 @@ func TestReconcileOrphanedTasksSkipsRunningTasks(t *testing.T) {
 
 	exec.windowExistsFn = func(taskID int64) bool { return false }
 
-	exec.reconcileOrphanedTasks()
+	exec.reconcileOrphanedTasks(true)
 
 	got, err := database.GetTask(running.ID)
 	if err != nil {
@@ -143,7 +144,7 @@ func TestReconcileOrphanedTasksOnlyTouchesProcessing(t *testing.T) {
 
 	exec.windowExistsFn = func(taskID int64) bool { return false }
 
-	exec.reconcileOrphanedTasks()
+	exec.reconcileOrphanedTasks(true)
 
 	got, err := database.GetTask(queued.ID)
 	if err != nil {
@@ -151,5 +152,105 @@ func TestReconcileOrphanedTasksOnlyTouchesProcessing(t *testing.T) {
 	}
 	if got.Status != db.StatusQueued {
 		t.Fatalf("expected queued task to stay queued, got %q", got.Status)
+	}
+}
+
+// backdateStartedAt pushes a task's started_at into the past so the periodic
+// sweep's spawn grace period no longer covers it.
+func backdateStartedAt(t *testing.T, database *db.DB, taskID int64, d time.Duration) {
+	t.Helper()
+	_, err := database.Exec(
+		"UPDATE tasks SET started_at = ? WHERE id = ?",
+		time.Now().Add(-d).UTC(),
+		taskID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReconcileOrphanedTasksPeriodicSweepsDeadExecutor is the regression test for
+// an executor that dies mid-run while the daemon stays up. Before the periodic
+// sweep existed this task sat in 'processing' with no pane until the next daemon
+// restart, and the board reported it as still running.
+func TestReconcileOrphanedTasksPeriodicSweepsDeadExecutor(t *testing.T) {
+	exec, database := newTestExecutor(t)
+
+	orphan := createProcessingTask(t, database, "executor died mid-run")
+	backdateStartedAt(t, database, orphan.ID, 10*time.Minute)
+
+	// The executor's window is gone, and the daemon never had it in runningTasks
+	// (e.g. the TUI started it).
+	exec.windowExistsFn = func(taskID int64) bool { return false }
+
+	exec.reconcileOrphanedTasks(false)
+
+	got, err := database.GetTask(orphan.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.StatusBlocked {
+		t.Fatalf("expected dead-executor task to be blocked, got %q", got.Status)
+	}
+
+	logs, err := database.GetTaskLogs(orphan.ID, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, l := range logs {
+		if l.LineType == "error" && strings.Contains(l.Content, "Executor died") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a log entry recording the dead executor, got %+v", logs)
+	}
+}
+
+// TestReconcileOrphanedTasksPeriodicRespectsSpawnGrace verifies the periodic
+// sweep leaves a just-started task alone. A freshly spawned executor needs a
+// moment before its tmux window is visible, and a TUI-started task is never in
+// this executor's runningTasks - without the grace period the sweep would block
+// a task that is still coming up.
+func TestReconcileOrphanedTasksPeriodicRespectsSpawnGrace(t *testing.T) {
+	exec, database := newTestExecutor(t)
+
+	// createProcessingTask stamps started_at as it flips to processing, so this
+	// task is inside the grace window.
+	starting := createProcessingTask(t, database, "just spawned")
+
+	exec.windowExistsFn = func(taskID int64) bool { return false }
+
+	exec.reconcileOrphanedTasks(false)
+
+	got, err := database.GetTask(starting.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.StatusProcessing {
+		t.Fatalf("expected just-started task to stay processing, got %q", got.Status)
+	}
+}
+
+// TestReconcileOrphanedTasksStartupIgnoresSpawnGrace verifies the startup pass
+// still sweeps a recently-started task: after a daemon restart every executor
+// pane is dead no matter how recently the task began.
+func TestReconcileOrphanedTasksStartupIgnoresSpawnGrace(t *testing.T) {
+	exec, database := newTestExecutor(t)
+
+	recent := createProcessingTask(t, database, "started just before restart")
+
+	exec.windowExistsFn = func(taskID int64) bool { return false }
+
+	exec.reconcileOrphanedTasks(true)
+
+	got, err := database.GetTask(recent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.StatusBlocked {
+		t.Fatalf("expected startup sweep to block recent task, got %q", got.Status)
 	}
 }


### PR DESCRIPTION
## The bug

`reconcileOrphanedTasks` moves tasks stuck in `processing` with no live executor window back to `blocked`. Its own doc comment states the stakes:

> Without this they stay stuck in 'processing' forever and the board lies about them still running.

But it was only ever called from `Start()` (`executor.go:263`) — **startup only**, not in the worker loop, not on a ticker. So it caught executors killed *by* a daemon restart, and nothing else. An executor that died mid-run under a healthy daemon left its task in `processing` until the next restart.

## How it surfaced

Task 4919's executor was revived by the TUI at 09:40:49 — four minutes *after* the boot sweep had run — then died at 09:44:57. Three sibling tasks (4915, 4874, 3261) whose executors died *at* the 09:40:34 restart were swept and came back automatically. 4919 was stranded, and the TUI polled its dead window forever:

```
INFO: findTaskWindow: window not found for task 4919  (stored ID: "@405")
```

Recovery took a manual `ty recover` + `ty retry`.

## The fix

Call the sweep from the worker loop every 60s, alongside the other reconcilers.

The periodic pass needs a guard the startup pass doesn't: a freshly spawned executor takes a moment to bring its tmux window up, and a TUI-started task never enters the daemon's `runningTasks` set — so without a grace period the sweep would block a task that's still coming up. Tasks whose `started_at` is within 90s are skipped. The startup pass ignores the grace period, since after a restart every pane is dead regardless of how recently the task began.

The log line now distinguishes "executor died" from "daemon restart" instead of blaming a restart that didn't happen.

## Tests

Three added to `reconcile_test.go`:
- `PeriodicSweepsDeadExecutor` — the regression: dead window + not in `runningTasks` → blocked
- `PeriodicRespectsSpawnGrace` — just-started task is left alone
- `StartupIgnoresSpawnGrace` — startup still sweeps a recently-started task

Mutation-checked the grace guard (replaced the condition with `if false`) to confirm `PeriodicRespectsSpawnGrace` actually fails without it — it does.

`go build ./...`, `go vet`, and `go test ./internal/...` all green; `gofmt` clean.

## Not covered

The tests exercise the function, not the ticker wiring — verifying that would mean driving the worker loop. The wiring is a one-line call next to four identical existing ones.

Also unaddressed: 4919's `completed_at` (09:40:34) is *earlier* than its `started_at`. The restart path stamps `completed_at` unconditionally — same class as the zombie-`completed_at` bug PR #660 fixed for pipeline steps. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)