### PR TITLE
ci: smoke test packaged CLI onboarding before releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,26 @@ jobs:
         run: |
           go build -o bin/ty ./cmd/task
           go build -o bin/taskd ./cmd/taskd
+
+  release-onboarding:
+    name: Release onboarding
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Package release snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean
+
+      - name: Smoke test packaged CLI onboarding
+        run: scripts/qa/check-release-onboarding.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,38 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  preflight:
+    name: Release onboarding smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Package release snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean
+
+      - name: Smoke test packaged CLI onboarding
+        run: scripts/qa/check-release-onboarding.sh
+
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: preflight
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -30,3 +56,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Smoke test released CLI onboarding
+        run: scripts/qa/check-release-onboarding.sh

--- a/scripts/qa/check-onboarding.sh
+++ b/scripts/qa/check-onboarding.sh
@@ -12,6 +12,18 @@ export TY_PLUGINS_DIR="$CHECK_ROOT/plugins"
 export TMUX_TMPDIR="$CHECK_ROOT/tmux"
 unset TMUX
 mkdir -p "$TY_WORKFLOWS_DIR" "$TY_PLUGINS_DIR" "$TMUX_TMPDIR"
+# CLI commands normally check GitHub for updates. Seed that cache with the
+# binary under test so this smoke check stays deterministic and offline.
+TY_CHECK_VERSION="$("$TY_CHECK_BIN" --version)"
+python3 - "$CHECK_ROOT/version-check.json" "$TY_CHECK_VERSION" <<'PY'
+import datetime, json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+path.write_text(json.dumps({
+    "version": sys.argv[2],
+    "url": "",
+    "checked_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+}))
+PY
 unzip -q "$REPO_ROOT/docs/downloads/taskyou-storefront.zip" -d "$CHECK_ROOT"
 cd "$CHECK_ROOT/taskyou-storefront"
 git init -q

--- a/scripts/qa/check-release-onboarding.sh
+++ b/scripts/qa/check-release-onboarding.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Extract a GoReleaser ty archive and exercise the documented first-use path.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ARCHIVE="${1:-}"
+
+if [[ -z "$ARCHIVE" ]]; then
+    case "$(uname -s)" in
+        Darwin) RELEASE_OS="darwin" ;;
+        Linux) RELEASE_OS="linux" ;;
+        *) echo "Unsupported release smoke-test OS: $(uname -s)" >&2; exit 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64) RELEASE_ARCH="amd64" ;;
+        arm64|aarch64) RELEASE_ARCH="arm64" ;;
+        *) echo "Unsupported release smoke-test architecture: $(uname -m)" >&2; exit 1 ;;
+    esac
+
+    shopt -s nullglob
+    archives=("$REPO_ROOT"/dist/ty_*_"$RELEASE_OS"_"$RELEASE_ARCH".tar.gz)
+    shopt -u nullglob
+    if [[ ${#archives[@]} -ne 1 ]]; then
+        echo "Expected one packaged ty archive for $RELEASE_OS/$RELEASE_ARCH in dist; found ${#archives[@]}" >&2
+        exit 1
+    fi
+    ARCHIVE="${archives[0]}"
+fi
+
+if [[ ! -f "$ARCHIVE" ]]; then
+    echo "Release archive does not exist: $ARCHIVE" >&2
+    exit 1
+fi
+
+CHECK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/ty-release-onboarding.XXXXXX")"
+trap 'rm -rf "$CHECK_ROOT"' EXIT
+
+LC_ALL=C tar -xzf "$ARCHIVE" -C "$CHECK_ROOT"
+TY_BIN="$CHECK_ROOT/ty"
+if [[ ! -x "$TY_BIN" ]]; then
+    echo "Release archive does not contain an executable top-level ty binary: $ARCHIVE" >&2
+    exit 1
+fi
+
+"$TY_BIN" --version
+"$REPO_ROOT/scripts/qa/check-onboarding.sh" "$TY_BIN"


### PR DESCRIPTION
Exercise the documented first-task path using a CLI extracted from a GoReleaser archive. CI and a release preflight now package a snapshot and verify project registration, task creation, and all three staged workflow recipes in an isolated environment, without executing agents.

The publish job depends on preflight and also checks the exact release archive after publication. Release write permission is scoped to that job. A temporary version cache keeps onboarding checks offline.

Validation: full snapshot packaging and offline smoke passed during implementation; Bash syntax, ShellCheck, and packaged onboarding smoke passed after rebasing. The preflight checks a snapshot built with the release configuration; the exact release archive check happens after publication.
