### PR TITLE
fix: clear task detail title when returning to Kanban

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2740,6 +2740,7 @@ func (m *AppModel) detachDetail(saveHeight bool) tea.Cmd {
 	m.detailCleanupInFlight = true
 	return func() tea.Msg {
 		detail.paneWork.Wait()
+		defer detail.resetBoardPaneStyle()
 		detail.closeRemotePane(true)
 		if detail.claudePaneID != "" || detail.workdirPaneID != "" {
 			detail.breakTmuxPanes(saveHeight, true)

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1424,9 +1424,37 @@ func (m *DetailModel) paneCommand(work tea.Cmd) tea.Cmd {
 	}
 }
 
+// resetBoardPaneStyle clears detail presentation even when no local panes were joined.
+// Target the actual TUI pane: it need not be pane zero or in the current window.
+func (m *DetailModel) resetBoardPaneStyle() {
+	paneID := m.titlePaneID()
+	if os.Getenv("TMUX") == "" || paneID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	runTmuxBatch(ctx, [][]string{
+		{"set-option", "-t", paneID, "status-right", " "},
+		{"set-option", "-t", paneID, "pane-border-lines", "single"},
+		{"set-option", "-t", paneID, "pane-border-indicators", "off"},
+		{"set-option", "-t", paneID, "pane-border-style", "fg=#374151"},
+		{"set-option", "-t", paneID, "pane-active-border-style", "fg=#61AFEF"},
+		{"set-option", "-t", paneID, "window-style", "default"},
+		{"set-option", "-t", paneID, "window-active-style", "default"},
+		{"unbind-key", "-T", "root", "S-Down"},
+		{"unbind-key", "-T", "root", "S-Right"},
+		{"unbind-key", "-T", "root", "S-Up"},
+		{"unbind-key", "-T", "root", "S-Left"},
+		{"unbind-key", "-T", "root", "M-S-Up"},
+		{"unbind-key", "-T", "root", "M-S-Down"},
+		{"select-pane", "-t", paneID, "-T", "Tasks"},
+	})
+}
+
 // Cleanup should be called when leaving detail view.
 // It saves the current pane height before breaking the panes.
 func (m *DetailModel) Cleanup() {
+	defer m.resetBoardPaneStyle()
 	m.closeRemotePane(true)
 	if m.claudePaneID != "" || m.workdirPaneID != "" {
 		m.breakTmuxPanes(true, true) // saveHeight=true, resizeTUI=true
@@ -1440,6 +1468,7 @@ func (m *DetailModel) Cleanup() {
 // Use this during task transitions (prev/next) to avoid rounding errors
 // that accumulate with each transition and cause the pane to shrink.
 func (m *DetailModel) CleanupWithoutSaving() {
+	defer m.resetBoardPaneStyle()
 	m.closeRemotePane(true)
 	if m.claudePaneID != "" || m.workdirPaneID != "" {
 		m.breakTmuxPanes(false, true) // saveHeight=false, resizeTUI=true
@@ -2773,25 +2802,6 @@ func (m *DetailModel) breakTmuxPanes(saveHeight bool, resizeTUI bool) {
 			m.database.SetSetting(config.SettingDetailPaneHeight, fmt.Sprintf("%d%%", currentHeight))
 		}
 	}
-
-	// Reset status bar and pane styling
-	log.Debug("breakTmuxPanes: resetting status bar and pane styling")
-	runTmuxBatch(ctx, [][]string{
-		{"set-option", "-t", m.uiSessionName, "status-right", " "},
-		{"set-option", "-t", m.uiSessionName, "pane-border-lines", "single"},
-		{"set-option", "-t", m.uiSessionName, "pane-border-indicators", "off"},
-		{"set-option", "-t", m.uiSessionName, "pane-border-style", "fg=#374151"},
-		{"set-option", "-t", m.uiSessionName, "pane-active-border-style", "fg=#61AFEF"},
-		{"set-option", "-t", m.uiSessionName, "window-style", "default"},
-		{"set-option", "-t", m.uiSessionName, "window-active-style", "default"},
-		{"unbind-key", "-T", "root", "S-Down"},
-		{"unbind-key", "-T", "root", "S-Right"},
-		{"unbind-key", "-T", "root", "S-Up"},
-		{"unbind-key", "-T", "root", "S-Left"},
-		{"unbind-key", "-T", "root", "M-S-Up"},
-		{"unbind-key", "-T", "root", "M-S-Down"},
-		{"select-pane", "-t", m.uiSessionName + ":.0", "-T", "Tasks"},
-	})
 
 	// Break the Claude pane back to task-daemon
 	if m.claudePaneID == "" {

--- a/internal/ui/detail_board_title_test.go
+++ b/internal/ui/detail_board_title_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bborn/workflow/internal/db"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/bborn/workflow/internal/db"
 )
 
 func TestLeavingDetailResetsBoardTitleWithoutLocalPanes(t *testing.T) {

--- a/internal/ui/detail_board_title_test.go
+++ b/internal/ui/detail_board_title_test.go
@@ -1,0 +1,52 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestLeavingDetailResetsBoardTitleWithoutLocalPanes(t *testing.T) {
+	for _, exit := range []string{"escape", "cleanup", "without-saving"} {
+		for _, remote := range []bool{false, true} {
+			t.Run(exit+map[bool]string{false: "/no-panes", true: "/remote"}[remote], func(t *testing.T) {
+				app, marker := refreshTestModel(t)
+				t.Setenv("TMUX", "test")
+				t.Setenv("TMUX_PANE", "%42")
+				if err := os.WriteFile(filepath.Join(filepath.Dir(marker), "tmux"), []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TITLE_TEST_LOG\"\n"), 0700); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("TITLE_TEST_LOG", marker)
+				detail := &DetailModel{task: &db.Task{ID: 5278, Title: "Previous task"}, uiSessionName: "test-ui"}
+				if remote {
+					detail.remotePaneID = "%43"
+				}
+				switch exit {
+				case "escape":
+					app.detailView, app.currentView = detail, ViewDetail
+					_, cmd := app.updateDetail(tea.KeyMsg{Type: tea.KeyEsc})
+					if app.currentView != ViewDashboard {
+						t.Fatal("did not return to board")
+					}
+					cmd()
+				case "cleanup":
+					detail.Cleanup()
+				case "without-saving":
+					detail.CleanupWithoutSaving()
+				}
+				data, _ := os.ReadFile(marker)
+				calls := string(data)
+				if !strings.Contains(calls, "select-pane -t %42 -T Tasks") {
+					t.Errorf("board title was not restored on the TUI pane: %s", calls)
+				}
+				if !strings.Contains(calls, "pane-border-indicators off") {
+					t.Errorf("detail border styling remains: %s", calls)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Returning from task detail to Kanban could leave the previous task's title and border styling in tmux, especially for remote tasks or tasks without joined local panes. Reset that presentation on every detail cleanup path, targeting the actual TUI pane instead of assuming pane zero.

Adds regression coverage for Escape and both cleanup methods, with remote panes and without attached panes.

Validation:
- QA harness (`ty-qa-up`, `seed`, `tui`, `key`, `state`): reproduced the stale title on base `35c6d1c4`; the patched binary restores `Tasks`. Three repeated detail/board transitions passed.
- Before/after captures use VHS attached to the harness's isolated tmux session, with pane borders enabled.
- `go test ./...` and `go vet ./internal/ui/...` passed; both base and patched CLI binaries built successfully.
- `golangci-lint v2.13.2 run` passed with zero issues, using the same version as CI.
- Remote cleanup is covered by subprocess-stub regression tests; no live remote host was used.


<!-- QA evidence (paste into the PR comment) -->
![before](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-09-07/kanban-title-before.png)
![after](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-09-07/kanban-title-after.png)
