### PR TITLE
docs: correct when the worktree teardown script runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,9 @@ This means when you retry a blocked task with feedback, Claude doesn't start ove
 |-------|----------|
 | Task completes | Process stays alive for 30 minutes, then auto-killed |
 | Task blocked | Process suspends after 6 hours of idle time |
-| Task deleted | Window killed, worktree removed, teardown script runs |
+| Task deleted (`d`) | Window killed, task trashed — worktree kept on disk so it can be restored |
+| Trash retention expires | Worktree removed, [teardown script](#worktree-teardown-script) runs (default 14 days) |
+| Task archived, or stale-worktree sweep | Worktree archived to a git ref and removed, [teardown script](#worktree-teardown-script) runs (sweep default: 24h after completion) |
 | Daemon restart | Orphaned windows are cleaned up on next poll |
 
 ## Routines
@@ -787,7 +789,7 @@ worktree:
 | Field | Description | Example |
 |-------|-------------|---------|
 | `worktree.init_script` | Path to script that runs after worktree creation (relative or absolute) | `bin/worktree-setup` |
-| `worktree.teardown_script` | Path to script that runs before worktree deletion (relative or absolute) | `bin/worktree-teardown` |
+| `worktree.teardown_script` | Path to script that runs before a worktree is removed — on archive as well as delete (relative or absolute) | `bin/worktree-teardown` |
 
 ### Projects
 
@@ -836,18 +838,32 @@ The script runs in the worktree directory and has access to all worktree environ
 
 #### Worktree Teardown Script
 
-You can configure a script to run automatically before a worktree is deleted.
-
-**Important:** The teardown script **only runs when a task is deleted** (via the `d` key in the TUI or `task delete` command). It does **not** run when:
-- A task completes (moves to `done` status)
-- A task is archived or closed
-- You manually remove the worktree via `git worktree remove` or `rm -rf`
-
-This is useful for:
+You can configure a script to run automatically just before a worktree is removed. This is useful for releasing per-worktree resources:
 - Dropping task-specific databases
-- Stopping background services
-- Cleaning up docker containers
+- Freeing an allocated Redis DB, S3 prefix, or dev-server symlink
+- Stopping background services and docker containers
 - Removing temporary files
+
+TaskYou removes a worktree in one of two ways — **archive** (worktree state, including uncommitted changes, is first saved to a git ref so the task can be unarchived later with everything restored) and **delete** — and the teardown script runs on **both**.
+
+**When it runs:**
+
+| Trigger | How the worktree goes away |
+|---------|---------------------------|
+| **Automatic stale-worktree sweep** — the daemon archives and removes worktrees for `done`/`archived` tasks whose completion is older than the cleanup max age (default **24h**, setting `worktree_cleanup_max_age`; set to `0`/`disabled` to turn off) | archive |
+| `ty worktrees cleanup` (`--max-age 0` sweeps every done/archived worktree now, `--dry-run` previews) | archive |
+| Archiving a task in the TUI (`a`) | archive |
+| **Trash sweep** — a trashed task's worktree is removed once the retention window expires (default **14 days**, setting `trash_retention`) | delete |
+| `ty delete --hard` | delete |
+| Moving a task to another project (`ty move`, or the TUI move action) — the old worktree is removed | delete |
+
+So a finished task releases its resources on its own: by default the sweep archives and tears down its worktree ~24 hours after it completes. You do not need to build a separate reaper.
+
+Note that `d` in the TUI and plain `ty delete` **trash** a task rather than destroying it — the worktree is deliberately left on disk so `ty restore` works. Teardown for those runs later, when the trash sweep hard-deletes the task (or immediately if you pass `--hard`).
+
+**When it does not run:**
+- You remove the worktree yourself, outside TaskYou (`git worktree remove`, `rm -rf`) — TaskYou never sees it happen.
+- Projects that don't use worktrees (the task runs in the project directory itself). Nothing per-task was created, so nothing is torn down.
 
 **Two ways to configure:**
 
@@ -864,7 +880,11 @@ worktree:
   teardown_script: scripts/my-teardown.sh
 ```
 
-**Note:** If you want automated cleanup when tasks complete (not just when deleted), use [Event Hooks](#event-hooks) to trigger your teardown script on the `task.completed` event.
+The script is resolved from the project root but executed with the worktree as its working directory, with the same environment variables as the setup script (`WORKTREE_TASK_ID`, `WORKTREE_PORT`, `WORKTREE_PATH`). Its output is streamed into the task log, prefixed with `[teardown]`.
+
+**Your teardown script must not refuse to run.** A non-zero exit is logged as a warning and TaskYou removes the worktree anyway — cleanup never fails on your script. A script that guards itself (bailing out when the worktree is dirty, for example) will therefore leak whatever it was supposed to release, silently. Write it to be unconditional and idempotent. TaskYou also waits for the script to finish with no timeout, so keep it quick.
+
+**Note:** Teardown is tied to worktree removal, not to task status, so it happens after the max-age delay rather than the moment a task finishes. If you need cleanup at the exact moment a task completes, use [Event Hooks](#event-hooks) on the `task.completed` event — but be aware the worktree is still live at that point (the agent's changes may not be merged yet), and the teardown script will still run later when the worktree is actually removed.
 
 ### Running Applications in Worktrees
 


### PR DESCRIPTION
## Problem

README's worktree-teardown section said:

> **Important:** The teardown script **only runs when a task is deleted** … It does **not** run when: a task completes … a task is archived or closed

That's wrong, and it's the kind of wrong that makes people build things they don't need. Reported by someone writing a `bin/worktree-teardown` that allocates a Redis DB, a Postgres clone and a puma-dev symlink per worktree — "delete only" implied they'd need a separate reaper for completed tasks.

## What the code actually does

`runWorktreeTeardownScript` (`internal/executor/executor.go:5530`) has **two** callers:

| Caller | Reached from |
|---|---|
| `ArchiveWorktree` (teardown at `executor.go:5944`) | `cleanupStaleWorktrees()` — the daemon's periodic sweep (`executor.go:1583`, fired on `staleWorktreeInterval`), which archives + removes worktrees for `done`/`archived` tasks past `getWorktreeCleanupMaxAge()` (default 24h); `CleanupStaleWorktreesManual` i.e. `ty worktrees cleanup` (`executor.go:1702`); TUI archive `a` (`internal/ui/app.go:4523`) |
| `CleanupWorktree` (teardown at `executor.go:5807`) | `sweepTrashedTasks()` after the trash retention window (`executor.go:1632`); `ty delete --hard` (`cmd/task/main.go:6324`); `ty move` (`cmd/task/main.go:6210`) and the TUI move action (`internal/ui/app.go:4806`) |

So the most important trigger — the automatic sweep that tears down every completed task's worktree ~24h later — was the one the docs denied existed.

Two further corrections found while verifying:

- **`d` / `ty delete` no longer tear down immediately.** They soft-delete (trash) and deliberately leave the worktree on disk for `ty restore`; teardown happens at `--hard` or when the trash sweep expires the task (default 14 days). The old text pointed at `d` as *the* trigger.
- **Moving a task between projects** removes the old worktree and runs teardown. Undocumented.

## Changes (docs only)

- Rewrote the **Worktree Teardown Script** section: a table of every trigger (with the archive/delete path and the relevant setting + default), what genuinely does *not* trigger it (manual `git worktree remove`/`rm -rf`, non-worktree projects), and the resolution/cwd/env/streaming details.
- Added the trap for script authors: **a non-zero exit is logged as a warning and the worktree is removed anyway**, so a teardown script that guards itself (refusing on a dirty worktree, say) silently leaks whatever it was supposed to release. Write it unconditional and idempotent. Also noted there's no timeout — cleanup blocks on the script.
- Reframed rather than dropped the Event Hooks note: the sweep already covers automated cleanup, so hooks are only for cleanup at the *exact moment* a task completes — with the caveat that the worktree is still live then and teardown will still run later.
- Fixed the Lifecycle & Cleanup table (`Task deleted | … worktree removed, teardown script runs`), which had the same soft-delete inaccuracy.
- Fixed the `.taskyou.yml` config table description for `worktree.teardown_script`.

AGENTS.md does not repeat the claim — no change needed there.

No code changed, so no tests; every claim above was traced in the current source rather than from the (drifted) line numbers in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)