### PR TITLE
fix(palette): don't present an older query's results as matches

### DIFF
--- a/internal/ui/command_palette.go
+++ b/internal/ui/command_palette.go
@@ -36,6 +36,11 @@ type CommandPaletteModel struct {
 	searchInFlight bool
 	searchPending  bool
 	enterPending   bool
+	// resultsQuery is the query filteredTasks was computed from. While it
+	// differs from what is typed, the list on screen belongs to an older query
+	// and says nothing about the current one, so it must not be presented (or
+	// selected from) as if it were a result set.
+	resultsQuery string
 
 	// Action mode: entered by typing a leading ">". Filters plugin actions
 	// instead of tasks. Task-switching behavior is unchanged when not in it.
@@ -130,7 +135,14 @@ func (m *CommandPaletteModel) Update(msg tea.Msg) (*CommandPaletteModel, tea.Cmd
 			return m, m.searchAsync()
 		}
 		m.searchPending = false
+		staleList := m.resultsQuery != msg.query
 		m.filteredTasks = msg.tasks
+		m.resultsQuery = msg.query
+		if staleList {
+			// These rows replace an unrelated list; an index picked against
+			// those rows points at an arbitrary task here.
+			m.selectedIndex = 0
+		}
 		m.selectedIndex = min(m.selectedIndex, max(0, len(msg.tasks)-1))
 		if m.enterPending {
 			m.enterPending = false
@@ -211,6 +223,16 @@ func (m *CommandPaletteModel) Update(msg tea.Msg) (*CommandPaletteModel, tea.Cmd
 	return m, nil
 }
 
+// resultsStale reports whether filteredTasks was computed from a different
+// query than the one currently typed. A stale list is rendered as the searching
+// state rather than as rows: drawn normally it is indistinguishable from real
+// results — same rows, same selection highlight — so a user acts on a task the
+// query never matched, which is how a paste of "task/5174-..." could open an
+// unrelated task sitting at the top of the previous list.
+func (m *CommandPaletteModel) resultsStale() bool {
+	return m.resultsQuery != m.searchInput.Value()
+}
+
 // Search uses a private snapshot and one worker. Closing/reopening the palette
 // cannot apply an old worker's results to a different palette instance.
 type paletteSearchMsg struct {
@@ -224,6 +246,7 @@ func (m *CommandPaletteModel) searchAsync() tea.Cmd {
 	if strings.TrimSpace(query) == "" || strings.HasPrefix(strings.TrimSpace(query), ">") {
 		m.searchPending = false
 		m.filter()
+		m.resultsQuery = query
 		return nil
 	}
 	m.actionMode = false
@@ -360,6 +383,8 @@ func (m *CommandPaletteModel) filterTasks() {
 			m.filteredTasks[i] = st.task
 		}
 	}
+
+	m.resultsQuery = query
 
 	// Clamp selected index
 	if m.selectedIndex >= len(m.filteredTasks) {
@@ -742,12 +767,12 @@ func (m *CommandPaletteModel) View() string {
 	var taskList strings.Builder
 	if m.actionMode {
 		m.renderActionList(&taskList, modalWidth-6)
-	} else if len(m.filteredTasks) == 0 {
+	} else if len(m.filteredTasks) == 0 || m.resultsStale() {
 		emptyStyle := lipgloss.NewStyle().
 			Foreground(ColorMuted).
 			Italic(true).
 			Padding(1, 0)
-		if m.searchPending {
+		if m.searchPending || m.resultsStale() {
 			taskList.WriteString(emptyStyle.Render("Searching tasks…"))
 		} else if query != "" {
 			// Show AI command hint when there's input but no matching tasks

--- a/internal/ui/palette_stale_results_test.go
+++ b/internal/ui/palette_stale_results_test.go
@@ -1,0 +1,115 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// stalePaletteModel is a palette showing results for one query while the user
+// has already typed a different one — the state the palette sits in for the
+// whole duration of an in-flight search.
+func stalePaletteModel(t *testing.T, shown []*db.Task, typed string) *CommandPaletteModel {
+	t.Helper()
+	in := textinput.New()
+	in.SetValue(typed)
+	return &CommandPaletteModel{
+		allTasks:      shown,
+		filteredTasks: shown,
+		resultsQuery:  "", // the recency list: produced by the empty query
+		searchInput:   in,
+		searchPending: true,
+		width:         100,
+		height:        40,
+		maxVisible:    10,
+	}
+}
+
+func staleTasks() []*db.Task {
+	return []*db.Task{
+		{ID: 4778, Title: "Build a generalized SOCIAL-INTERACTION framework", Status: db.StatusBlocked},
+		{ID: 5119, Title: "Creator Referral v2", Status: db.StatusBlocked},
+	}
+}
+
+// A list produced by a different query must not be drawn as though it were the
+// results for what is currently typed. Every row in it is arbitrary relative to
+// the query, so presenting it with a live selection invites the user to act on
+// a task that does not match at all.
+func TestPaletteDoesNotRenderStaleResultsAsMatches(t *testing.T) {
+	m := stalePaletteModel(t, staleTasks(), "task/5174-add-stripe-connect-credit-incentive-feat")
+	view := m.View()
+	if strings.Contains(view, "SOCIAL-INTERACTION") || strings.Contains(view, "Creator Referral") {
+		t.Fatal("stale non-matching rows rendered as results for the typed query")
+	}
+	if !strings.Contains(view, "Searching") {
+		t.Fatal("no indication that results are still being computed")
+	}
+}
+
+// Results arriving for a new query replace an unrelated list, so a selection
+// index chosen against the old rows means nothing. It must land on the new
+// top-ranked match, not carry over into a different set of tasks.
+func TestPaletteResetsSelectionWhenResultsReplaceStaleList(t *testing.T) {
+	m := stalePaletteModel(t, staleTasks(), "stripe")
+	m.selectedIndex = 1 // user had moved down the stale list
+
+	fresh := []*db.Task{
+		{ID: 5174, Title: "Add Stripe Connect credit incentive feature", Status: db.StatusBlocked},
+		{ID: 4001, Title: "Stripe webhook retries", Status: db.StatusBlocked},
+	}
+	m.Update(paletteSearchMsg{owner: m, query: "stripe", tasks: fresh})
+
+	if m.selectedIndex != 0 {
+		t.Fatalf("selection carried over from the stale list: index %d", m.selectedIndex)
+	}
+	if m.filteredTasks[m.selectedIndex].ID != 5174 {
+		t.Fatalf("selection landed on #%d, not the top match", m.filteredTasks[m.selectedIndex].ID)
+	}
+}
+
+// Once results match what is typed, the list renders normally.
+func TestPaletteRendersFreshResults(t *testing.T) {
+	m := stalePaletteModel(t, staleTasks(), "stripe")
+	fresh := []*db.Task{{ID: 5174, Title: "Add Stripe Connect credit incentive feature", Status: db.StatusBlocked}}
+	m.Update(paletteSearchMsg{owner: m, query: "stripe", tasks: fresh})
+	if m.searchPending {
+		t.Fatal("still pending after results for the current query")
+	}
+	if !strings.Contains(m.View(), "Stripe Connect") {
+		t.Fatal("fresh matching results not rendered")
+	}
+}
+
+// Enter pressed while a slow search is still running must select from the real
+// results, never from whatever happened to be on screen. The gate makes the
+// search genuinely outlast the keypress; an instant fake would pass either way.
+func TestPaletteEnterDuringSlowSearchUsesRealResults(t *testing.T) {
+	m := stalePaletteModel(t, staleTasks(), "stripe")
+	m.searchInFlight = true
+
+	gate := make(chan struct{})
+	fresh := []*db.Task{{ID: 5174, Title: "Add Stripe Connect credit incentive feature", Status: db.StatusBlocked}}
+	search := func() tea.Msg {
+		<-gate
+		return paletteSearchMsg{owner: m, query: "stripe", tasks: fresh}
+	}
+
+	m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.selectedTask != nil {
+		t.Fatalf("Enter selected #%d from the on-screen list before results arrived", m.selectedTask.ID)
+	}
+
+	done := make(chan tea.Msg, 1)
+	go func() { done <- search() }()
+	close(gate)
+	m.Update(<-done)
+
+	if m.selectedTask == nil || m.selectedTask.ID != 5174 {
+		t.Fatalf("deferred Enter did not select the real top match: %+v", m.selectedTask)
+	}
+}


### PR DESCRIPTION
## The bug

Pasting a branch name into the command palette opens an **entirely unrelated task**. Searching `task/5174-add-stripe-connect-credit-incentive-feat` left **#4778** selected at the top:


```
Searching…
> task/5174-add-stripe-connect-credit-incentive-feat

> ⚠ #4778 [ik] [Verify] Build a generalized SOCIAL-INTERACTION AUTOMATI...   ← selected
  ⚠ #5174 [ik] Add Stripe Connect credit incentive feature
  ⚠ #5119 [ik] Creator Referral v2: ...
  ... 124 more below
```

## Root cause

**The scorer was never wrong.** `extractTaskID` pulls `5174` out of the branch name and `scoreTask` returns 1000 for it — first place. Verified directly:

```
task 4778 score=-1        ← cannot be a result at all
task 5174 score=1000
rank 0 -> #5174
```

The list on screen simply wasn't that query's results. It was the **previous** list — after opening the palette, the recency-ordered one — because `View` only substitutes the "Searching…" placeholder when `filteredTasks` is *empty* (`command_palette.go:743`). With any list present it draws the old rows at full fidelity, **selection highlight included**, distinguishable from real results only by one word in the header.

It's also self-reinforcing: each wrong entry makes #4778 more recently accessed, keeping it pinned to the top of the recency list for the next attempt.

## The fix

Track the query each result set was computed from (`resultsQuery`) and treat a mismatch as stale:

- render the searching state instead of rows belonging to a different query
- reset the selection when results replace an unrelated list, so an index chosen against the old rows can't carry into a different set of tasks

## On the "slow search"

`SearchTasks` is **not** the bottleneck — a `LIKE` scan over 2,396 rows measures **12–183ms** and never touches the 877k-row `task_logs`. The stale window is only wide enough to act on when the machine is under memory pressure. Left alone here; this PR fixes what the palette *shows* during that window, however long it lasts.

## Tests

Four tests in `palette_stale_results_test.go`. The Enter test gates its search behind a channel so the search genuinely outlasts the keypress — with an instant fake it would pass either way.

Both halves verified load-bearing by reverting each:

- stale render: `stale non-matching rows rendered as results for the typed query`
- selection reset: `selection carried over from the stale list: index 1`

`go test ./internal/ui/` passes, including under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWUetsantf6kBSQEaSDS7c
