### PR TITLE
fix(sessions): stop orphan cleanup from killing another machine's agents

### DIFF
--- a/cmd/task/cleanup_ownership_test.go
+++ b/cmd/task/cleanup_ownership_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/executor"
+)
+
+// The failure this guards against: an agent placed on another host ran the
+// taskyou test suite, cleanupOrphanedSessions walked the host's tmux, found the
+// agent's own window for a task that lives in a DIFFERENT machine's database,
+// called it deleted, and killed it. The agent's shell command came back "exit
+// code 137" and the task parked as "Task needs review" with nothing explaining
+// why. Four attempts died this way.
+func TestCleanupOrphanedSessions_SparesAnotherMachinesSession(t *testing.T) {
+	requireTmux(t)
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	t.Setenv("WORKTREE_DB_PATH", dbPath)
+	t.Setenv("WORKTREE_SESSION_ID", "")
+	if got := db.DefaultPath(); got != dbPath {
+		t.Skipf("db.DefaultPath() does not honor WORKTREE_DB_PATH (got %q)", got)
+	}
+
+	socketDir, err := os.MkdirTemp("/tmp", "tytmux")
+	if err != nil {
+		t.Fatalf("socket dir: %v", err)
+	}
+	t.Setenv("TMUX_TMPDIR", socketDir)
+	t.Cleanup(func() {
+		osexec.Command("tmux", "kill-server").Run()
+		_ = os.RemoveAll(socketDir)
+	})
+	suppressStdout(t)
+
+	// A session owned by another machine, holding a window for a task ID this
+	// machine's database has never heard of — exactly the placed-task shape.
+	const session = "task-daemon-82562"
+	const remoteTaskID = 5289
+	window := fmt.Sprintf("task-%d", remoteTaskID)
+	if err := osexec.Command("tmux", "new-session", "-d", "-s", session, "-n", window, "sleep", "60").Run(); err != nil {
+		t.Fatalf("create foreign session: %v", err)
+	}
+	if err := osexec.Command("tmux", "set-option", "-t", session, executor.TmuxOwnerOption, "someone-elses-laptop").Run(); err != nil {
+		t.Fatalf("tag foreign session: %v", err)
+	}
+
+	cleanupOrphanedSessions(false)
+
+	if !windowExists(session, window) {
+		t.Fatal("cleanup killed a live window belonging to another machine's daemon")
+	}
+}
+
+// The feature still has to work: our OWN session's orphan is still collected.
+func TestCleanupOrphanedSessions_StillKillsOurOwnOrphan(t *testing.T) {
+	session := setupCleanupTest(t, "owned")
+	const orphanID = 992002
+	makeDaemonSessionWithName(t, session, orphanID)
+	if err := osexec.Command("tmux", "set-option", "-t", session, executor.TmuxOwnerOption, executor.LocalOwnerTag()).Run(); err != nil {
+		t.Fatalf("tag own session: %v", err)
+	}
+
+	cleanupOrphanedSessions(false)
+
+	if windowExists(session, fmt.Sprintf("task-%d", orphanID)) {
+		t.Error("our own orphan window survived cleanup")
+	}
+}


### PR DESCRIPTION
## What was broken

`cleanupOrphanedSessions` walks every `task-daemon-*` session tmux can see and kills windows whose task ID is missing from the **local** database. On a host running placed tasks that rule is inverted: the window belongs to a task in the **placing** machine's database, so "missing here" is the normal case — and cleanup called it deleted and killed a live agent mid-run.

This is what killed task #5289 four times. The agent ran the test suite; `cmd/task`'s `TestCleanupOrphanedSessions_*` called the real function against the real default tmux socket; it tore down the agent's own window. The shell command came back `exit code 137`, and ty parked the task as `Task needs review` — which is all any of the four attempts ever said.

**The host was never at fault.** mona builds and runs the full suite cleanly — cold cache, inside tmux, 75s, never below 10.3Gi available.

## Reproduction

```
# before: with WORKTREE_SESSION_ID set, the suite kills its own session
./cmd/task        *** SESSION KILLED ***   (<5s)
./internal/executor   survived
./internal/ui         survived
```

## Three fixes, independent on purpose

| Fix | Why separate |
|---|---|
| Sessions tagged with the machine owning their tasks (`@ty_owner`); cleanup skips foreign ones and says so | The product bug. Fires with no test suite involved — any `ty` cleanup on a placed host would do this. |
| Tests run against a private tmux server via `TMUX_TMPDIR` | Defence in depth: they must not reach real sessions even on a machine with no tag. |
| A database that will not open no longer means "kill everything" | The old `tmux-only orphan check` fallback treated *every* window as deleted, firing precisely when we knew least. |

An untagged session reads as **unknown**, never as "mine".

> Absence of evidence is not evidence of an orphan — the same rule the sweep had to learn about steps that had never run.

## Validation

- Full suite `go test -race -p 1 ./...` — **21 packages ok, 0 fail**
- Both guards mutation-checked: disabling the ownership check fails `TestCleanupOrphanedSessions_SparesAnotherMachinesSession`; the feature test `TestCleanupOrphanedSessions_StillKillsOurOwnOrphan` proves our own orphans are still collected.
- **End-to-end on mona**, the original repro against this branch:

```
victim session up (owned by brunos-mac, window task-4242)
suite exit=0
RESULT: session SURVIVED
  window: task-4242
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP9gZVc4BQeiizRUWj38nz
