### PR TITLE
fix: never start a task outside its worktree, and say so when one is missing

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -430,6 +430,11 @@ func (e *Executor) reconcileReadyTasks() {
 // far longer; anything "completing" faster is almost certainly a step we caught mid-setup.
 const minWorkflowStepRuntime = 30 * time.Second
 
+// stepMissingWorktreeLog is written (once) to a pipeline step that has started but
+// has no worktree recorded, so a workflow that cannot advance says why on the task
+// instead of stalling in silence.
+const stepMissingWorktreeLog = "This step started without a recorded worktree, so the workflow cannot verify it finished or advance past it. Its work (if any) is not where the pipeline expects it. Re-queue the step to have the daemon provision it properly."
+
 // reconcileFinishedWorkflowSteps recovers workflow steps that finished their work
 // (committed + pushed) but never reached 'done'. Two shapes: (1) parked in 'blocked'
 // because the Stop hook's git-state check fired at a transient moment (a temp file
@@ -465,7 +470,22 @@ func (e *Executor) reconcileFinishedWorkflowSteps() {
 	for _, task := range tasks {
 		// Only steps that actually ran; leave un-started (DAG-waiting) ones to
 		// reconcileReadyTasks.
-		if task.StartedAt == nil || task.WorktreePath == "" {
+		if task.StartedAt == nil {
+			continue
+		}
+		// A step with no recorded worktree cannot be assessed: WorkflowStepFinished
+		// needs a worktree and a base commit to tell "produced work" from "sat
+		// still", so this sweep can only skip it. Skipping is right — but skipping
+		// SILENTLY is how a finished pipeline stalls with nothing to look at. A step
+		// that has started and still has no worktree is an anomaly (its executor was
+		// launched outside the daemon's provisioning, or provisioning never
+		// completed), so say so once, on the task, where the stall is visible.
+		if task.WorktreePath == "" {
+			if logged, _ := e.db.HasLogLineContaining(task.ID, stepMissingWorktreeLog); !logged {
+				e.logLine(task.ID, "error", stepMissingWorktreeLog)
+				e.logger.Warn("Pipeline step has started but has no worktree; cannot auto-complete it",
+					"id", task.ID, "title", task.Title, "status", task.Status)
+			}
 			continue
 		}
 		// A 'processing' step is only a recovery candidate once its session has actually

--- a/internal/executor/launch_workdir_test.go
+++ b/internal/executor/launch_workdir_test.go
@@ -1,0 +1,94 @@
+package executor
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/bborn/workflow/internal/config"
+	"github.com/bborn/workflow/internal/db"
+)
+
+func launchWorkdirExecutor(t *testing.T, projectDir string, usesWorktrees bool) *Executor {
+	t.Helper()
+	database, err := db.Open(filepath.Join(t.TempDir(), "tasks.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	if err := database.CreateProject(&db.Project{Name: "p", Path: projectDir, UseWorktrees: usesWorktrees}); err != nil {
+		t.Fatal(err)
+	}
+	return New(database, config.New(database))
+}
+
+// The guard this file exists for. EnsureTaskWindow is reachable from the TUI, the
+// GUI and the HTTP API, and it used to resolve its working directory through
+// taskWorkdir, which falls back to the project directory and then to $HOME. A task
+// the daemon had not yet provisioned could therefore be started BY HAND straight
+// into the primary clone — which is exactly how a pipeline verify step ran 42
+// minutes in the main repo and, having no worktree recorded, never parked for
+// merge review. Starting must fail instead.
+func TestLaunchWorkdirRefusesProjectDirForWorktreeProject(t *testing.T) {
+	projectDir := t.TempDir()
+	e := launchWorkdirExecutor(t, projectDir, true)
+
+	task := &db.Task{Title: "verify step", Project: "p"} // no WorktreePath
+	if err := e.db.CreateTask(task); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := e.launchWorkdir(task)
+	if !errors.Is(err, ErrNoWorktree) {
+		t.Fatalf("want ErrNoWorktree for an unprovisioned task, got (%q, %v)", got, err)
+	}
+	if got == projectDir {
+		t.Fatal("returned the primary clone as a place to start an agent")
+	}
+
+	// And the old fallback really would have handed back the main repo, which is
+	// what makes the guard necessary rather than cosmetic.
+	if fallback := e.taskWorkdir(task); fallback != projectDir {
+		t.Fatalf("taskWorkdir = %q, expected the project dir %q (the unsafe fallback this guards)", fallback, projectDir)
+	}
+}
+
+// A project that opts out of worktrees shares the project directory by design;
+// that is its normal working directory, not a fallback.
+func TestLaunchWorkdirAllowsProjectDirWhenWorktreesDisabled(t *testing.T) {
+	projectDir := t.TempDir()
+	e := launchWorkdirExecutor(t, projectDir, false)
+
+	task := &db.Task{Title: "ordinary task", Project: "p"}
+	if err := e.db.CreateTask(task); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := e.launchWorkdir(task)
+	if err != nil {
+		t.Fatalf("non-worktree project should start in its project dir: %v", err)
+	}
+	if got != projectDir {
+		t.Fatalf("launchWorkdir = %q, want %q", got, projectDir)
+	}
+}
+
+// A provisioned task starts in its worktree, worktree-project or not.
+func TestLaunchWorkdirUsesWorktreeWhenPresent(t *testing.T) {
+	projectDir := t.TempDir()
+	worktree := t.TempDir()
+	e := launchWorkdirExecutor(t, projectDir, true)
+
+	task := &db.Task{Title: "provisioned", Project: "p", WorktreePath: worktree}
+	if err := e.db.CreateTask(task); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := e.launchWorkdir(task)
+	if err != nil {
+		t.Fatalf("provisioned task should launch: %v", err)
+	}
+	if got != worktree {
+		t.Fatalf("launchWorkdir = %q, want the worktree %q", got, worktree)
+	}
+}

--- a/internal/executor/session.go
+++ b/internal/executor/session.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -89,7 +90,10 @@ func (e *Executor) EnsureTaskWindow(ctx context.Context, task *db.Task, sessionI
 		return "", false, err
 	}
 
-	workDir := e.taskWorkdir(task)
+	workDir, err := e.launchWorkdir(task)
+	if err != nil {
+		return "", false, err
+	}
 
 	taskExecutor := e.GetTaskExecutor(task)
 	if taskExecutor == nil {
@@ -182,8 +186,12 @@ func (e *Executor) EnsureTaskWindow(ctx context.Context, task *db.Task, sessionI
 	return windowTarget, true, nil
 }
 
-// taskWorkdir returns the directory an interactive session should start in:
-// the task worktree when present, then the project directory, then home.
+// taskWorkdir returns the directory associated with a task: its worktree when
+// present, then the project directory, then home.
+//
+// This is for READ-ONLY uses (probing for a session file on disk, displaying a
+// path). Anything that LAUNCHES an agent must use launchWorkdir, which refuses
+// the fallbacks.
 func (e *Executor) taskWorkdir(task *db.Task) string {
 	if task.WorktreePath != "" {
 		return task.WorktreePath
@@ -195,6 +203,43 @@ func (e *Executor) taskWorkdir(task *db.Task) string {
 	}
 	home, _ := os.UserHomeDir()
 	return home
+}
+
+// ErrNoWorktree means a task in a worktree-isolated project has no worktree yet,
+// so there is nowhere safe to start an agent.
+var ErrNoWorktree = errors.New("task has no worktree yet")
+
+// launchWorkdir returns the directory to START AN AGENT in, or an error when no
+// isolated directory exists.
+//
+// The daemon's setupWorktree already refuses to fall back to the project
+// directory ("never fall back to project directory to prevent Claude from
+// accidentally writing to the main repo"). taskWorkdir did exactly that, and
+// EnsureTaskWindow — reachable from the TUI, the GUI and the HTTP API — used it,
+// so any task the daemon had not yet provisioned could be started by hand
+// straight into the primary clone, or into $HOME if the project had no directory
+// at all.
+//
+// That is not hypothetical. A pipeline's verify step whose daemon spin-up was
+// blocked on a contended branch was launched this way: it ran 42 minutes in the
+// main repo, and because no worktree was ever recorded for it, it stayed
+// invisible to reconcileFinishedWorkflowSteps and never parked for merge review.
+// An unprovisioned task must fail loudly here instead.
+func (e *Executor) launchWorkdir(task *db.Task) (string, error) {
+	if task == nil {
+		return "", ErrNoWorktree
+	}
+	if task.WorktreePath != "" {
+		return task.WorktreePath, nil
+	}
+	// A project that does not use worktrees shares the project directory by
+	// design; that is its normal, isolated-enough working directory.
+	if task.Project != "" && !e.config.ProjectUsesWorktrees(task.Project) {
+		if dir := e.GetProjectDir(task.Project); dir != "" {
+			return dir, nil
+		}
+	}
+	return "", fmt.Errorf("%w: refusing to start task %d outside an isolated worktree", ErrNoWorktree, task.ID)
 }
 
 // findExistingTaskWindow looks for windowName in any task-daemon session and

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -93,8 +93,21 @@ const waitForExecutorTimeout = 60 * time.Second
 // shouldFallBackToStart reports whether a view that has been passively waiting for
 // the daemon's executor (paneActionWaitForExecutor) should give up and start one
 // itself. It gives up only once the timeout has elapsed with no panes joined.
-func shouldFallBackToStart(waitingForExecutor, panesJoined bool, waited, timeout time.Duration) bool {
-	return waitingForExecutor && !panesJoined && waited >= timeout
+//
+// hasWorktree gates the whole fallback. The wait times out for two very
+// different reasons, and only one of them is safe to recover from here:
+//
+//   - The daemon provisioned the task (worktree exists) but its window never
+//     appeared — it died mid-spin-up. Starting the session ourselves lands in
+//     that worktree, and is the recovery this fallback was written for.
+//   - The daemon never provisioned the task at all (no worktree). Starting it
+//     now has nowhere isolated to run: EnsureTaskWindow used to fall back to the
+//     primary clone, which is how a pipeline verify step ran 42 minutes in the
+//     main repo and — having no recorded worktree — stayed invisible to
+//     reconcileFinishedWorkflowSteps and never parked for merge review. Nothing
+//     here can fix an unprovisioned task, so keep waiting for the daemon.
+func shouldFallBackToStart(waitingForExecutor, panesJoined, hasWorktree bool, waited, timeout time.Duration) bool {
+	return waitingForExecutor && !panesJoined && hasWorktree && waited >= timeout
 }
 
 // liveExecutorInPaneCommands reports whether any of the given tmux pane
@@ -715,7 +728,9 @@ func (m *DetailModel) Refresh() tea.Cmd {
 		// Start the executor ourselves rather than spin forever. Safe from the
 		// double-spawn this whole change prevents: startPanesAsync goes through
 		// EnsureTaskWindow's spawn lock, which re-checks for an existing window.
-		if shouldFallBackToStart(m.waitingForExecutor, m.claudePaneID != "", time.Since(m.paneLoadingStart), waitForExecutorTimeout) {
+		// Only when the task actually has a worktree to start in — see
+		// shouldFallBackToStart.
+		if shouldFallBackToStart(m.waitingForExecutor, m.claudePaneID != "", m.task.WorktreePath != "", time.Since(m.paneLoadingStart), waitForExecutorTimeout) {
 			GetLogger().Info("Refresh: waited %s for daemon executor on task %d with no window; starting it ourselves", waitForExecutorTimeout, m.task.ID)
 			m.waitingForExecutor = false
 			return tea.Batch(cmd, m.startPanesAsync())

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -661,20 +661,26 @@ func TestShouldFallBackToStart(t *testing.T) {
 		name        string
 		waiting     bool
 		panesJoined bool
+		hasWorktree bool
 		waited      time.Duration
 		want        bool
 	}{
-		{"waiting, no panes, past timeout -> start", true, false, 61 * time.Second, true},
-		{"waiting, no panes, before timeout -> keep waiting", true, false, 10 * time.Second, false},
-		{"waiting, panes joined -> no fallback", true, true, 120 * time.Second, false},
-		{"not waiting -> no fallback", false, false, 120 * time.Second, false},
-		{"waiting, no panes, exactly at timeout -> start", true, false, timeout, true},
+		{"waiting, no panes, past timeout -> start", true, false, true, 61 * time.Second, true},
+		{"waiting, no panes, before timeout -> keep waiting", true, false, true, 10 * time.Second, false},
+		{"waiting, panes joined -> no fallback", true, true, true, 120 * time.Second, false},
+		{"not waiting -> no fallback", false, false, true, 120 * time.Second, false},
+		{"waiting, no panes, exactly at timeout -> start", true, false, true, timeout, true},
+		// The daemon never provisioned this task. There is no isolated directory to
+		// start in, so starting it would run the agent in the primary clone — the
+		// stall that let a pipeline verify step work 42 minutes in the main repo.
+		{"no worktree, past timeout -> keep waiting", true, false, false, 120 * time.Second, false},
+		{"no worktree, way past timeout -> still no fallback", true, false, false, time.Hour, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := shouldFallBackToStart(tc.waiting, tc.panesJoined, tc.waited, timeout); got != tc.want {
-				t.Errorf("shouldFallBackToStart(waiting=%v panes=%v waited=%v) = %v, want %v",
-					tc.waiting, tc.panesJoined, tc.waited, got, tc.want)
+			if got := shouldFallBackToStart(tc.waiting, tc.panesJoined, tc.hasWorktree, tc.waited, timeout); got != tc.want {
+				t.Errorf("shouldFallBackToStart(waiting=%v panes=%v worktree=%v waited=%v) = %v, want %v",
+					tc.waiting, tc.panesJoined, tc.hasWorktree, tc.waited, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Follow-up to #688. That PR stopped the *loud* failure (a step re-queueing at 2Hz). This one fixes the quiet one underneath it.

## What happened

The Collab Product Network pipeline's `[Verify]` step ran **42 minutes inside the primary offerlab clone** instead of a worktree, then disappeared from the workflow: it committed, pushed and opened a PR, but never parked in `blocked` for merge review. The board showed the pipeline complete while the PR sat unmerged and conflicting.

The Claude session transcript is unambiguous:

```
20:48:01.537Z  /Users/bruno/Projects/rails/offerlab                    ← launched in the main clone
20:48:21.812Z  .../.task-worktrees/5124-build-collab-product-network…  ← agent cd'd itself
21:30:37.347Z  (last event — 42m36s, matching the session's own "Worked for 42m 36s")
```

It only reached the right branch because the agent worked out where the shared branch was checked out and walked into another step's worktree by hand.

## The chain

1. The daemon hit `ErrBranchBusy` on its first attempt (stale tmux window pinning the shared branch — fixed in #688), so `setupWorktree` returned **before** persisting `worktree_path`. The task had no worktree at all.
2. The detail view waits 60s for the daemon's executor window, then gives up and starts the session itself. The daemon was looping and never going to create one.
3. `EnsureTaskWindow` resolved its workdir via `taskWorkdir`, which falls back to the project directory and then to `$HOME`:
   ```go
   if task.WorktreePath != "" { return task.WorktreePath }
   if task.Project != "" {
       if dir := e.GetProjectDir(task.Project); dir != "" { return dir }  // ← the primary clone
   }
   home, _ := os.UserHomeDir(); return home                               // ← or your home directory
   ```
4. `reconcileFinishedWorkflowSteps` skips any step with no `worktree_path` — **silently**. With nothing recorded, the terminal step could never be parked for merge review, however often the sweep ran.

The daemon's own path already refuses step 3 — *"never fall back to project directory to prevent Claude from accidentally writing to the main repo"*. Every other launch path (TUI, GUI, HTTP API) ignored that rule.

## The fixes — one per link

**`launchWorkdir` (new)** is the workdir resolver for anything that *starts* an agent. It returns `ErrNoWorktree` instead of falling back. A project that opts out of worktrees still gets its project dir — that's its normal working directory, not a fallback. `taskWorkdir` stays for read-only callers (session-file probes, display).

**`shouldFallBackToStart` takes `hasWorktree`** and refuses to start an unprovisioned task. The fallback exists for a daemon that died *after* provisioning; a task with no worktree has nowhere isolated to run, so waiting is the only correct answer.

**`reconcileFinishedWorkflowSteps` logs once, on the task**, when a started pipeline step has no worktree. It still can't assess such a step — `WorkflowStepFinished` needs a worktree and base commit — but a workflow that can't advance should say why rather than stall in silence.

## Tests

Both guards verified to fail without the fix:

- `TestLaunchWorkdirRefusesProjectDirForWorktreeProject` — without it: `got ("/…/TestLaunchWorkdir…/001", <nil>)`, i.e. it hands back the primary clone. The test also asserts `taskWorkdir` *still* returns the project dir, so the guard is demonstrably load-bearing rather than cosmetic.
- `TestShouldFallBackToStart` — two new cases fail without it: `worktree=false waited=2m0s = true, want false` and the same at 1h.
- Plus `...AllowsProjectDirWhenWorktreesDisabled` and `...UsesWorktreeWhenPresent` so the guard doesn't over-correct.

`go vet ./...`, `go test -race ./...` (full repo, incl. the parity harness), and `make lint` (0 issues) all pass.

## Note

This does not retroactively fix task 5128 — its work is already on `pipeline/5120-…` and PR offerlab#3435 is still open and conflicting. It prevents the next pipeline from ending up the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)