### PR TITLE
fix(tui): hold the task-switch guard until panes are joined

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -421,9 +421,13 @@ type AppModel struct {
 	detailView   *DetailModel
 	// Prevent rapid arrow key navigation from causing duplicate panes
 	taskTransitionInProgress bool
-	detailCleanupInFlight    bool
-	pendingDetailLoad        *taskLoadedMsg
-	taskLoadRevision         uint64
+	// Deadline after which a held transition is treated as finished. Pane setup
+	// reports back through panesJoinedMsg / paneWaitForExecutorMsg; if such a
+	// result is ever lost, this keeps a stuck guard from wedging navigation.
+	taskTransitionDeadline time.Time
+	detailCleanupInFlight  bool
+	pendingDetailLoad      *taskLoadedMsg
+	taskLoadRevision       uint64
 	// Grace period after task transition to prevent focus flashing
 	taskTransitionGraceUntil time.Time
 
@@ -1138,7 +1142,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.currentView = ViewDetail
 			m.pendingDetailLoad = nil
 			m.taskLoadRevision++
-			m.taskTransitionInProgress = false
+			m.endTaskTransition()
 			m.notification = "Could not return task panes to the daemon; the running process was preserved. Try Back again."
 			m.detailView.paneError = m.notification
 			if m.detailView.task != nil {
@@ -1221,8 +1225,11 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.pendingDetailLoad = &msg
 			return m, nil
 		}
-		// Reset transition flag now that task is loaded
-		m.taskTransitionInProgress = false
+		// The row is loaded, but the switch is not finished: the new detail view's
+		// tmux panes are joined asynchronously below. Hand the guard to that join
+		// (released on panesJoinedMsg / paneWaitForExecutorMsg) rather than
+		// reopening it here, where it would let keys queued during the join each
+		// start another detach/join cycle.
 		// Set grace period to prevent focus flashing during task switch
 		// This allows the new detail view to settle before checking focus
 		m.taskTransitionGraceUntil = time.Now().Add(500 * time.Millisecond)
@@ -1252,9 +1259,15 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.detailView.SetPosition(pos, total)
 			m.previousView = m.currentView
 			m.currentView = ViewDetail
-			// Start async pane setup if needed
+			// Start async pane setup if needed. The detail view reports whether it
+			// is waiting on panes; when it is not (no tmux, nothing to join) the
+			// switch is already complete and the guard must not wait for a pane
+			// message that will never be sent.
 			if initCmd != nil {
 				cmds = append(cmds, initCmd)
+			}
+			if !m.detailView.paneLoading {
+				m.endTaskTransition()
 			}
 			// Start tmux output ticker if session is active
 			if tickerCmd := m.detailView.StartTmuxTicker(); tickerCmd != nil {
@@ -1279,6 +1292,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		} else {
 			m.err = msg.err
+			m.endTaskTransition()
 		}
 
 	case prInfoMsg:
@@ -1587,11 +1601,33 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.currentView == ViewDetail && m.detailView != nil {
 			// Skip focus checking during task transitions to prevent visual flashing
 			// The grace period allows the new task to settle before checking focus
-			if !m.taskTransitionInProgress && time.Now().After(m.taskTransitionGraceUntil) && !m.focusLoadInFlight {
+			if !m.transitionInProgress() && time.Now().After(m.taskTransitionGraceUntil) && !m.focusLoadInFlight {
 				m.focusLoadInFlight = true
 				cmds = append(cmds, m.detailView.focusStateCmd())
 			}
 			cmds = append(cmds, m.focusTick())
+		}
+
+	case panesJoinedMsg, paneWaitForExecutorMsg:
+		// Pane setup has reported back: either the panes are in place, or the task
+		// is now waiting on the daemon to build a window (an open-ended wait that
+		// must not hold navigation). Either way that switch is over.
+		//
+		// Only when a detail view actually owns it. detachDetail nils detailView
+		// and then waits on paneWork, so the *outgoing* task's join lands here
+		// mid-switch; opening the guard on that would let another key start a
+		// cycle before the incoming task has its panes. The incoming view sends
+		// its own message (or clears the guard at load time when it has no pane
+		// work to do), and taskTransitionTimeout backstops a lost one.
+		if m.detailView != nil {
+			m.endTaskTransition()
+			if m.currentView == ViewDetail {
+				var cmd tea.Cmd
+				m.detailView, cmd = m.detailView.Update(msg)
+				if cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+			}
 		}
 
 	case dbChangeMsg:
@@ -2698,6 +2734,44 @@ type detailCleanupMsg struct {
 	failed *DetailModel
 }
 
+// taskTransitionTimeout bounds how long a task switch may hold the navigation
+// guard while waiting for its panes. Joins are normally well under a second but
+// have been observed at ~2s on a task whose stored window ID went stale; this is
+// the backstop for a pane result that never arrives at all.
+const taskTransitionTimeout = 10 * time.Second
+
+// beginTaskTransition closes the navigation guard for a task switch. It stays
+// closed until the new detail view's panes are in place (endTaskTransition), so a
+// second switch cannot start while tmux panes are still being moved.
+func (m *AppModel) beginTaskTransition() {
+	m.taskTransitionInProgress = true
+	m.taskTransitionDeadline = time.Now().Add(taskTransitionTimeout)
+}
+
+// endTaskTransition reopens the navigation guard.
+func (m *AppModel) endTaskTransition() {
+	m.taskTransitionInProgress = false
+	m.taskTransitionDeadline = time.Time{}
+}
+
+// transitionInProgress reports whether a task switch still owns the detail view.
+//
+// The guard must outlive the *database* load: NewDetailModel returns as soon as
+// the row is read, but the ~30-call tmux join that actually populates the pane
+// runs asynchronously for another 0.5-2s. Reopening at row-load time let every
+// key pressed during that window start its own detach/join cycle, and because
+// detachDetail blocks on paneWork.Wait() each cycle tore the executor pane back
+// out microseconds after it landed — the pane visibly flickering between tasks.
+func (m *AppModel) transitionInProgress() bool {
+	if !m.taskTransitionInProgress {
+		return false
+	}
+	if !m.taskTransitionDeadline.IsZero() && time.Now().After(m.taskTransitionDeadline) {
+		return false
+	}
+	return true
+}
+
 // Detach ownership immediately so board input can continue. New detail loads
 // wait for the handoff, and old pane results cannot reach the next detail view.
 func (m *AppModel) detachDetail(saveHeight bool) tea.Cmd {
@@ -2744,7 +2818,7 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if key.Matches(keyMsg, m.keys.Back) {
 		m.taskLoadRevision++
 		m.pendingDetailLoad = nil
-		m.taskTransitionInProgress = false
+		m.endTaskTransition()
 		m.currentView = ViewDashboard
 		// Clear origin column when exiting detail view
 		m.kanban.ClearOriginColumn()
@@ -2880,10 +2954,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// Ignore if transition already in progress to prevent duplicate panes
-		if m.taskTransitionInProgress {
+		if m.transitionInProgress() {
 			return m, nil
 		}
-		m.taskTransitionInProgress = true
+		m.beginTaskTransition()
 		// Clean up current detail view before switching (without saving height)
 		cleanup := m.detachDetail(false)
 		// Move selection up in the kanban
@@ -2892,7 +2966,7 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if task := m.kanban.SelectedTask(); task != nil {
 			return m, tea.Batch(cleanup, m.loadTaskWithOptions(task.ID, keyMsg.String() == "ctrl+up"))
 		}
-		m.taskTransitionInProgress = false
+		m.endTaskTransition()
 		return m, cleanup
 	}
 	if key.Matches(keyMsg, m.keys.Down) || keyMsg.String() == "ctrl+down" {
@@ -2901,10 +2975,10 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// Ignore if transition already in progress to prevent duplicate panes
-		if m.taskTransitionInProgress {
+		if m.transitionInProgress() {
 			return m, nil
 		}
-		m.taskTransitionInProgress = true
+		m.beginTaskTransition()
 		// Clean up current detail view before switching (without saving height)
 		cleanup := m.detachDetail(false)
 		// Move selection down in the kanban
@@ -2913,7 +2987,7 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if task := m.kanban.SelectedTask(); task != nil {
 			return m, tea.Batch(cleanup, m.loadTaskWithOptions(task.ID, keyMsg.String() == "ctrl+down"))
 		}
-		m.taskTransitionInProgress = false
+		m.endTaskTransition()
 		return m, cleanup
 	}
 

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2852,7 +2852,8 @@ func (m *DetailModel) breakTmuxPanes(saveHeight bool, resizeTUI bool) {
 			"-s", m.claudePaneID,
 			"-t", daemonSession+":",
 			"-n", windowName).Run()
-		if newWindowErr != nil {
+		returned := newWindowErr == nil
+		if !returned {
 			log.Warn("breakTmuxPanes: break-pane also failed: %v - leaving pane in place", newWindowErr)
 			// Last resort: leave panes in task-ui rather than kill Claude
 			// The panes will be visible but Claude keeps running
@@ -2864,8 +2865,16 @@ func (m *DetailModel) breakTmuxPanes(saveHeight bool, resizeTUI bool) {
 			osExec.CommandContext(ctx, "tmux", "kill-pane", "-t", m.workdirPaneID).Run()
 			m.workdirPaneID = ""
 		}
-		m.claudePaneID = ""
-		m.daemonSessionID = ""
+		// Only forget the Claude pane once it has actually left task-ui. Clearing it
+		// unconditionally reported a clean handoff for a pane that is still sitting
+		// in the TUI window: the board released the executor lock and moved on, and
+		// the next join's "kill leftover panes in task-ui" step was then free to kill
+		// a live executor. Keeping the ID makes detachDetail surface the failure
+		// (see detailCleanupMsg.failed) instead of orphaning the session silently.
+		if returned {
+			m.claudePaneID = ""
+			m.daemonSessionID = ""
+		}
 		if resizeTUI {
 			osExec.CommandContext(ctx, "tmux", "resize-pane", "-t", "task-ui:.0", "-y", "100%").Run()
 		}

--- a/internal/ui/detail_break_orphan_test.go
+++ b/internal/ui/detail_break_orphan_test.go
@@ -1,0 +1,90 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// stubTmux puts a tmux on PATH that fails the named subcommands and succeeds
+// (printing canned output) for everything else, so breakTmuxPanes can be driven
+// down a specific failure branch without a tmux server.
+func stubTmux(t *testing.T, failing ...string) {
+	t.Helper()
+	root := t.TempDir()
+	script := "#!/bin/sh\n"
+	for _, sub := range failing {
+		script += "case \"$*\" in *" + sub + "*) exit 1;; esac\n"
+	}
+	// display-message drives window/pane lookups; a non-empty answer keeps
+	// findOrCreateTaskWindow on its "found a window" path.
+	script += "case \"$*\" in *display-message*) echo '@99';; esac\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(root, "tmux"), []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", root+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func breakTestModel() *DetailModel {
+	return &DetailModel{
+		task:            &db.Task{ID: 7, TmuxWindowID: "@99", WorktreePath: "/tmp/wt-7"},
+		claudePaneID:    "%700",
+		daemonSessionID: "task-daemon-1",
+		tuiPaneID:       "%1",
+	}
+}
+
+// When tmux cannot move the executor pane out of task-ui, the pane is still in
+// the TUI window and a live Claude is still attached to it. Reporting a clean
+// handoff there loses the pane: the board releases the executor lock, and the
+// next join is free to kill it as a "leftover" pane.
+func TestBreakKeepsPaneIDWhenPaneCouldNotLeaveTaskUI(t *testing.T) {
+	stubTmux(t, "join-pane", "break-pane")
+	m := breakTestModel()
+	m.breakTmuxPanes(false, false)
+	if m.claudePaneID == "" {
+		t.Fatal("reported a clean handoff for a pane still sitting in task-ui")
+	}
+}
+
+// The same branch when break-pane rescues the pane into a new daemon window: it
+// really did leave task-ui, so the model must forget it.
+func TestBreakClearsPaneIDWhenBreakPaneRescuesIt(t *testing.T) {
+	stubTmux(t, "join-pane")
+	m := breakTestModel()
+	m.breakTmuxPanes(false, false)
+	if m.claudePaneID != "" {
+		t.Fatalf("pane %q left task-ui but is still tracked", m.claudePaneID)
+	}
+}
+
+// A stuck pane must reach the user as the "could not return panes" state rather
+// than a silent return to the board.
+func TestDetachReportsFailureWhenPaneIsStuck(t *testing.T) {
+	app, _ := refreshTestModel(t)
+	detail := breakTestModel()
+	app.detailView, app.currentView = detail, ViewDetail
+	detail.claudePaneID = "%700"
+
+	cleanup := app.detachDetail(false)
+	if cleanup == nil {
+		t.Fatal("no cleanup scheduled")
+	}
+	msg, ok := cleanup().(detailCleanupMsg)
+	if !ok {
+		t.Fatalf("unexpected cleanup message %T", msg)
+	}
+	if msg.failed == nil {
+		t.Fatal("stuck executor pane reported as a clean handoff")
+	}
+	app.Update(msg)
+	if app.currentView != ViewDetail || app.notification == "" {
+		t.Fatal("user was not told the panes could not be returned")
+	}
+}
+
+var _ tea.Msg = detailCleanupMsg{}

--- a/internal/ui/detail_transition_guard_test.go
+++ b/internal/ui/detail_transition_guard_test.go
@@ -1,0 +1,148 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// transitionTestModel builds an app sitting in the detail view of the first of
+// three blocked tasks, with TMUX set so NewDetailModel takes the real async pane
+// path. The pane command it returns is never run by the test, which is exactly
+// what a slow join looks like to the update loop: the detail view exists, but
+// panesJoinedMsg has not arrived yet.
+func transitionTestModel(t *testing.T) (*AppModel, []*db.Task) {
+	t.Helper()
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	app, _ := refreshTestModel(t)
+	tasks := []*db.Task{
+		{ID: 1, Title: "first", Status: db.StatusBlocked},
+		{ID: 2, Title: "second", Status: db.StatusBlocked},
+		{ID: 3, Title: "third", Status: db.StatusBlocked},
+	}
+	app.kanban.SetTasks(tasks)
+	app.kanban.SelectTask(1)
+	app.selectedTask = tasks[0]
+	detail, _ := NewDetailModel(tasks[0], app.db, nil, 100, 40, false)
+	app.detailView = detail
+	app.currentView = ViewDetail
+	return app, tasks
+}
+
+// A join that has not reported back must keep the transition guard closed. The
+// guard exists to stop a second switch from starting while the first is still
+// moving tmux panes around; clearing it when the *database* row loads reopens it
+// within milliseconds, long before the ~0.5-2s join finishes, so queued keys each
+// kick off another detach/join cycle and the executor pane visibly flickers.
+func TestTaskTransitionGuardHeldUntilPanesJoined(t *testing.T) {
+	app, tasks := transitionTestModel(t)
+
+	if _, cmd := app.updateDetail(tea.KeyMsg{Type: tea.KeyCtrlDown}); cmd == nil {
+		t.Fatal("first switch did not start")
+	}
+	if !app.transitionInProgress() {
+		t.Fatal("guard not closed by the first switch")
+	}
+
+	// The row load finishes fast; the pane join has not.
+	app.detailCleanupInFlight = false
+	app.Update(taskLoadedMsg{task: tasks[1], revision: app.taskLoadRevision, focusExecutor: true})
+	if app.detailView == nil || !app.detailView.paneLoading {
+		t.Fatal("detail view is not waiting on an async pane join")
+	}
+	if !app.transitionInProgress() {
+		t.Fatal("guard reopened once the row loaded, while the pane join was still running")
+	}
+
+	// A key arriving during the join must be dropped, not start a second cycle.
+	before := app.taskLoadRevision
+	if _, cmd := app.updateDetail(tea.KeyMsg{Type: tea.KeyCtrlDown}); cmd != nil {
+		t.Fatal("second switch started while panes were still joining")
+	}
+	if app.taskLoadRevision != before {
+		t.Fatal("second switch loaded another task mid-join")
+	}
+
+	// Once the join reports, navigation is available again.
+	app.Update(panesJoinedMsg{claudePaneID: "%1"})
+	if app.transitionInProgress() {
+		t.Fatal("guard still closed after panes joined")
+	}
+	if _, cmd := app.updateDetail(tea.KeyMsg{Type: tea.KeyCtrlDown}); cmd == nil {
+		t.Fatal("navigation not restored after the join completed")
+	}
+}
+
+// Waiting on the daemon to build a window is an open-ended wait, so it must
+// release the guard rather than wedge navigation behind an executor that may
+// never appear.
+func TestTaskTransitionGuardReleasedWhenWaitingForExecutor(t *testing.T) {
+	app, tasks := transitionTestModel(t)
+	app.updateDetail(tea.KeyMsg{Type: tea.KeyCtrlDown})
+	app.detailCleanupInFlight = false
+	app.Update(taskLoadedMsg{task: tasks[1], revision: app.taskLoadRevision})
+	if !app.transitionInProgress() {
+		t.Fatal("guard not held across the row load")
+	}
+	app.Update(paneWaitForExecutorMsg{})
+	if app.transitionInProgress() {
+		t.Fatal("guard held while merely waiting for the daemon's executor")
+	}
+}
+
+// A detail view with no pane work to do (not under tmux) must not hold the guard
+// at all, or every switch would wait for a message that never comes.
+func TestTaskTransitionGuardReleasedWithoutPaneWork(t *testing.T) {
+	t.Setenv("TMUX", "")
+	app, _ := refreshTestModel(t)
+	tasks := []*db.Task{
+		{ID: 1, Title: "first", Status: db.StatusBlocked},
+		{ID: 2, Title: "second", Status: db.StatusBlocked},
+	}
+	app.kanban.SetTasks(tasks)
+	app.kanban.SelectTask(1)
+	app.currentView = ViewDetail
+	app.beginTaskTransition()
+	app.Update(taskLoadedMsg{task: tasks[1], revision: app.taskLoadRevision})
+	if app.detailView == nil || app.detailView.paneLoading {
+		t.Fatal("expected a detail view with no pending pane work")
+	}
+	if app.transitionInProgress() {
+		t.Fatal("guard held even though there was no pane work to wait for")
+	}
+}
+
+// The guard must never be able to wedge navigation permanently: if the pane
+// result is lost, it expires on its own.
+func TestTaskTransitionGuardExpires(t *testing.T) {
+	app, _ := transitionTestModel(t)
+	app.updateDetail(tea.KeyMsg{Type: tea.KeyCtrlDown})
+	if !app.transitionInProgress() {
+		t.Fatal("guard not closed")
+	}
+	app.taskTransitionDeadline = app.taskTransitionDeadline.Add(-2 * taskTransitionTimeout)
+	if app.transitionInProgress() {
+		t.Fatal("guard outlived its deadline and wedged navigation")
+	}
+}
+
+// detachDetail clears detailView and then waits on paneWork, so the pane result
+// of the task being *left* arrives while the switch to the next task is still in
+// flight. It must not be mistaken for the incoming task's panes.
+func TestStalePaneResultDoesNotOpenGuardMidSwitch(t *testing.T) {
+	app, _ := transitionTestModel(t)
+	app.updateDetail(tea.KeyMsg{Type: tea.KeyCtrlDown})
+	if app.detailView != nil {
+		t.Fatal("detach did not release the detail view")
+	}
+	if !app.transitionInProgress() {
+		t.Fatal("guard not closed by the switch")
+	}
+	// The outgoing task's join finally reports, with no detail view owning it.
+	app.Update(panesJoinedMsg{claudePaneID: "%old"})
+	if !app.transitionInProgress() {
+		t.Fatal("outgoing task's pane result opened the guard mid-switch")
+	}
+}


### PR DESCRIPTION
## The bug

Entering task 5119 made the detail view flicker between tasks: the executor pane appeared, vanished, and the view walked on to a neighbour. Reported as "when I enter it it just flickers between some other task and is broken".

`ui.log` shows the same shape on **every** entry — join completes, break starts 9ms later:

```
21:34:25.312  NewDetailModel: task 5119
21:34:25.760  joinTmuxPanes: completed, claudePaneID="%24833"   ← 448ms to join
21:34:25.769  breakTmuxPanes: starting for task 5119            ← ripped out 9ms later
21:34:25.892  NewDetailModel: task 5151
21:34:26.270  NewDetailModel: task 5266
```

Repeated at 21:32:48, 21:33:19, 21:33:40 and 21:34:25, with joins from 448ms up to **1.9s**.

## Root cause

`taskTransitionInProgress` is the guard that stops a second switch starting while the first is still moving tmux panes (`app.go` ctrl+up/ctrl+down handlers). It was cleared on `taskLoadedMsg` — the *database* row load, which finishes in milliseconds.

The ~30-call tmux join that actually populates the pane runs asynchronously for another 0.5–2s, completely unguarded. Every key pressed during that window started its own detach/join cycle, and because `detachDetail` blocks on `paneWork.Wait()`, each queued cycle tore the executor pane back out microseconds after it landed. That 9ms gap is the join finishing and the waiting detach immediately firing.

## The fix

Hold the guard until pane setup reports back through `panesJoinedMsg` / `paneWaitForExecutorMsg`:

- `beginTaskTransition` / `endTaskTransition` / `transitionInProgress` replace the raw bool
- `taskLoadedMsg` hands the guard to the async join instead of clearing it, releasing early only when the new detail view has no pane work (`!paneLoading` — no tmux, nothing to join) or the load errored
- new `case panesJoinedMsg, paneWaitForExecutorMsg` releases it and **forwards** the message to the detail view rather than consuming it
- a stale result from the task being *left* is ignored: `detachDetail` nils `detailView` then waits on `paneWork`, so the outgoing task's join lands mid-switch and would otherwise open the guard early
- `taskTransitionTimeout` (10s) backstops a lost pane message, so the guard can never wedge navigation permanently

`paneWaitForExecutorMsg` releases the guard because waiting on the daemon to build a window is open-ended and must not block navigation.

## Second fix: orphaned executor pane

`breakTmuxPanes` cleared `claudePaneID` even when **both** `join-pane` and `break-pane` failed — in which case the pane is still sitting in task-ui with a live Claude attached. That reported a clean handoff for a pane that never left: the board released the executor lock and moved on, and the next join's "kill leftover panes in task-ui" step was then free to kill a live executor. Now the ID is only cleared when `break-pane` actually rescued the pane, so `detachDetail` surfaces the failure instead.

(The neighbouring `targetWindowID == ""` early return already does the right thing — keeping the ID is what raises the "could not return panes" notice.)

## Tests

8 tests across `detail_transition_guard_test.go` and `detail_break_orphan_test.go`.

The slow join is **real, not a zero-cost mock**: `t.Setenv("TMUX", ...)` puts `NewDetailModel` on its true async path, and the test simply never runs the returned command — exactly what a 2s join looks like to the update loop. A mock that returned instantly would pass with the guard deleted.

Both fixes verified by reverting them:

- guard: `guard reopened once the row loaded, while the pane join was still running`
- pane leak: `reported a clean handoff for a pane still sitting in task-ui`

## Verification

- `go test ./internal/ui/` passes, including under `-race`
- repo-wide `go test ./...` passes except `cmd/task/TestCompletionCmdOutput/bash`, which hangs forever writing bash completion into a full OS pipe (`cobra.GenBashCompletion` blocked in `internal/poll.waitWrite`). **Pre-existing** — reproduced on clean `main` with these changes stashed.

## Not addressed

Task 5119's stored tmux window ID reads back stale on every entry, so each exit creates a brand-new window (`@12441 → @12515 → @12519 → @12522 → @12528`) and each entry pays a full "search all sessions" scan. That churn is *why* its join is slow enough to expose this bug; worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWUetsantf6kBSQEaSDS7c