### PR TITLE
feat: say when a step was stopped by the model provider

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4770,6 +4770,7 @@ func handleNotificationHook(database *db.DB, taskID int64, input *ClaudeHookInpu
 				}
 			}
 			database.AppendTaskLog(taskID, "system", msg)
+			noteProviderError(database, taskID, input)
 		}
 	}
 	return nil
@@ -4789,6 +4790,33 @@ func runMCPServer(taskID int64) error {
 	// Create and run MCP server
 	server := mcp.NewServer(database, taskID)
 	return server.Run()
+}
+
+// noteProviderError records, on the task's activity log, the provider-side error
+// a session ended on — a rate limit, an auth rejection, an overloaded upstream.
+//
+// Without this a step killed by the provider is indistinguishable on the board
+// from one genuinely waiting on a human: both say "Waiting for user input", and
+// the actual cause exists only inside the session transcript. A workflow step
+// once ran three times, committed nothing, and looked like a bad prompt; it had
+// been rejected with a 429 every time.
+//
+// Logged as "error" so it lands with the other failures rather than reading as
+// narration, and only when the session really ended on it (LastAPIError ignores
+// failures the session recovered from).
+func noteProviderError(database *db.DB, taskID int64, input *ClaudeHookInput) {
+	if input == nil {
+		return
+	}
+	apiErr := executor.LastAPIError(input.TranscriptPath)
+	if apiErr == nil {
+		return
+	}
+	msg := "Executor stopped on a provider error: " + apiErr.String()
+	if apiErr.Transient {
+		msg += " (provider says this may be transient — retrying the task may work)"
+	}
+	database.AppendTaskLog(taskID, "error", msg)
 }
 
 // handleStopHook handles Stop hooks from Claude (agent finished responding).
@@ -4845,10 +4873,12 @@ func handleStopHook(database *db.DB, taskID int64, input *ClaudeHookInput) error
 					// files), leaving the DAG stalled with no clue on the board.
 					database.UpdateTaskStatus(taskID, db.StatusBlocked)
 					database.AppendTaskLog(taskID, "system", "Step ended its turn without completing the handoff — "+reason)
+					noteProviderError(database, taskID, input)
 				}
 			} else {
 				database.UpdateTaskStatus(taskID, db.StatusBlocked)
 				database.AppendTaskLog(taskID, "system", "Waiting for user input")
+				noteProviderError(database, taskID, input)
 			}
 		}
 	case "tool_use":

--- a/internal/executor/api_error.go
+++ b/internal/executor/api_error.go
@@ -1,0 +1,127 @@
+package executor
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// APIError is a provider-side failure recorded in a Claude session transcript:
+// a rate limit, an auth rejection, an overloaded upstream.
+type APIError struct {
+	Status    int    // HTTP status, when the transcript recorded one (e.g. 429)
+	Transient bool   // the provider's own hint that a retry may succeed
+	Message   string // the error text shown to the agent
+}
+
+// String renders the error for a task's activity log.
+func (e *APIError) String() string {
+	if e == nil {
+		return ""
+	}
+	if e.Status > 0 && !strings.Contains(e.Message, fmt.Sprint(e.Status)) {
+		return fmt.Sprintf("%s (HTTP %d)", e.Message, e.Status)
+	}
+	return e.Message
+}
+
+// maxAPIErrorMessage bounds what we copy into the activity log. Provider errors
+// carry upgrade links and request refs that are useful, but a log line is not
+// the place for an essay.
+const maxAPIErrorMessage = 400
+
+// LastAPIError returns the provider error a session ENDED on, or nil.
+//
+// Why this exists: when the model provider rejects a request, the agent's turn
+// stops and ty parks the task with "Waiting for user input" — a message that
+// reads as a question the agent never asked. The real cause is recorded only in
+// the session transcript, so a step killed by a rate limit looks identical on
+// the board to one genuinely waiting on a human. That cost a real debugging
+// session: a workflow step ran three times, committed nothing each time, and
+// looked like a bad prompt; the transcript said
+//
+//	API Error: Request rejected (429) · you have reached your session usage limit
+//
+// An error is only reported if the session ended on it. Claude Code retries
+// transient failures, so an error followed by a successful assistant response is
+// noise — reporting it would train the reader to ignore these lines.
+func LastAPIError(transcriptPath string) *APIError {
+	if strings.TrimSpace(transcriptPath) == "" {
+		return nil
+	}
+	f, err := os.Open(transcriptPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var last *APIError
+	scanner := bufio.NewScanner(f)
+	// Transcript lines carry whole assistant turns and can be large; the default
+	// 64KB limit would silently truncate and mis-parse them.
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		var entry struct {
+			Type      string `json:"type"`
+			IsAPIErr  bool   `json:"isApiErrorMessage"`
+			Status    int    `json:"apiErrorStatus"`
+			Transient bool   `json:"apiErrorIsTransient"`
+			Message   struct {
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Type != "assistant" {
+			continue
+		}
+		if !entry.IsAPIErr {
+			// The model answered after the failure, so the session recovered.
+			last = nil
+			continue
+		}
+		text := transcriptText(entry.Message.Content)
+		if text == "" {
+			continue
+		}
+		last = &APIError{Status: entry.Status, Transient: entry.Transient, Message: text}
+	}
+	return last
+}
+
+// transcriptText flattens a transcript entry's content to its text, which is
+// either a plain string or the usual array of typed blocks.
+func transcriptText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return truncateMessage(s)
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" && strings.TrimSpace(b.Text) != "" {
+			parts = append(parts, strings.TrimSpace(b.Text))
+		}
+	}
+	return truncateMessage(strings.Join(parts, " "))
+}
+
+func truncateMessage(s string) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if len(s) > maxAPIErrorMessage {
+		s = strings.TrimSpace(s[:maxAPIErrorMessage]) + "…"
+	}
+	return s
+}

--- a/internal/executor/api_error_test.go
+++ b/internal/executor/api_error_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTranscript writes JSONL lines to a temp transcript file.
+func writeTranscript(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const (
+	// The real shape Claude Code writes, from the ollama 429 that killed a
+	// workflow step three runs in a row.
+	rateLimited = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"apiErrorIsTransient":false,"message":{"content":[{"type":"text","text":"API Error: Request rejected (429) · you (someone) have reached your session usage limit, upgrade for higher limits: https://ollama.com/upgrade"}]}}`
+	overloaded  = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":529,"apiErrorIsTransient":true,"message":{"content":[{"type":"text","text":"API Error: Overloaded"}]}}`
+	goodReply   = `{"type":"assistant","message":{"content":[{"type":"text","text":"Done — pushed the review."}]}}`
+	userTurn    = `{"type":"user","message":{"content":"go on"}}`
+)
+
+func TestLastAPIErrorReportsTheFailureASessionEndedOn(t *testing.T) {
+	got := LastAPIError(writeTranscript(t, userTurn, goodReply, rateLimited))
+	if got == nil {
+		t.Fatal("no error reported; the session ended on a 429")
+	}
+	if got.Status != 429 {
+		t.Errorf("Status = %d, want 429", got.Status)
+	}
+	if got.Transient {
+		t.Error("Transient = true; a usage-limit rejection is not transient")
+	}
+	if want := "usage limit"; !strings.Contains(got.Message, want) {
+		t.Errorf("Message = %q, want it to mention %q", got.Message, want)
+	}
+}
+
+// Claude Code retries transient failures. An error the session recovered from is
+// noise — reporting it would train the reader to ignore these lines.
+func TestLastAPIErrorIgnoresAFailureTheSessionRecoveredFrom(t *testing.T) {
+	if got := LastAPIError(writeTranscript(t, overloaded, goodReply)); got != nil {
+		t.Errorf("reported %q, want nil — the model answered after the error", got.String())
+	}
+}
+
+func TestLastAPIErrorKeepsTheTransientHint(t *testing.T) {
+	got := LastAPIError(writeTranscript(t, overloaded))
+	if got == nil {
+		t.Fatal("no error reported")
+	}
+	if !got.Transient {
+		t.Error("Transient = false, want true so the log can suggest a retry")
+	}
+}
+
+func TestLastAPIErrorOnCleanOrMissingTranscript(t *testing.T) {
+	if got := LastAPIError(writeTranscript(t, userTurn, goodReply)); got != nil {
+		t.Errorf("reported %q on a clean session, want nil", got.String())
+	}
+	if got := LastAPIError(filepath.Join(t.TempDir(), "nope.jsonl")); got != nil {
+		t.Errorf("reported %q for a missing transcript, want nil", got.String())
+	}
+	if got := LastAPIError(""); got != nil {
+		t.Errorf("reported %q for an empty path, want nil", got.String())
+	}
+}
+
+// A status the message doesn't already state is appended, so the log line is
+// self-contained; one it does state is not duplicated.
+func TestAPIErrorString(t *testing.T) {
+	e := &APIError{Status: 500, Message: "API Error: internal"}
+	if want := "API Error: internal (HTTP 500)"; e.String() != want {
+		t.Errorf("String() = %q, want %q", e.String(), want)
+	}
+	e = &APIError{Status: 429, Message: "API Error: Request rejected (429)"}
+	if want := "API Error: Request rejected (429)"; e.String() != want {
+		t.Errorf("String() = %q, want %q", e.String(), want)
+	}
+}


### PR DESCRIPTION
## Why

Follow-up to #686. While recovering pipeline #5120, one step ran three times, committed nothing each time, and looked like a bad prompt or a broken worktree. Its activity log said only:

```
Waiting for user input
```

The actual cause existed only inside the session transcript:

```
API Error: Request rejected (429) · you (brunobornsztein) have reached your
session usage limit, upgrade for higher limits: https://ollama.com/upgrade
```

On the board, a rate-limited step is indistinguishable from one genuinely waiting on a human — and "Waiting for user input" actively misleads, since it reads as a question the agent never asked.

## What

`executor.LastAPIError` reads the transcript Claude Code already hands the hook (`transcript_path`) and reports the provider failure a session **ended on**. It keys off the transcript entry's own fields — `isApiErrorMessage`, `apiErrorStatus`, `apiErrorIsTransient` — rather than sniffing message text, so it doesn't depend on error wording.

Errors the session recovered from are ignored: Claude Code retries transient failures, and reporting those would train the reader to skip these lines. When the provider itself says a failure is transient, the log line says a retry may work.

Wired into all three places a task parks:
- Notification hook — idle and permission prompts
- Stop hook — the workflow-step path and the generic `end_turn` path

The board now shows, as an `error` line:

```
Executor stopped on a provider error: API Error: Request rejected (429) ·
you (brunobornsztein) have reached your session usage limit, upgrade for
higher limits: https://ollama.com/upgrade (ref: d5ebadad-…)
```

## Verification

Run against the real transcript from the incident:

```
status=429 transient=false
msg=API Error: Request rejected (429) · you (brunobornsztein) have reached your
    session usage limit, upgrade for higher limits: https://ollama.com/upgrade …
```

Unit tests cover: the failure a session ended on, a failure it recovered from (must stay silent), the transient hint, a clean session, and a missing/empty transcript path.

- `go test ./...` — all green
- `go vet ./...`, `gofmt -l` — clean
- `golangci-lint run` with the CI-pinned v2.8.0 — 0 issues

No visible surface changes beyond the log line quoted above, which is text on the existing activity feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)