### PR TITLE
fix(executor): stale tmux window no longer pins a shared branch forever

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -79,6 +79,20 @@ type Executor struct {
 	// windowExistsFn reports whether a live executor tmux window exists for a
 	// task. Overridable in tests; nil means use tmuxWindowExistsForTask.
 	windowExistsFn func(taskID int64) bool
+
+	// branchWaits tracks steps deferred by ErrBranchBusy so their retries back
+	// off instead of spinning at the worker tick. Keyed by task ID.
+	branchWaitMu sync.Mutex
+	branchWaits  map[int64]*branchWait
+}
+
+// windowExists reports whether a live executor tmux window exists for a task,
+// honouring the test override.
+func (e *Executor) windowExists(taskID int64) bool {
+	if e.windowExistsFn != nil {
+		return e.windowExistsFn(taskID)
+	}
+	return tmuxWindowExistsForTask(taskID)
 }
 
 // DefaultSuspendIdleTimeout is the default time a blocked task must be idle before being suspended.
@@ -362,11 +376,7 @@ func (e *Executor) reconcileOrphanedTasks(startup bool) {
 
 		// A processing task with a live executor window is genuinely still
 		// running (e.g. the tmux server survived a daemon restart) - leave it.
-		windowExists := tmuxWindowExistsForTask
-		if e.windowExistsFn != nil {
-			windowExists = e.windowExistsFn
-		}
-		if windowExists(task.ID) {
+		if e.windowExists(task.ID) {
 			continue
 		}
 
@@ -1755,6 +1765,13 @@ func (e *Executor) processNextTask(ctx context.Context) {
 			continue
 		}
 
+		// A step deferred for branch contention serves its backoff here. Without
+		// this gate the task is re-entered on every 2s tick, and each pass writes
+		// a fresh "Starting task #N" line for a step that cannot start.
+		if !e.branchWaitDue(task.ID) {
+			continue
+		}
+
 		// Atomically check-and-set to prevent race where two ticks
 		// both see the task as not-running and spawn duplicate goroutines
 		e.mu.Lock()
@@ -1866,16 +1883,33 @@ func (e *Executor) executeTask(ctx context.Context, task *db.Task) {
 	workDir, createdWorktree, err := e.setupWorktree(task)
 	if errors.Is(err, ErrBranchBusy) {
 		// Not a failure: the branch this step needs is held by a sibling that is
-		// still running. Leave the task QUEUED so the next tick retries it, and
+		// still running. Leave the task QUEUED so a later tick retries it, and
 		// leave no completion timestamps behind — a step parked 'blocked' with a
 		// started_at/completed_at pair reads as a step that ran, which is how a
 		// pipeline silently loses a phase.
-		e.logger.Info("Deferring step until the branch it needs is free", "id", task.ID, "error", err)
+		//
+		// The retry backs off (see branchWaitDue in processNextTask); without that
+		// this return is a 2s spin that re-logs the start line every pass.
+		retryIn, keepWaiting := e.deferForBusyBranch(task.ID)
+		if !keepWaiting {
+			e.logger.Warn("Giving up on a contended branch", "id", task.ID, "waited", branchWaitGiveUp, "error", err)
+			e.logLine(task.ID, "error", fmt.Sprintf(
+				"Could not start: %v. Waited %s without that branch being freed, so this step is parked instead of retrying forever. Free the branch (detach the worktree named above) and re-queue this task.",
+				err, branchWaitGiveUp))
+			_ = e.db.UpdateTaskStatus(task.ID, db.StatusBlocked)
+			e.hooks.OnStatusChange(task, db.StatusBlocked, "Blocked: the branch this step needs never became free")
+			return
+		}
+		e.logger.Info("Deferring step until the branch it needs is free",
+			"id", task.ID, "retry_in", retryIn, "error", err)
 		if err := e.db.UpdateTaskStatus(task.ID, db.StatusQueued); err != nil {
 			e.logger.Error("Failed to requeue deferred step", "id", task.ID, "error", err)
 		}
 		return
 	}
+	// Past worktree setup: whatever contention this step saw is over, so it
+	// starts from a fresh backoff the next time it contends.
+	e.clearBranchWait(task.ID)
 	if err != nil {
 		e.logger.Error("Failed to setup worktree", "error", err)
 		e.logLine(task.ID, "error", fmt.Sprintf("Failed to setup worktree: %v", err))

--- a/internal/executor/shared_branch.go
+++ b/internal/executor/shared_branch.go
@@ -25,6 +25,95 @@ import (
 // the holder is done.
 var ErrBranchBusy = errors.New("branch is checked out by a running step")
 
+// Branch-contention retry policy.
+//
+// Re-queueing a contended step is correct, but on its own it is a hot loop: the
+// worker ticks every 2s, and each pass re-enters executeTask, re-logs "Starting
+// task #N" and re-queues. One branch that never freed produced ~1,100 such
+// passes in 38 minutes and flushed the task's entire history out of the log ring
+// buffer — so the one record of what the step had actually done was destroyed by
+// the retries.
+//
+// A deferred step therefore backs off geometrically, and if the branch still has
+// not freed after branchWaitGiveUp it parks in 'blocked' where a human can see
+// it. Parking sets a started_at with no real run behind it, which this file
+// otherwise avoids — but a step that has genuinely waited half an hour is a
+// stall someone needs to look at, and silence is the worse failure.
+const (
+	branchWaitInitialBackoff = 5 * time.Second
+	branchWaitMaxBackoff     = 2 * time.Minute
+	branchWaitGiveUp         = 30 * time.Minute
+	// branchWaitMaxShift caps the exponent so the shift below cannot overflow
+	// on a long-lived wait; the backoff is clamped to branchWaitMaxBackoff well
+	// before this matters.
+	branchWaitMaxShift = 8
+)
+
+// branchWait records how long a step has been waiting for a contended branch.
+type branchWait struct {
+	first     time.Time
+	nextRetry time.Time
+	attempts  int
+}
+
+// deferForBusyBranch records one branch-contention deferral for a task and
+// reports how long to wait before the next attempt. keepWaiting is false once
+// the step has been waiting longer than branchWaitGiveUp, meaning the caller
+// should park it rather than re-queue it again.
+func (e *Executor) deferForBusyBranch(taskID int64) (retryIn time.Duration, keepWaiting bool) {
+	e.branchWaitMu.Lock()
+	defer e.branchWaitMu.Unlock()
+
+	if e.branchWaits == nil {
+		e.branchWaits = make(map[int64]*branchWait)
+	}
+	now := time.Now()
+	wait := e.branchWaits[taskID]
+	if wait == nil {
+		wait = &branchWait{first: now}
+		e.branchWaits[taskID] = wait
+	}
+	wait.attempts++
+
+	if now.Sub(wait.first) >= branchWaitGiveUp {
+		delete(e.branchWaits, taskID)
+		return 0, false
+	}
+
+	shift := wait.attempts - 1
+	if shift > branchWaitMaxShift {
+		shift = branchWaitMaxShift
+	}
+	backoff := branchWaitInitialBackoff << shift
+	if backoff > branchWaitMaxBackoff {
+		backoff = branchWaitMaxBackoff
+	}
+	wait.nextRetry = now.Add(backoff)
+	return backoff, true
+}
+
+// branchWaitDue reports whether a step deferred for branch contention has served
+// its backoff and may be attempted again. A task with no recorded wait is always
+// due, so this gate is invisible to everything except a contended step.
+func (e *Executor) branchWaitDue(taskID int64) bool {
+	e.branchWaitMu.Lock()
+	defer e.branchWaitMu.Unlock()
+
+	wait := e.branchWaits[taskID]
+	if wait == nil {
+		return true
+	}
+	return !time.Now().Before(wait.nextRetry)
+}
+
+// clearBranchWait forgets a step's contention history, so a step that waited
+// once and then ran starts from a fresh backoff if it ever contends again.
+func (e *Executor) clearBranchWait(taskID int64) {
+	e.branchWaitMu.Lock()
+	defer e.branchWaitMu.Unlock()
+	delete(e.branchWaits, taskID)
+}
+
 // gitWorktreeHolder returns the path of the worktree that currently has branch
 // checked out, or "" if no worktree holds it.
 //
@@ -164,6 +253,17 @@ func worktreePathForms(path string) []string {
 // taskIsLive reports whether a task is actively executing right now: mid-flight
 // in this daemon, in a running status, or still owning a tmux window. Any of the
 // three means "hands off".
+//
+// A task in a TERMINAL status is never live, whatever tmux still shows. An
+// executor window routinely outlives the step that opened it: when the agent
+// exits, the pane falls back to a plain shell and the window lingers until
+// something reaps it. Trusting that stale window is what let a finished step pin
+// its shared branch indefinitely — releaseBranchFromFinishedHolder read the
+// leftover window as "still working", refused to reclaim, and the next step
+// re-queued itself on ErrBranchBusy every tick until a human intervened. Once a
+// status is terminal it is the authority; the window is only a tiebreaker for a
+// task that has not reached one (a 'blocked' step, for instance, may still have
+// a live agent sitting on a question).
 func (e *Executor) taskIsLive(task *db.Task) bool {
 	if task == nil {
 		return false
@@ -177,7 +277,10 @@ func (e *Executor) taskIsLive(task *db.Task) bool {
 	if task.Status == db.StatusProcessing || task.Status == db.StatusQueued {
 		return true
 	}
-	return tmuxWindowExistsForTask(task.ID)
+	if task.Status == db.StatusDone || task.Status == db.StatusArchived {
+		return false
+	}
+	return e.windowExists(task.ID)
 }
 
 // addStepBranchWorktree creates a worktree for a FAN-OUT step on its own branch,

--- a/internal/executor/shared_branch_test.go
+++ b/internal/executor/shared_branch_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bborn/workflow/internal/config"
 	"github.com/bborn/workflow/internal/db"
@@ -264,5 +265,121 @@ func mustGit(t *testing.T, dir string, args ...string) {
 		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// The stall this fix exists for: the holder is DONE, but its executor tmux
+// window was never reaped. taskIsLive used to read that leftover window as
+// "still working", so the branch was never reclaimed and every downstream step
+// re-queued itself on ErrBranchBusy forever. A terminal status wins over tmux.
+func TestSourceBranchWorktreeReclaimsFromDoneHolderWithStaleTmuxWindow(t *testing.T) {
+	repo, branch := sharedBranchRepo(t)
+	e, database := sharedBranchExecutor(t, repo)
+	holder := holdBranch(t, e, database, repo, branch, db.StatusDone)
+
+	// The window outlives the agent: the pane falls back to a shell and nothing
+	// reaps the window.
+	e.windowExistsFn = func(taskID int64) bool { return taskID == holder.ID }
+
+	next := filepath.Join(t.TempDir(), "next")
+	if err := e.addSourceBranchWorktree(repo, next, branch); err != nil {
+		t.Fatalf("a done holder's stale tmux window still pins the branch: %v", err)
+	}
+	got, err := gitCurrentBranch(next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != branch {
+		t.Fatalf("next step worktree is on %q, want %q", got, branch)
+	}
+}
+
+// The correction must not go too far: a step that has not reached a terminal
+// status may still have a live agent behind that window (a 'blocked' step
+// sitting on a question), and its branch stays put.
+func TestSourceBranchWorktreeKeepsBranchForBlockedHolderWithLiveWindow(t *testing.T) {
+	repo, branch := sharedBranchRepo(t)
+	e, database := sharedBranchExecutor(t, repo)
+	holder := holdBranch(t, e, database, repo, branch, db.StatusBlocked)
+	e.windowExistsFn = func(taskID int64) bool { return taskID == holder.ID }
+
+	err := e.addSourceBranchWorktree(repo, filepath.Join(t.TempDir(), "next"), branch)
+	if !errors.Is(err, ErrBranchBusy) {
+		t.Fatalf("want ErrBranchBusy while a blocked holder still owns its window, got %v", err)
+	}
+}
+
+// A blocked holder whose window is gone is finished for our purposes — nothing
+// is going to come back and use that worktree.
+func TestSourceBranchWorktreeReclaimsFromBlockedHolderWithNoWindow(t *testing.T) {
+	repo, branch := sharedBranchRepo(t)
+	e, database := sharedBranchExecutor(t, repo)
+	holdBranch(t, e, database, repo, branch, db.StatusBlocked)
+	e.windowExistsFn = func(int64) bool { return false }
+
+	if err := e.addSourceBranchWorktree(repo, filepath.Join(t.TempDir(), "next"), branch); err != nil {
+		t.Fatalf("abandoned blocked holder should release the branch: %v", err)
+	}
+}
+
+// Re-queueing a contended step every 2s tick is what flushed a task's whole log
+// history out of the ring buffer. Deferrals must back off, and the gate must
+// actually hold the step back between attempts.
+func TestBranchWaitBacksOff(t *testing.T) {
+	e := &Executor{}
+
+	first, keepWaiting := e.deferForBusyBranch(7)
+	if !keepWaiting {
+		t.Fatal("first deferral should keep waiting")
+	}
+	if first != branchWaitInitialBackoff {
+		t.Fatalf("first backoff = %s, want %s", first, branchWaitInitialBackoff)
+	}
+	if e.branchWaitDue(7) {
+		t.Fatal("step is due again immediately; the 2s spin is still possible")
+	}
+	// An unrelated task is never gated by someone else's contention.
+	if !e.branchWaitDue(8) {
+		t.Fatal("a task with no recorded wait must always be due")
+	}
+
+	second, _ := e.deferForBusyBranch(7)
+	if second <= first {
+		t.Fatalf("backoff did not grow: %s then %s", first, second)
+	}
+
+	for i := 0; i < 20; i++ {
+		got, keep := e.deferForBusyBranch(7)
+		if !keep {
+			t.Fatal("give-up fired on elapsed attempts rather than elapsed time")
+		}
+		if got > branchWaitMaxBackoff {
+			t.Fatalf("backoff %s exceeded the %s cap", got, branchWaitMaxBackoff)
+		}
+	}
+
+	e.clearBranchWait(7)
+	if !e.branchWaitDue(7) {
+		t.Fatal("cleared wait should leave the task due")
+	}
+}
+
+// A branch that never frees must not be retried forever in silence: past the
+// give-up window the step is parked so a human sees the stall.
+func TestBranchWaitGivesUpAfterDeadline(t *testing.T) {
+	e := &Executor{}
+	if _, keepWaiting := e.deferForBusyBranch(9); !keepWaiting {
+		t.Fatal("should still be waiting on the first deferral")
+	}
+
+	e.branchWaitMu.Lock()
+	e.branchWaits[9].first = time.Now().Add(-branchWaitGiveUp - time.Second)
+	e.branchWaitMu.Unlock()
+
+	if _, keepWaiting := e.deferForBusyBranch(9); keepWaiting {
+		t.Fatalf("still waiting after %s; the step would spin indefinitely", branchWaitGiveUp)
+	}
+	if !e.branchWaitDue(9) {
+		t.Fatal("giving up should drop the wait record")
 	}
 }


### PR DESCRIPTION
## The stall

Task 5128 (`[Verify]` step of the Collab Product Network pipeline) finished its work — committed, pushed, opened a PR — then re-queued itself every 2 seconds for 38 minutes.

Diagnosis, from the live system:

1. The **Build** step (5124) still held the shared branch checked out:
   ```
   worktree .task-worktrees/5124-build-collab-product-networkhttpslineara
   HEAD    aaa3cac90   ← the verify step's own commit
   branch  refs/heads/pipeline/5120-collab-product-network-https-linear-app
   ```
2. Task 5124 was `done`, **but its tmux window `task-5124` was still open.**
3. `taskIsLive` consults `tmuxWindowExistsForTask` regardless of status → read the leftover window as "still working".
4. `releaseBranchFromFinishedHolder` refused to reclaim → `addSourceBranchWorktree` returned `ErrBranchBusy`.
5. `executeTask` re-queued the step. Worker ticker is `2 * time.Second`. Repeat forever.

An executor window routinely outlives its agent: when the agent exits the pane falls back to a plain shell, and nothing reaps the window. So this is the *normal* end state of a finished step, not an edge case — any completed step can pin its branch this way.

## Why the spin made it worse

`ErrBranchBusy` re-queueing rather than failing is right, but unbounded it is a hot loop. Each pass re-enters `executeTask` and re-logs `Starting task #N`. ~1,100 passes flushed the task's **entire log history out of the 1000-entry ring buffer** — the only record of what the step had actually done was destroyed by its own retries. It also made the task un-parkable by hand: setting it `blocked` was overwritten by the next tick's re-queue. Only `close` escaped.

## The fix

**1. A terminal status is authoritative.** `taskIsLive` stops consulting tmux for `done`/`archived`. The window stays the tiebreaker for a non-terminal task, since a `blocked` step may still have a live agent sitting on a question.

**2. Deferrals back off and give up.** Contention deferrals now back off geometrically (5s → capped at 2m) and park in `blocked` after 30m, so a branch that never frees surfaces to a human instead of spinning silently. `processNextTask` gates deferred steps on that backoff — that is what stops the log spam.

Also folds the duplicated `windowExistsFn` override into an `e.windowExists` helper.

## Tests

Four new cases in `shared_branch_test.go`, on real git repos like the existing ones:

- `...ReclaimsFromDoneHolderWithStaleTmuxWindow` — the regression. **Verified it fails without the fix**, with the exact production error:
  ```
  a done holder's stale tmux window still pins the branch: branch is checked out by
  a running step: pipeline/1-demo is checked out at .../holder
  ```
- `...KeepsBranchForBlockedHolderWithLiveWindow` — guards against over-correcting; a blocked step with a live window keeps its branch.
- `...ReclaimsFromBlockedHolderWithNoWindow` — an abandoned blocked holder releases.
- `TestBranchWaitBacksOff` / `TestBranchWaitGivesUpAfterDeadline` — backoff grows, respects the cap, gates the retry, isolates per-task, and gives up on elapsed *time* rather than attempt count.

`go vet ./...`, `go test -race ./...` (full repo, incl. the parity harness), and `make lint` (0 issues) all pass.

## Not covered here

The verify step also never signalled completion after its successful run — it sat in `processing`, which is what fed it into the retry loop to begin with. That is a separate bug in the pipeline completion handoff and is not addressed by this PR.

The `task-5124` window is still open on the affected machine; until it is closed, that branch stays pinned under the old binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)