### PR TITLE
fix(sessions): treat an untagged tmux session as unknown, not as ours

### DIFF
--- a/cmd/task/cleanup_ownership_test.go
+++ b/cmd/task/cleanup_ownership_test.go
@@ -72,3 +72,21 @@ func TestCleanupOrphanedSessions_StillKillsOurOwnOrphan(t *testing.T) {
 		t.Error("our own orphan window survived cleanup")
 	}
 }
+
+// The tag is new; every session created before it is untagged — including the
+// long-lived daemon session on a placed host, which is the exact one whose live
+// agent window kept being killed. An untagged session must therefore be treated
+// as unknown, not as ours, or the ownership guard protects only sessions that
+// were never in danger.
+func TestCleanupOrphanedSessions_SparesAnUntaggedSession(t *testing.T) {
+	session := setupCleanupTest(t, "untagged")
+	const foreignTaskID = 5289
+	makeDaemonSessionWithName(t, session, foreignTaskID)
+	// Deliberately NO @ty_owner option set.
+
+	cleanupOrphanedSessions(false)
+
+	if !windowExists(session, fmt.Sprintf("task-%d", foreignTaskID)) {
+		t.Fatal("cleanup killed a window in an untagged session; untagged means unknown, not ours")
+	}
+}

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -6192,9 +6192,10 @@ func quotedWindowList(windows map[string]bool) string {
 // being visible to ps / pgrep.
 func cleanupOrphanedSessions(force bool) {
 	type windowRef struct {
-		session string
-		window  string
-		taskID  int
+		session   string
+		window    string
+		taskID    int
+		ownedByUs bool
 	}
 
 	sessionsOut, err := osexec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
@@ -6216,10 +6217,19 @@ func cleanupOrphanedSessions(force bool) {
 		// every one of them and kills live agents: a placed host running this
 		// (directly, or through the test suite) tore down the very window the
 		// running agent lived in. Not ours, not our call.
-		if owner := tmuxSessionOwner(session); owner != "" && owner != localOwner {
+		owner := tmuxSessionOwner(session)
+		if owner != "" && owner != localOwner {
 			foreignSessions = append(foreignSessions, session+" (owned by "+owner+")")
 			continue
 		}
+		// An UNTAGGED session is unknown, not ours. Every session created before
+		// the tag existed is untagged, including the long-lived daemon session on
+		// a placed host — which is precisely the one that kept getting its live
+		// agent window killed. Unknown sessions are still scanned, because a
+		// window whose task we can see is provably ours to clean, but they are
+		// never allowed to have a window killed merely for being ABSENT from the
+		// database: absence is what a foreign task looks like.
+		ownedByUs := owner == localOwner
 		windowsOut, err := osexec.Command("tmux", "list-windows", "-t", session, "-F", "#{window_name}").Output()
 		if err != nil {
 			continue
@@ -6233,7 +6243,7 @@ func cleanupOrphanedSessions(force bool) {
 			if _, err := fmt.Sscanf(window, "task-%d", &taskID); err != nil {
 				continue
 			}
-			allWindows = append(allWindows, windowRef{session: session, window: window, taskID: taskID})
+			allWindows = append(allWindows, windowRef{session: session, window: window, taskID: taskID, ownedByUs: ownedByUs})
 		}
 	}
 
@@ -6266,9 +6276,16 @@ func cleanupOrphanedSessions(force bool) {
 	}
 
 	var deletedWindows, oldDoneWindows []windowRef
+	var unknownWindows []string
 	for _, w := range allWindows {
 		if !existingTaskIDs[w.taskID] {
-			deletedWindows = append(deletedWindows, w)
+			// Only a session we can prove is ours may have a window killed for a
+			// task we cannot see. Anywhere else that reasoning is backwards.
+			if w.ownedByUs {
+				deletedWindows = append(deletedWindows, w)
+			} else {
+				unknownWindows = append(unknownWindows, w.session+":"+w.window)
+			}
 			continue
 		}
 		if oldDoneTaskIDs[w.taskID] {
@@ -6277,6 +6294,11 @@ func cleanupOrphanedSessions(force bool) {
 	}
 
 	totalToKill := len(deletedWindows) + len(oldDoneWindows)
+	if len(unknownWindows) > 0 {
+		fmt.Println(dimStyle.Render(fmt.Sprintf(
+			"Left %d window(s) alone: their task is not in this database and their session is not tagged as this machine's (%s)",
+			len(unknownWindows), strings.Join(unknownWindows, ", "))))
+	}
 	if len(foreignSessions) > 0 {
 		fmt.Println(dimStyle.Render(fmt.Sprintf(
 			"Skipped %d session(s) owned by another machine: %s",

--- a/cmd/task/sessions_test.go
+++ b/cmd/task/sessions_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/executor"
 )
 
 // requireTmux skips the test if tmux is not available.
@@ -255,6 +256,13 @@ func TestCleanupOrphanedSessions_KillsWindowForDeletedTask(t *testing.T) {
 	// Task ID has no row in the (empty) DB — pure orphan.
 	const orphanID = 992001
 	makeDaemonSessionWithName(t, sessionName, orphanID)
+	// Killing a window for a task we cannot see is only defensible on a session
+	// we can prove is ours, so the session has to say so. Untagged is unknown,
+	// and unknown windows are left alone — see the untagged case in
+	// cleanup_ownership_test.go.
+	if err := osexec.Command("tmux", "set-option", "-t", sessionName, executor.TmuxOwnerOption, executor.LocalOwnerTag()).Run(); err != nil {
+		t.Fatalf("tag session as ours: %v", err)
+	}
 
 	cleanupOrphanedSessions(false)
 


### PR DESCRIPTION
Follow-up to #703, which did not actually fix the case it was written for.

#703 skips sessions tagged as another machine's. But the tag is new, so **every session created before it carries no tag** — including the long-lived daemon session on a placed host, which is precisely the one whose live agent window kept being killed. The guard protected only sessions that were never in danger, and #5289 died the same way with the fix merged.

Verified after the merge landed: the agent ran `go test ./cmd/task/`, got `exit code 137` at 14:38:32, and parked.

## The rule

A window is killed for a task missing from the database **only when its session is provably ours**. Untagged sessions are still scanned — a window whose task we *can* see is provably ours to clean — but absence stops being grounds for killing, because absence is exactly what a foreign task looks like from here. Windows left alone are named in the output, so nothing goes silently uncleaned.

`TestCleanupOrphanedSessions_KillsWindowForDeletedTask` now tags its session as ours, because that is the claim the kill actually rests on.

## Validation

- `go test -race -p 1 ./...` — **21 ok, 0 fail**
- `golangci-lint v2.13.2` — **0 issues**
- Mutation-checked: forcing `ownedByUs` true fails `TestCleanupOrphanedSessions_SparesAnUntaggedSession`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP9gZVc4BQeiizRUWj38nz