### PR TITLE
fix(ci): green main — carry a WIP commit without ambient git identity

### DIFF
--- a/cmd/task/place.go
+++ b/cmd/task/place.go
@@ -149,14 +149,6 @@ func placeWhere(target string) string {
 	return "on " + target
 }
 
-// placeDestination names a target for a sentence about a task MOVING.
-func placeDestination(target string) string {
-	if target == "" {
-		return "back to this machine"
-	}
-	return "to " + target
-}
-
 // preflightHost checks the host can actually run a task before a placement that
 // names it is written, and returns the absolute directory it resolved to.
 //

--- a/internal/executor/move.go
+++ b/internal/executor/move.go
@@ -110,7 +110,8 @@ func CarryWork(ctx context.Context, src WorkSource, handoff, destination string)
 		if destination == "" {
 			msg = "wip: carry work"
 		}
-		if _, err := src.git(ctx, "commit", "--no-verify", "-m", msg); err != nil {
+		args := append(src.commitIdentity(ctx), "commit", "--no-verify", "-m", msg)
+		if _, err := src.git(ctx, args...); err != nil {
 			return rep, fmt.Errorf("could not commit the work on %s: %w", src.Where(), err)
 		}
 		rep.WIPCommit = true
@@ -182,6 +183,22 @@ func (s WorkSource) ignoredFiles(ctx context.Context) []string {
 }
 
 // git runs a git command in the worktree and returns its stdout.
+// commitIdentity returns the `-c user.name=... -c user.email=...` flags the WIP
+// carry commit needs, or nothing when the machine already has an identity.
+//
+// The carry commit is ty's, not the author's: it exists so uncommitted work can
+// travel to another host. Wherever a real identity is configured we use it, so
+// the commit is attributed to the person whose work it is. Where none is — a CI
+// runner, a fresh host, a container — git refuses with "Author identity unknown"
+// and the work is stranded on a machine the task is leaving. A carry must not
+// depend on ambient config that a placed host has no reason to have.
+func (s WorkSource) commitIdentity(ctx context.Context) []string {
+	if email, err := s.git(ctx, "config", "user.email"); err == nil && strings.TrimSpace(email) != "" {
+		return nil
+	}
+	return []string{"-c", "user.name=ty", "-c", "user.email=ty@localhost"}
+}
+
 func (s WorkSource) git(ctx context.Context, args ...string) (string, error) {
 	cmd := s.Runner.Command(ctx, s.WorkDir, "git", args...)
 	return runCapturingStdout(cmd)


### PR DESCRIPTION
main is red on Lint and Test from the placement-move work. Both fixed here.

**Lint** — `cmd/task/place.go: placeDestination is unused`. Dead since the move refactor took over the sentence it built. Removed.

**Test** — `TestCarryWork*` fail with `Author identity unknown`. `CarryWork`'s WIP commit relies on the machine having a git identity. A laptop has one; a CI runner does not — and neither does a fresh placed host or a container, which is exactly where a carry has to work, since its whole job is getting uncommitted work off a machine the task is leaving.

The commit now supplies an identity **only when none is configured**, so where a real one exists the work stays attributed to the person who did it, and where none does the carry happens instead of stranding the work.

## Validation

- `go test -race -p 1 ./...` — **21 ok, 0 fail**
- `golangci-lint v2.13.2` (CI's pin) — **0 issues**

Honest limit: the identity path can't be reproduced on this machine — git guesses an identity from the system here, which is why this only ever failed on CI. CI is the check that matters for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP9gZVc4BQeiizRUWj38nz