### PR TITLE
feat(executor): add Warp Agent CLI as a task executor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Guide for AI agents working in this repository.
 This is **Task You** - a personal task management system with:
 - **SQLite storage** for tasks and projects
 - **SSH-accessible TUI** via Wish
-- **Background executor** with support for multiple AI coding agents (Claude, Codex, Gemini, Pi, OpenClaw, OpenCode)
+- **Background executor** with support for multiple AI coding agents (Claude, Codex, Gemini, Pi, OpenClaw, OpenCode, Warp)
 - **Beautiful terminal UI** built with Charm libraries (Kanban board)
 - **Git worktree isolation** for parallel task execution
 - **Task lifecycle hooks** for real-time task state tracking
@@ -306,6 +306,7 @@ TaskYou supports multiple AI coding agent backends:
 - **pi** - Pi coding agent with session continuity
 - **openclaw** - OpenClaw AI assistant
 - **opencode** - OpenCode AI assistant
+- **warp** - Warp Agent CLI (prompt delivered by tmux paste; `--auto-approve` for dangerous mode)
 
 Each task can specify its executor in the task form. The executor runs in an isolated git worktree with environment variables for task context.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Task You
 
-A personal task management system with background task execution via pluggable AI agents (Claude Code, OpenAI Codex, Gemini, Pi, OpenClaw, or OpenCode). Tasks live in SQLite, run in isolated git worktrees, and are tracked on a Kanban board.
+A personal task management system with background task execution via pluggable AI agents (Claude Code, OpenAI Codex, Gemini, Pi, OpenClaw, OpenCode, or Warp). Tasks live in SQLite, run in isolated git worktrees, and are tracked on a Kanban board.
 
 One engine — `ty` — three interfaces:
 
@@ -75,7 +75,7 @@ The same UI is also served in your browser at `http://localhost:8484` whenever `
 
 - **Kanban Board** - Visual task management with 4 columns (Backlog, In Progress, Blocked, Done)
 - **Git Worktrees** - Each task runs in an isolated worktree, no conflicts between parallel tasks
-- **Pluggable Executors** - Choose between Claude Code, OpenAI Codex, Gemini, Pi, OpenClaw, or OpenCode per task
+- **Pluggable Executors** - Choose between Claude Code, OpenAI Codex, Gemini, Pi, OpenClaw, OpenCode, or Warp per task
 - **Workflows** - Turn one goal into a multi-step DAG (e.g. plan → code → parallel review → collect), each step on its own executor/model, advancing automatically (see [Workflows](#workflows))
 - **Event Hooks & Plugins** - Run scripts when tasks change state, or drop in self-contained plugins (see [Event Hooks](#event-hooks) and [Plugins](#plugins))
 - **Ghost Text Autocomplete** - LLM-powered suggestions for task titles and descriptions as you type
@@ -455,12 +455,14 @@ Task You supports multiple AI executors for processing tasks. You can choose the
 | Pi | `pi` | [Pi Coding Agent](https://github.com/mariozechner/pi-coding-agent) - Multi-provider AI coding agent with session continuity |
 | OpenCode | `opencode` | [OpenCode](https://opencode.ai) - Open-source AI coding assistant with multi-LLM support |
 | OpenClaw | `openclaw` | [OpenClaw](https://openclaw.ai) - Open-source personal AI assistant with session resumption |
+| Warp | `warp` | [Warp Agent CLI](https://www.warp.dev/agent-cli) - Warp's terminal coding agent, driven as a TUI |
 
 All executors run in tmux windows with the same worktree isolation and environment variables. The main differences:
 
 - **Claude Code**, **Pi**, and **OpenClaw** support session resumption - when you retry a task, they continue with full conversation history
 - **Codex** and **Gemini** start fresh on each execution but receive the full prompt with any feedback
 - **OpenCode** does not support session resumption
+- **Warp** takes no prompt argument, so ty pastes the prompt into its TUI and submits it; retries start a fresh conversation. `--auto-approve` backs dangerous mode. The taskyou MCP server is not wired into Warp, so its prompt points it at the `ty` CLI (`ty complete`, `ty artifact ...`) instead of the `taskyou_*` tools
 
 ### Installing Executors
 
@@ -482,6 +484,10 @@ npm install -g @mariozechner/pi-coding-agent
 # OpenClaw
 npm install -g openclaw@latest
 openclaw onboard  # Run setup wizard
+
+# Warp Agent CLI
+curl -fsSL https://app.warp.dev/download/agent-cli | bash
+warp  # Complete the device login once, then quit
 ```
 
 ### How Task Executors Work
@@ -578,7 +584,7 @@ Claude Code supports **session resumption** - when you retry a task or press `R`
 
 This means when you retry a blocked task with feedback, Claude doesn't start over—it continues the conversation with full awareness of what it already tried.
 
-**Note:** Codex and Gemini do not support session resumption. When retrying these tasks, they receive the full prompt including any feedback, but start a fresh session. Claude Code and OpenClaw support full session resumption.
+**Note:** Codex, Gemini and Warp do not support session resumption. When retrying these tasks, they receive the full prompt including any feedback, but start a fresh session. Claude Code and OpenClaw support full session resumption.
 
 #### Lifecycle & Cleanup
 

--- a/cmd/task/completion.go
+++ b/cmd/task/completion.go
@@ -144,6 +144,7 @@ func completeFlagExecutors(cmd *cobra.Command, args []string, toComplete string)
 		"pi\tInflection Pi",
 		"opencode\tOpenCode",
 		"openclaw\tOpenClaw",
+		"warp\tWarp Agent CLI",
 	}, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/task/completion_test.go
+++ b/cmd/task/completion_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/bborn/workflow/internal/db"
 )
 
 func TestNewCompletionCmd(t *testing.T) {
@@ -100,8 +103,22 @@ func TestCompleteFlagExecutors(t *testing.T) {
 	if directive != cobra.ShellCompDirectiveNoFileComp {
 		t.Errorf("expected NoFileComp directive")
 	}
-	if len(completions) != 6 {
-		t.Errorf("expected 6 executors, got %d", len(completions))
+	// Every executor ty can drive should be offered, so a new backend can't ship
+	// without its completion entry.
+	for _, want := range []string{
+		db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini,
+		db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw, db.ExecutorWarp,
+	} {
+		found := false
+		for _, c := range completions {
+			if strings.HasPrefix(c, want+"\t") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("executor %q missing from completions %v", want, completions)
+		}
 	}
 }
 

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -763,7 +763,7 @@ Examples:
 			}
 
 			// Validate executor if provided
-			validExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw}
+			validExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw, db.ExecutorWarp}
 			if taskExecutor != "" {
 				validExecutor := false
 				for _, e := range validExecutors {
@@ -897,7 +897,7 @@ Examples:
 	createCmd.Flags().String("body", "", "Task body/description (if no title, AI generates from body)")
 	createCmd.Flags().StringP("type", "t", "", "Task type: code, writing, thinking (default: code)")
 	createCmd.Flags().StringP("project", "p", "", "Project name (auto-detected from cwd if not specified)")
-	createCmd.Flags().StringP("executor", "e", "", "Task executor: claude, codex, gemini, pi, opencode, openclaw (default: claude)")
+	createCmd.Flags().StringP("executor", "e", "", "Task executor: claude, codex, gemini, pi, opencode, openclaw, warp (default: claude)")
 	createCmd.Flags().String("effort", "", "Per-task Claude effort override: low, medium, high, xhigh, max (default: Claude's global default)")
 	createCmd.Flags().String("model", "", "Per-task Claude model override: opus, sonnet, haiku, or a full model name (default: Claude's global default)")
 	createCmd.Flags().BoolP("execute", "x", false, "Queue task for immediate execution")
@@ -1873,7 +1873,7 @@ Examples:
 
 			// Validate executor if provided
 			if taskExecutor != "" {
-				validExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw}
+				validExecutors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorPi, db.ExecutorOpenCode, db.ExecutorOpenClaw, db.ExecutorWarp}
 				validExecutor := false
 				for _, e := range validExecutors {
 					if e == taskExecutor {
@@ -1932,7 +1932,7 @@ Examples:
 	updateCmd.Flags().String("body", "", "Update task body/description")
 	updateCmd.Flags().StringP("type", "t", "", "Update task type: code, writing, thinking")
 	updateCmd.Flags().StringP("project", "p", "", "Update project name")
-	updateCmd.Flags().StringP("executor", "e", "", "Update task executor: claude, codex, gemini, pi, opencode, openclaw")
+	updateCmd.Flags().StringP("executor", "e", "", "Update task executor: claude, codex, gemini, pi, opencode, openclaw, warp")
 	updateCmd.Flags().String("tags", "", "Update task tags (comma-separated)")
 	updateCmd.Flags().Bool("pinned", false, "Pin or unpin the task")
 	updateCmd.RegisterFlagCompletionFunc("project", completeFlagProjects)
@@ -5661,12 +5661,12 @@ func getSessions() []agentSession {
 
 // getAgentMemoryByTaskID returns a map of task ID -> memory (MB) for all agent processes.
 // It identifies task IDs by examining each agent process's working directory.
-// Supports all executors: claude, codex, gemini, openclaw, opencode, pi.
+// Supports all executors: claude, codex, gemini, openclaw, opencode, pi, warp.
 func getAgentMemoryByTaskID() map[int]int {
 	result := make(map[int]int)
 
 	// Find processes for all supported executors
-	executorNames := []string{"claude", "codex", "gemini", "openclaw", "opencode", "pi"}
+	executorNames := []string{"claude", "codex", "gemini", "openclaw", "opencode", "pi", "warp"}
 
 	for _, executorName := range executorNames {
 		pgrepOut, err := osexec.Command("pgrep", "-f", executorName).Output()

--- a/desktop/src-tauri/src/env_check.rs
+++ b/desktop/src-tauri/src/env_check.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use std::process::Command;
 
 /// Executor CLIs taskyou knows how to drive, in display order.
-const EXECUTOR_CLIS: &[&str] = &["claude", "codex", "gemini", "opencode", "pi", "openclaw"];
+const EXECUTOR_CLIS: &[&str] = &["claude", "codex", "gemini", "opencode", "pi", "openclaw", "warp"];
 
 /// Replace this process's PATH with the login shell's PATH so child processes
 /// (ty → tmux → executors) resolve tools the way the user's terminal does.

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -211,6 +211,7 @@ const (
 	ExecutorOpenClaw = "openclaw" // OpenClaw AI assistant (https://openclaw.ai)
 	ExecutorOpenCode = "opencode" // OpenCode AI assistant (https://opencode.ai)
 	ExecutorPi       = "pi"       // Pi coding agent (https://github.com/mariozechner/pi-coding-agent)
+	ExecutorWarp     = "warp"     // Warp Agent CLI (https://www.warp.dev/agent-cli)
 )
 
 // DefaultExecutor returns the default executor if none is specified.

--- a/internal/executor/auth_check.go
+++ b/internal/executor/auth_check.go
@@ -14,11 +14,15 @@ type authPattern struct {
 	reason string // human-readable explanation surfaced to the user
 }
 
-// authRequiredPatterns are phrases Claude Code prints when its login/cloud
+// authRequiredPatterns are phrases an executor prints when its login/cloud
 // session has expired or is otherwise unauthenticated. Multi-word phrases are
 // used deliberately to avoid false positives from ordinary task output (e.g. a
 // diff that happens to mention "login").
 var authRequiredPatterns = []authPattern{
+	// Warp Agent CLI shows a device-code login screen instead of the agent when
+	// it has no credentials, and otherwise sits there indefinitely.
+	{"log in with warp", "Warp is not logged in — run warp and complete the device login"},
+	{"waiting for login...", "Warp is waiting for a device login to complete"},
 	{"please run /login", "Claude session expired — run /login to re-authenticate"},
 	{"run `/login`", "Claude session expired — run /login to re-authenticate"},
 	{"oauth token has expired", "Claude OAuth token expired — run /login to re-authenticate"},

--- a/internal/executor/dangerous_mode_test.go
+++ b/internal/executor/dangerous_mode_test.go
@@ -80,6 +80,13 @@ func TestExecutorInterfaceImplementation(t *testing.T) {
 			supportsDangerousMode: false, // Pi does not support dangerous mode
 			dangerousFlag:         "",
 		},
+		{
+			name:                  "Warp executor",
+			executorName:          db.ExecutorWarp,
+			supportsSessionResume: false, // Warp resume tokens are not discoverable
+			supportsDangerousMode: true,
+			dangerousFlag:         "--auto-approve",
+		},
 	}
 
 	for _, tt := range tests {
@@ -994,7 +1001,7 @@ func TestBuildCommandIncludesEnvironmentVariables(t *testing.T) {
 		WorktreePath: "/home/user/projects/myapp/.task-worktrees/42-fix-bug",
 	}
 
-	executors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorOpenClaw, db.ExecutorOpenCode}
+	executors := []string{db.ExecutorClaude, db.ExecutorCodex, db.ExecutorGemini, db.ExecutorOpenClaw, db.ExecutorOpenCode, db.ExecutorWarp}
 
 	for _, name := range executors {
 		t.Run(name, func(t *testing.T) {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -186,6 +186,7 @@ func New(database *db.DB, cfg *config.Config) *Executor {
 	e.executorFactory.Register(NewOpenClawExecutor(e))
 	e.executorFactory.Register(NewOpenCodeExecutor(e))
 	e.executorFactory.Register(NewPiExecutor(e))
+	e.executorFactory.Register(NewWarpExecutor(e))
 
 	return e
 }
@@ -224,6 +225,7 @@ func NewWithLogging(database *db.DB, cfg *config.Config, w io.Writer) *Executor 
 	e.executorFactory.Register(NewOpenClawExecutor(e))
 	e.executorFactory.Register(NewOpenCodeExecutor(e))
 	e.executorFactory.Register(NewPiExecutor(e))
+	e.executorFactory.Register(NewWarpExecutor(e))
 
 	return e
 }

--- a/internal/executor/warp_executor.go
+++ b/internal/executor/warp_executor.go
@@ -1,0 +1,429 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/charmbracelet/log"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// WarpExecutor implements TaskExecutor for the Warp Agent CLI — the agent from
+// the Warp terminal, shipped as a standalone TUI that runs in any terminal.
+// See: https://www.warp.dev/agent-cli
+//
+// CLI Reference (warp --help):
+//   - warp                     Start the interactive agent TUI
+//   - warp --auto-approve      Approve agent actions without prompting
+//   - warp --resume <TOKEN>    Resume a conversation by server token
+//   - warp --api-key <KEY>     Non-interactive auth (also WARP_API_KEY)
+//
+// Unlike every other executor ty drives, the Warp CLI accepts no prompt on the
+// command line: it is a TUI with a single input box and nothing else. So the
+// prompt is delivered the way a human would deliver it — a tmux bracketed paste
+// into the agent pane once the TUI owns it, followed by Enter. Warp advertises
+// bracketed paste (DECSET 2004) on startup, so a multi-line markdown prompt
+// arrives as one paste rather than as one submission per line.
+type WarpExecutor struct {
+	executor       *Executor
+	logger         *log.Logger
+	suspendedTasks map[int64]time.Time
+}
+
+// NewWarpExecutor creates a new Warp executor.
+func NewWarpExecutor(e *Executor) *WarpExecutor {
+	return &WarpExecutor{
+		executor:       e,
+		logger:         e.logger,
+		suspendedTasks: make(map[int64]time.Time),
+	}
+}
+
+// Name returns the executor name.
+func (w *WarpExecutor) Name() string {
+	return db.ExecutorWarp
+}
+
+// IsAvailable checks if the warp CLI is installed.
+func (w *WarpExecutor) IsAvailable() bool {
+	_, err := exec.LookPath("warp")
+	return err == nil
+}
+
+// Execute runs a task using the Warp Agent CLI.
+func (w *WarpExecutor) Execute(ctx context.Context, task *db.Task, workDir, prompt string) ExecResult {
+	return w.runWarp(ctx, task, workDir, prompt, "", false)
+}
+
+// Resume replays the full prompt plus feedback. Warp conversations are resumable
+// only by a server-side token the CLI does not hand back to us, so a retry starts
+// a fresh conversation (see SupportsSessionResume).
+func (w *WarpExecutor) Resume(ctx context.Context, task *db.Task, workDir, prompt, feedback string) ExecResult {
+	return w.runWarp(ctx, task, workDir, prompt, feedback, true)
+}
+
+func (w *WarpExecutor) runWarp(ctx context.Context, task *db.Task, workDir, prompt, feedback string, isResume bool) ExecResult {
+	paths := w.executor.claudePathsForProject(task.Project)
+
+	if !w.IsAvailable() {
+		w.executor.logLine(task.ID, "error", "warp CLI is not installed - run: curl -fsSL https://app.warp.dev/download/agent-cli | bash")
+		return ExecResult{Message: "warp CLI is not installed"}
+	}
+
+	if _, err := exec.LookPath("tmux"); err != nil {
+		w.executor.logLine(task.ID, "error", "tmux is not installed - required for task execution")
+		return ExecResult{Message: "tmux is not installed"}
+	}
+
+	daemonSession, err := ensureTmuxDaemon()
+	if err != nil {
+		w.logger.Error("could not create task-daemon session", "error", err)
+		w.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux daemon: %s", err.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create tmux daemon: %s", err.Error())}
+	}
+
+	windowName := TmuxWindowName(task.ID)
+	windowTarget := fmt.Sprintf("%s:%s", daemonSession, windowName)
+
+	// Kill ALL existing windows with this name (handles duplicates)
+	KillAllWindowsByNameAllSessions(windowName)
+
+	promptFile, err := writeWarpPromptFile(buildWarpPrompt(workDir, prompt, feedback, isResume))
+	if err != nil {
+		w.logger.Error("could not create temp file", "error", err)
+		w.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create temp file: %s", err.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create temp file: %s", err.Error())}
+	}
+	// The launch script removes the prompt file once it has been pasted; this is
+	// the backstop for the paths where the window never starts.
+	defer os.Remove(promptFile)
+
+	script := warpLaunchScript(task, workDir, promptFile, claudeEnvPrefix(paths.configDir))
+
+	actualSession, tmuxErr := createTmuxWindow(daemonSession, windowName, workDir, script, w.executor.getProjectDir(task.Project), task.ID)
+	if tmuxErr != nil {
+		w.logger.Error("tmux new-window failed", "error", tmuxErr, "session", daemonSession)
+		w.executor.logLine(task.ID, "error", fmt.Sprintf("Failed to create tmux window: %s", tmuxErr.Error()))
+		return ExecResult{Message: fmt.Sprintf("failed to create tmux window: %s", tmuxErr.Error())}
+	}
+
+	if actualSession != daemonSession {
+		windowTarget = fmt.Sprintf("%s:%s", actualSession, windowName)
+		daemonSession = actualSession
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := w.executor.db.UpdateTaskDaemonSession(task.ID, daemonSession); err != nil {
+		w.logger.Warn("failed to save daemon session", "task", task.ID, "error", err)
+	}
+	if windowID := getWindowID(daemonSession, windowName); windowID != "" {
+		if err := w.executor.db.UpdateTaskWindowID(task.ID, windowID); err != nil {
+			w.logger.Warn("failed to save window ID", "task", task.ID, "error", err)
+		}
+	}
+
+	w.executor.ensureShellPane(windowTarget, workDir, task.ID, task.Port, task.WorktreePath, paths.configDir)
+	w.executor.configureTmuxWindow(windowTarget)
+
+	result := w.executor.pollTmuxSession(ctx, task.ID, windowTarget)
+
+	return ExecResult(result)
+}
+
+// buildWarpPrompt assembles the text pasted into the Warp TUI.
+//
+// The working-directory preamble matches the other TUI executors. The tooling
+// note is Warp-specific: ty injects its MCP server into Claude Code's config,
+// but has no equivalent hook into Warp, so the agent has to reach ty through the
+// `ty` CLI instead of the taskyou_* tools the shared prompt tells it to expect.
+func buildWarpPrompt(workDir, prompt, feedback string, isResume bool) string {
+	var b strings.Builder
+	b.WriteString("## Working Directory\n\n")
+	b.WriteString(fmt.Sprintf("You are working in a git worktree at: `%s`\n\n", workDir))
+	b.WriteString("IMPORTANT: All file operations (reading, writing, creating files) MUST be done within this directory. ")
+	b.WriteString("Do NOT use your default workspace. Always use absolute paths or paths relative to this working directory.\n\n")
+	b.WriteString("## TaskYou Tooling\n\n")
+	b.WriteString("The taskyou MCP server is NOT connected to this session, so the taskyou_* tools described below are unavailable to you. ")
+	b.WriteString("Use the `ty` CLI instead — it is on PATH and resolves the task from WORKTREE_TASK_ID:\n")
+	b.WriteString("- Finish the task:      ty complete --summary \"<summary>\"   (equivalent to taskyou_complete)\n")
+	b.WriteString("- Ask for input:        ty needs-input \"<question>\"          (equivalent to taskyou_needs_input)\n")
+	b.WriteString("- Workflow documents:   ty artifact get|set|list\n\n")
+	b.WriteString("---\n\n")
+	b.WriteString(prompt)
+	if isResume && feedback != "" {
+		b.WriteString("\n\n## User Feedback\n\n")
+		b.WriteString(feedback)
+	}
+	return b.String()
+}
+
+// writeWarpPromptFile stores the prompt in a temp file so it can be handed to
+// tmux load-buffer verbatim, with no shell quoting in the path.
+func writeWarpPromptFile(prompt string) (string, error) {
+	f, err := os.CreateTemp("", "task-prompt-*.txt")
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.WriteString(prompt); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+// warpReadyPollAttempts and warpReadyPollInterval bound how long the prompt
+// feeder waits for the TUI to take over the pane before pasting anyway.
+const (
+	warpReadyPollAttempts = 60
+	warpReadyPollInterval = "0.25"
+	// warpSettleDelay gives the TUI time to finish its first draw and put the
+	// cursor in the input box after it becomes the pane's foreground process.
+	warpSettleDelay = "2"
+)
+
+// warpLaunchScript builds the shell script for a task's Warp session. It is the
+// single source of truth for how ty starts Warp, shared by the daemon path
+// (runWarp) and the interactive path (BuildCommand), so the two can't drift.
+//
+// promptFile may be empty to start Warp with no prompt (a bare interactive
+// session). Warp's `--resume` is deliberately never passed: it takes a Warp
+// conversation token, and the only session ID ty stores for a task
+// (ClaudeSessionID) may hold another agent's identifier entirely.
+func warpLaunchScript(task *db.Task, workDir, promptFile, envPrefix string) string {
+	worktreeSessionID := os.Getenv("WORKTREE_SESSION_ID")
+	if worktreeSessionID == "" {
+		worktreeSessionID = fmt.Sprintf("%d", os.Getpid())
+	}
+
+	envVars := fmt.Sprintf(`WORKTREE_TASK_ID=%d WORKTREE_SESSION_ID=%s WORKTREE_PORT=%d WORKTREE_PATH=%q`,
+		task.ID, worktreeSessionID, task.Port, task.WorktreePath)
+
+	flags := ""
+	if task.DangerousMode {
+		flags += " --auto-approve"
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("cd %q\n", workDir))
+	if promptFile != "" {
+		b.WriteString(warpPromptFeeder(task.ID, promptFile))
+		b.WriteString("\n")
+	}
+	// exec so the Warp binary — not the wrapping shell — becomes the pane's
+	// foreground process: that is what the feeder above waits on, and what
+	// GetProcessID matches.
+	b.WriteString(fmt.Sprintf("exec env %s %s warp%s\n", envVars, envPrefix, flags))
+	return b.String()
+}
+
+// warpPromptFeeder returns a backgrounded POSIX-sh block that pastes promptFile
+// into this pane once the Warp TUI owns it, then presses Enter to submit.
+//
+// tmux paste-buffer -p wraps the text in bracketed-paste markers, which Warp
+// enables at startup, so an embedded newline does not submit a partial prompt.
+// Everything is best-effort: a failed paste must not take the session down, and
+// the prompt file is removed either way.
+func warpPromptFeeder(taskID int64, promptFile string) string {
+	buffer := fmt.Sprintf("ty-warp-%d", taskID)
+	return fmt.Sprintf(`(
+  i=0
+  while [ $i -lt %d ]; do
+    case "$(tmux display-message -p -t "$TMUX_PANE" '#{pane_current_command}' 2>/dev/null)" in
+      *warp*) break ;;
+    esac
+    i=$((i + 1))
+    sleep %s
+  done
+  sleep %s
+  if tmux load-buffer -b %s %q 2>/dev/null; then
+    tmux paste-buffer -d -p -b %s -t "$TMUX_PANE" 2>/dev/null && \
+      sleep 0.5 && tmux send-keys -t "$TMUX_PANE" Enter 2>/dev/null
+  fi
+  rm -f %q
+) >/dev/null 2>&1 &`,
+		warpReadyPollAttempts, warpReadyPollInterval, warpSettleDelay,
+		buffer, promptFile, buffer, promptFile)
+}
+
+// GetProcessID returns the PID of the Warp process for a task.
+func (w *WarpExecutor) GetProcessID(taskID int64) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	windowName := TmuxWindowName(taskID)
+
+	out, err := exec.CommandContext(ctx, "tmux", "list-panes", "-a", "-F", "#{session_name}:#{window_name}:#{pane_index} #{pane_pid}").Output()
+	if err != nil {
+		return 0
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		target := parts[0]
+		pidStr := parts[1]
+		if !strings.Contains(target, windowName) {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		// The launch script execs warp, so the pane process itself is normally
+		// the agent. The binary is installed as warp-tui-<channel> behind a
+		// `warp` symlink, so match on the prefix rather than an exact name.
+		cmdOut, _ := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+		if strings.Contains(string(cmdOut), "warp") {
+			return pid
+		}
+		// Fall back to a child process for setups where a wrapper shell survives.
+		childOut, err := exec.CommandContext(ctx, "pgrep", "-P", strconv.Itoa(pid), "-f", "warp").Output()
+		if err == nil && len(childOut) > 0 {
+			childPid, err := strconv.Atoi(strings.TrimSpace(strings.Split(string(childOut), "\n")[0]))
+			if err == nil {
+				return childPid
+			}
+		}
+	}
+	return 0
+}
+
+// Kill terminates the Warp process for a task.
+func (w *WarpExecutor) Kill(taskID int64) bool {
+	pid := w.GetProcessID(taskID)
+	if pid == 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		w.logger.Debug("Failed to find Warp process", "pid", pid, "error", err)
+		return false
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		w.logger.Debug("Failed to terminate Warp process", "pid", pid, "error", err)
+		return false
+	}
+	w.logger.Info("Terminated Warp process", "task", taskID, "pid", pid)
+	delete(w.suspendedTasks, taskID)
+	return true
+}
+
+// Suspend pauses the Warp process for a task.
+func (w *WarpExecutor) Suspend(taskID int64) bool {
+	pid := w.GetProcessID(taskID)
+	if pid == 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		w.logger.Debug("Failed to find process", "pid", pid, "error", err)
+		return false
+	}
+	if err := sendSIGTSTP(proc); err != nil {
+		w.logger.Debug("Failed to suspend process", "pid", pid, "error", err)
+		return false
+	}
+	w.suspendedTasks[taskID] = time.Now()
+	w.logger.Info("Suspended Warp process", "task", taskID, "pid", pid)
+	w.executor.logLine(taskID, "system", "Warp suspended (idle timeout)")
+	return true
+}
+
+// IsSuspended reports whether the Warp process is suspended for a task.
+func (w *WarpExecutor) IsSuspended(taskID int64) bool {
+	_, suspended := w.suspendedTasks[taskID]
+	return suspended
+}
+
+// ResumeProcess resumes a previously suspended Warp process.
+func (w *WarpExecutor) ResumeProcess(taskID int64) bool {
+	if !w.IsSuspended(taskID) {
+		return false
+	}
+	pid := w.GetProcessID(taskID)
+	if pid == 0 {
+		delete(w.suspendedTasks, taskID)
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		delete(w.suspendedTasks, taskID)
+		return false
+	}
+	if err := sendSIGCONT(proc); err != nil {
+		w.logger.Debug("Failed to resume process", "pid", pid, "error", err)
+		return false
+	}
+	delete(w.suspendedTasks, taskID)
+	w.logger.Info("Resumed Warp process", "task", taskID, "pid", pid)
+	w.executor.logLine(taskID, "system", "Warp resumed")
+	return true
+}
+
+// BuildCommand returns the shell command to start an interactive Warp session.
+// sessionID is ignored: Warp conversations are not resumable from ty (see
+// SupportsSessionResume), so a reconnect always starts a fresh conversation.
+func (w *WarpExecutor) BuildCommand(task *db.Task, sessionID, prompt string) string {
+	promptFile := ""
+	if prompt != "" {
+		var err error
+		promptFile, err = writeWarpPromptFile(prompt)
+		if err != nil {
+			w.logger.Error("BuildCommand: failed to create temp file", "error", err)
+			promptFile = ""
+		}
+	}
+	return warpLaunchScript(task, w.executor.taskWorkdir(task), promptFile, "")
+}
+
+// ---- Session and Dangerous Mode Support ----
+
+// SupportsSessionResume returns false. Warp's `--resume` takes a server-side
+// conversation token, and the CLI does not expose that token to the process that
+// launched it, so ty has nothing to store or rediscover.
+func (w *WarpExecutor) SupportsSessionResume() bool {
+	return false
+}
+
+// SupportsDangerousMode returns true - Warp supports --auto-approve.
+func (w *WarpExecutor) SupportsDangerousMode() bool {
+	return true
+}
+
+// FindSessionID returns empty - Warp conversation tokens are not discoverable
+// from the filesystem.
+func (w *WarpExecutor) FindSessionID(workDir string) string {
+	return ""
+}
+
+// ResumeDangerous is not supported: toggling the flag means restarting Warp, and
+// without a resumable session that would silently discard the conversation.
+func (w *WarpExecutor) ResumeDangerous(task *db.Task, workDir string) bool {
+	w.executor.logLine(task.ID, "system", "Warp cannot switch to auto-approve mid-session (no session resume); restart the task with dangerous mode enabled")
+	return false
+}
+
+// ResumeSafe is not supported for the same reason as ResumeDangerous.
+func (w *WarpExecutor) ResumeSafe(task *db.Task, workDir string) bool {
+	w.executor.logLine(task.ID, "system", "Warp cannot leave auto-approve mid-session (no session resume); restart the task with dangerous mode disabled")
+	return false
+}

--- a/internal/executor/warp_executor_test.go
+++ b/internal/executor/warp_executor_test.go
@@ -1,0 +1,295 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+func newWarpTestExecutor(t *testing.T) *Executor {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	database, err := db.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	return New(database, &config.Config{})
+}
+
+func warpTask() *db.Task {
+	return &db.Task{
+		ID:           42,
+		Port:         9000,
+		WorktreePath: "/tmp/projects/myapp/.task-worktrees/42-fix-bug",
+	}
+}
+
+// TestWarpLaunchScriptExecsWarp guards the property the prompt feeder depends on:
+// the Warp binary — not the wrapping shell — must become the pane's foreground
+// process, or `pane_current_command` never matches and the paste is delayed
+// until the readiness loop times out.
+func TestWarpLaunchScriptExecsWarp(t *testing.T) {
+	script := warpLaunchScript(warpTask(), "/tmp/work", "", "")
+
+	if !strings.Contains(script, "exec env ") {
+		t.Errorf("launch script should exec the warp binary, got:\n%s", script)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(script), "warp") {
+		t.Errorf("launch script should end by running warp, got:\n%s", script)
+	}
+	for _, want := range []string{"WORKTREE_TASK_ID=42", "WORKTREE_PORT=9000", "WORKTREE_PATH="} {
+		if !strings.Contains(script, want) {
+			t.Errorf("launch script should contain %q, got:\n%s", want, script)
+		}
+	}
+}
+
+func TestWarpLaunchScriptFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		dangerous bool
+		want      []string
+		notWant   []string
+	}{
+		{
+			name: "default has no flags",
+			// --resume is never passed: ty has no Warp conversation token, and
+			// task.ClaudeSessionID may belong to a different agent entirely.
+			notWant: []string{"--auto-approve", "--resume"},
+		},
+		{
+			name:      "dangerous mode auto-approves",
+			dangerous: true,
+			want:      []string{"--auto-approve"},
+			notWant:   []string{"--resume"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := warpTask()
+			task.DangerousMode = tt.dangerous
+
+			script := warpLaunchScript(task, "/tmp/work", "", "")
+
+			for _, want := range tt.want {
+				if !strings.Contains(script, want) {
+					t.Errorf("script should contain %q, got:\n%s", want, script)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(script, notWant) {
+					t.Errorf("script should not contain %q, got:\n%s", notWant, script)
+				}
+			}
+		})
+	}
+}
+
+// TestWarpLaunchScriptPromptFeeder checks the paste path: Warp takes no prompt
+// argument, so the prompt only reaches it via a bracketed tmux paste.
+func TestWarpLaunchScriptPromptFeeder(t *testing.T) {
+	promptFile := "/tmp/task-prompt-xyz.txt"
+	script := warpLaunchScript(warpTask(), "/tmp/work", promptFile, "")
+
+	for _, want := range []string{
+		"load-buffer",
+		"paste-buffer -d -p", // -p keeps a multi-line prompt as a single paste
+		"send-keys",          // submit
+		`"$TMUX_PANE"`,       // target this pane, not whatever is active
+		"rm -f " + `"` + promptFile + `"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("feeder should contain %q, got:\n%s", want, script)
+		}
+	}
+
+	// No prompt file means no feeder at all.
+	bare := warpLaunchScript(warpTask(), "/tmp/work", "", "")
+	if strings.Contains(bare, "paste-buffer") {
+		t.Errorf("bare session should not paste anything, got:\n%s", bare)
+	}
+}
+
+// TestWarpLaunchScriptIsValidShell catches quoting mistakes in the generated
+// script before they turn into a window that dies on startup.
+func TestWarpLaunchScriptIsValidShell(t *testing.T) {
+	task := warpTask()
+	task.DangerousMode = true
+
+	script := warpLaunchScript(task, "/tmp/work dir", "/tmp/task prompt.txt", "CLAUDE_CONFIG_DIR=/tmp/cfg ")
+
+	cmd := exec.Command("sh", "-n")
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Errorf("generated script is not valid sh: %v\n%s\nscript:\n%s", err, out, script)
+	}
+}
+
+func TestBuildWarpPrompt(t *testing.T) {
+	prompt := buildWarpPrompt("/tmp/wt/42-fix", "Do the thing", "", false)
+
+	if !strings.Contains(prompt, "/tmp/wt/42-fix") {
+		t.Errorf("prompt should name the worktree, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Do the thing") {
+		t.Errorf("prompt should contain the task prompt, got:\n%s", prompt)
+	}
+	// Warp has no taskyou MCP server, so it must be pointed at the ty CLI.
+	if !strings.Contains(prompt, "ty complete") {
+		t.Errorf("prompt should point Warp at the ty CLI for completion, got:\n%s", prompt)
+	}
+
+	withFeedback := buildWarpPrompt("/tmp/wt/42-fix", "Do the thing", "Also fix the tests", true)
+	if !strings.Contains(withFeedback, "Also fix the tests") {
+		t.Errorf("resume prompt should include feedback, got:\n%s", withFeedback)
+	}
+	if strings.Contains(prompt, "Also fix the tests") {
+		t.Error("fresh prompt should not include feedback")
+	}
+}
+
+func TestWarpBuildCommandWritesPromptFile(t *testing.T) {
+	e := newWarpTestExecutor(t)
+	warp := e.executorFactory.Get(db.ExecutorWarp)
+	if warp == nil {
+		t.Fatal("warp executor not registered")
+	}
+
+	script := warp.BuildCommand(warpTask(), "", "Fix the flaky test")
+
+	path := warpPromptPathFromScript(t, script)
+	defer os.Remove(path)
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("prompt file not written: %v", err)
+	}
+	if !strings.Contains(string(content), "Fix the flaky test") {
+		t.Errorf("prompt file should hold the prompt, got %q", content)
+	}
+}
+
+// warpPromptPathFromScript pulls the temp prompt path back out of a launch script.
+func warpPromptPathFromScript(t *testing.T, script string) string {
+	t.Helper()
+	for _, line := range strings.Split(script, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "rm -f ") {
+			continue
+		}
+		return strings.Trim(strings.TrimPrefix(line, "rm -f "), `"`)
+	}
+	t.Fatalf("no prompt file in script:\n%s", script)
+	return ""
+}
+
+// TestWarpPromptDeliveryInTmux runs the real launch script against a stub `warp`
+// that echoes whatever it is given, and asserts the prompt actually lands in the
+// pane. This is the only check that exercises the readiness wait, the bracketed
+// paste and the submit together.
+func TestWarpPromptDeliveryInTmux(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping tmux integration test in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+
+	dir := t.TempDir()
+
+	// A stub named `warp` that echoes whatever it is fed. It has to be a compiled
+	// binary rather than a shell script: the readiness wait matches on
+	// pane_current_command, which reports the interpreter for a script.
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available to build the warp stub")
+	}
+	stubSrc := filepath.Join(dir, "warp_stub.go")
+	if err := os.WriteFile(stubSrc, []byte("package main\n\nimport (\n\t\"io\"\n\t\"os\"\n)\n\nfunc main() { io.Copy(os.Stdout, os.Stdin) }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	build := exec.Command("go", "build", "-o", filepath.Join(binDir, "warp"), stubSrc)
+	build.Dir = dir
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Skipf("could not build warp stub: %v (%s)", err, out)
+	}
+
+	promptFile := filepath.Join(dir, "prompt.txt")
+	const promptText = "## Working Directory\n\nline two of the prompt\n"
+	if err := os.WriteFile(promptFile, []byte(promptText), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := "PATH=" + binDir + ":$PATH\n" + warpLaunchScript(warpTask(), dir, promptFile, "")
+
+	session := fmt.Sprintf("ty-warp-test-%d", os.Getpid())
+	if out, err := exec.Command("tmux", "new-session", "-d", "-s", session, "-x", "120", "-y", "40", "sh", "-c", script).CombinedOutput(); err != nil {
+		t.Fatalf("tmux new-session failed: %v (%s)", err, out)
+	}
+	defer exec.Command("tmux", "kill-session", "-t", session).Run()
+
+	// The stub echoes the paste back into the pane. Allow well under the
+	// readiness loop's own timeout, so a broken pane_current_command match
+	// (which would fall through to pasting blind) fails here instead of passing
+	// slowly.
+	deadline := time.Now().Add(12 * time.Second)
+	var got string
+	for time.Now().Before(deadline) {
+		pane, _ := exec.Command("tmux", "capture-pane", "-t", session, "-p").Output()
+		if strings.Contains(string(pane), "line two of the prompt") {
+			got = string(pane)
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	if got == "" {
+		pane, _ := exec.Command("tmux", "capture-pane", "-t", session, "-p").Output()
+		t.Fatalf("prompt never reached the pane\npane:\n%s", pane)
+	}
+	if !strings.Contains(got, "## Working Directory") {
+		t.Errorf("first line of the prompt was lost, pane:\n%s", got)
+	}
+
+	// The feeder is responsible for cleaning up after itself.
+	cleanupDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(cleanupDeadline) {
+		if _, err := os.Stat(promptFile); os.IsNotExist(err) {
+			return
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Errorf("prompt file %s was not removed after the paste", promptFile)
+}
+
+func TestWarpAuthPromptDetection(t *testing.T) {
+	// The device-login screen the Warp CLI shows when it has no credentials.
+	pane := "Welcome to Warp\n  ● Waiting for login...\n  Log in with Warp\n  Copy URL (c)"
+
+	reason, stuck := DetectAuthPrompt(pane)
+	if !stuck {
+		t.Fatal("logged-out Warp screen should be detected as needing auth")
+	}
+	if !strings.Contains(strings.ToLower(reason), "warp") {
+		t.Errorf("reason should name Warp, got %q", reason)
+	}
+}

--- a/internal/pipeline/generate.go
+++ b/internal/pipeline/generate.go
@@ -63,7 +63,7 @@ name: <kebab-case-id>
 description: <one line>
 steps:
   - name: <Step Name>
-    executor: <claude|codex|gemini|pi|opencode|openclaw>   # optional, default claude
+    executor: <claude|codex|gemini|pi|opencode|openclaw|warp>  # optional, default claude
     model: <opus|sonnet|haiku>                             # optional, only meaningful for claude
     deps: [<earlier step names>]                           # omit for the first step
     prompt: |


### PR DESCRIPTION
Adds the [Warp Agent CLI](https://www.warp.dev/agent-cli) as a ty executor, alongside claude / codex / gemini / pi / opencode / openclaw.

## The interesting part: Warp takes no prompt

Every other executor accepts the prompt as an argument. Warp does not — its entire flag surface is:

```
warp --resume <TOKEN> --auto-approve --api-key <KEY>
     --set-provider-api-key <p> --clear-provider-api-key <p>
```

It is a TUI with one input box, and it refuses to run without a TTY (`echo hi | warp` → `Error: Device not configured`). So the prompt is delivered the way a human delivers it. The launch script backgrounds a feeder that:

1. waits for the Warp binary to become the pane's foreground process (`pane_current_command`) — which is why the script `exec`s Warp instead of leaving a wrapper shell in the way,
2. `tmux load-buffer` + `paste-buffer -d -p` into `$TMUX_PANE`,
3. `send-keys Enter` to submit, then removes the prompt file.

`-p` is bracketed paste. I confirmed with `tmux pipe-pane` that Warp emits `ESC[?2004h` on startup, so a multi-line markdown prompt arrives as **one** paste instead of one submission per line.

`warpLaunchScript` is the single source of truth, shared by the daemon path (`runWarp`) and the interactive path (`BuildCommand`), so those two can't drift apart the way they have before.

## Capabilities

| | |
|---|---|
| Dangerous mode | ✅ `--auto-approve` |
| Session resume | ❌ (see below) |
| Runtime dangerous-mode toggle | ❌ — needs resume; logs why instead of silently failing |

**No session resume.** `--resume` takes a server-side conversation token that the CLI never hands back to the launching process, so ty has nothing to store or rediscover. `--resume` is therefore *never* passed: the only session ID ty keeps per task is `ClaudeSessionID`, which after an executor switch may hold a **Claude** session UUID. Passing that to Warp would be a live bug. Retries replay the prompt plus feedback.

**No MCP.** ty injects its MCP server into Claude Code's config; there is no equivalent hook for Warp, so the shared prompt's promise of `taskyou_*` tools is false here. The Warp prompt prefix says so explicitly and points the agent at the `ty` CLI (`ty complete`, `ty needs-input`, `ty artifact`) instead. Same gap pi/opencode have, handled rather than inherited.

**Auth detection.** A logged-out Warp shows a device-login screen and then sits there forever. `DetectAuthPrompt` now recognises it, so the task surfaces as auth-required instead of silently idling.

## Files

- `internal/executor/warp_executor.go` — new executor
- `internal/executor/warp_executor_test.go` — new tests
- `internal/executor/{executor,auth_check}.go` — registration + Warp login patterns
- `internal/db/tasks.go` — `ExecutorWarp`
- `cmd/task/{main,completion}.go`, `internal/pipeline/generate.go`, `desktop/src-tauri/src/env_check.rs` — validation, `--executor` help, shell completion, desktop CLI detection
- `README.md`, `AGENTS.md`

## Tests

`go test ./... ` green; `golangci-lint run` (v2.8.0, matching CI) reports 0 issues.

New coverage: launch-script shape (exec/flags/feeder), `sh -n` validity with spaces in paths, prompt assembly, and **`TestWarpPromptDeliveryInTmux`** — a real tmux window running the real launch script against a compiled stub named `warp`, asserting the prompt text actually lands in the pane and the temp file is cleaned up. Its 12s budget is deliberately under the feeder's own 15s readiness timeout, so a broken `pane_current_command` match fails the test instead of passing slowly. Skipped under `-short` or without tmux.

`TestCompleteFlagExecutors` now asserts each known executor slug is offered rather than counting to 6, so the next backend can't ship without its completion entry.

## QA

Verified end-to-end against the **real** Warp CLI (installed into a scratch dir, not `$HOME`) on an isolated ty instance (`scripts/qa`, private DB + tmux server):

- daemon created the worktree, allocated a port, and spawned Warp: `pane_current_command` = `warp-tui-stable` ✅
- Warp isn't logged in here, so it showed its device-login screen, and ty blocked the task on its own:

```
task_logs: error | Warp is waiting for a device login to complete
tasks:     status = blocked
```

```
   Welcome to Warp
   ● Waiting for login...
   Visit https://app.warp.dev/device?user_code=... to get started
```

![new-task form — Executor ‹ warp ›](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-08-04/5061-warp-form.png)

![detail view — "Starting Warp..."](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-08-04/5061-warp-detail.png)

![board with the warp task](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-08-04/5061-warp-board.png)

**Not verified:** that Warp's input box accepts the paste and starts working — that needs an authenticated Warp account, which this session doesn't have. The paste mechanism itself is verified (bracketed paste advertised by the real binary; delivery proven in the tmux test), but the first authenticated run is worth eyeballing.

## Follow-ups

- **Worktree write guard.** Warp's settings schema has `ExecutionProfileFile` with `directory_allowlist`, `command_allowlist/denylist` and `apply_code_diffs`/`execute_commands` permissions — the makings of a real guard like the OpenCode plugin one. It lives in Warp's *global* settings though, so a per-task profile needs a safe way to scope it; skipped rather than racing concurrent tasks through a shared file.
- **MCP.** `mcp_servers.file_based_mcp_enabled` suggests Warp can pick up file-based MCP configs; if so, ty could inject the taskyou server properly and drop the CLI-fallback prompt.
- **Session resume** if Warp ever surfaces the conversation token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
