### PR TITLE
fix(tui): resolve the remote attach pane from $TMUX_PANE, not tmux's "current"

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -918,12 +918,11 @@ func (m *DetailModel) setupPanesAsync() tea.Cmd {
 			}
 		}
 
-		// Resolve the actual UI session name (avoid prefix-matching the wrong session).
-		if out, err := osExec.Command("tmux", "display-message", "-p", "#{session_name}").Output(); err == nil {
-			m.uiSessionName = strings.TrimSpace(string(out))
-		} else {
-			m.uiSessionName = "task-ui" // fallback
-		}
+		// Resolve the actual UI session name (avoid prefix-matching the wrong
+		// session, and avoid naming another instance's — see ownSessionName).
+		sessionCtx, cancelSession := context.WithTimeout(context.Background(), 5*time.Second)
+		m.uiSessionName = m.ownSessionName(sessionCtx)
+		cancelSession()
 
 		// Find the task's existing window (one tmux call).
 		m.cachedWindowTarget = m.findTaskWindow()
@@ -1061,19 +1060,14 @@ func (m *DetailModel) attachRemotePane(loc executor.RemoteTaskLocation) string {
 	defer cancel()
 
 	if m.uiSessionName == "" {
-		if out, err := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{session_name}").Output(); err == nil {
-			m.uiSessionName = strings.TrimSpace(string(out))
-		} else {
-			m.uiSessionName = "task-ui"
-		}
+		m.uiSessionName = m.ownSessionName(ctx)
 	}
 
-	tuiPaneOut, err := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}").Output()
-	if err != nil {
-		log.Error("attachRemotePane: could not read the TUI pane id: %v", err)
+	tuiPaneID := ownPaneID()
+	if tuiPaneID == "" {
+		log.Error("attachRemotePane: no $TMUX_PANE; refusing to guess this instance's pane")
 		return ""
 	}
-	tuiPaneID := strings.TrimSpace(string(tuiPaneOut))
 	m.tuiPaneID = tuiPaneID
 
 	// Clear any panes left behind by the previously viewed task, exactly as the
@@ -1762,6 +1756,33 @@ func (m *DetailModel) updateTmuxPaneTitle() {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	osExec.CommandContext(ctx, "tmux", "select-pane", "-t", paneID, "-T", m.getPaneTitle()).Run()
+}
+
+// ownPaneID is the pane this ty process draws into. $TMUX_PANE is set by tmux
+// for the process it runs, so it names this instance's pane by definition.
+//
+// Asking tmux for "#{pane_id}" without a target answers with the active pane of
+// whichever client tmux currently considers foremost. With a second ty attached
+// to the same server that is somebody else's pane — and callers here go on to
+// kill the panes around the answer and split into it, so a wrong answer destroys
+// another instance's executor panes.
+func ownPaneID() string {
+	return os.Getenv("TMUX_PANE")
+}
+
+// ownSessionName resolves the session holding this process's own pane. Scoped to
+// ownPaneID for the same reason: an unscoped query names the foremost client's
+// session, which is how one instance ends up operating inside another's.
+func (m *DetailModel) ownSessionName(ctx context.Context) string {
+	if pane := ownPaneID(); pane != "" {
+		if out, err := osExec.CommandContext(ctx, "tmux", "display-message",
+			"-t", pane, "-p", "#{session_name}").Output(); err == nil {
+			if name := strings.TrimSpace(string(out)); name != "" {
+				return name
+			}
+		}
+	}
+	return "task-ui"
 }
 
 // titlePaneID is the pane whose border title names the task on screen: the one

--- a/internal/ui/detail_remote_pane_id_test.go
+++ b/internal/ui/detail_remote_pane_id_test.go
@@ -1,0 +1,88 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+	"github.com/bborn/workflow/internal/executor"
+)
+
+// recordingTmux installs a tmux that appends every invocation to a log and
+// answers queries with values belonging to a DIFFERENT ty instance, which is
+// what tmux returns when another client is the "current" one.
+func recordingTmux(t *testing.T) (logPath string) {
+	t.Helper()
+	root := t.TempDir()
+	logPath = filepath.Join(root, "calls.log")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> '" + logPath + "'\n" +
+		"case \"$*\" in\n" +
+		"  *'#{pane_id}'*) echo '%999';; \n" + // the OTHER instance's pane
+		"  *'#{session_name}'*) echo 'task-ui-OTHER';; \n" +
+		"  *list-panes*) echo '%999'; echo '%888';; \n" +
+		"  *split-window*) echo '%777';; \n" +
+		"esac\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(root, "tmux"), []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", root+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+// The pane this process draws into is $TMUX_PANE, by definition. Asking tmux for
+// the "current" pane returns whichever client tmux considers active — with a
+// second ty running, that is the other instance's pane. attachRemotePane then
+// kills "leftover" panes around it and splits into it, so a racy answer here
+// destroys another instance's panes. detail.go already documents this rule for
+// updateTmuxPaneTitle; the remote path must follow it too.
+func TestAttachRemotePaneUsesOwnPaneNotTmuxCurrent(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/fake,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+	app, _ := refreshTestModel(t)
+	calls := recordingTmux(t)
+
+	m := &DetailModel{database: app.db, task: &db.Task{ID: 5350, PlacementTarget: "ol-agents"}, shellPaneHidden: true}
+	m.attachRemotePane(executor.RemoteTaskLocation{Host: "ol-agents"})
+
+	if m.tuiPaneID == "%999" {
+		t.Fatal("adopted another instance's pane as its own TUI pane")
+	}
+	if m.tuiPaneID != "%42" {
+		t.Fatalf("tuiPaneID = %q, want $TMUX_PANE (%%42)", m.tuiPaneID)
+	}
+
+	data, err := os.ReadFile(calls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, "#{pane_id}") && !strings.Contains(line, "-t ") {
+			t.Fatalf("unscoped pane-id query still issued: %q", line)
+		}
+		if strings.Contains(line, "#{session_name}") && !strings.Contains(line, "-t ") {
+			t.Fatalf("unscoped session query still issued: %q", line)
+		}
+	}
+}
+
+// Killing "leftover" panes must never target a pane outside this instance's own
+// session, or one ty wipes out another's executor panes.
+func TestAttachRemotePaneNeverKillsOwnTuiPane(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/fake,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+	app, _ := refreshTestModel(t)
+	calls := recordingTmux(t)
+
+	m := &DetailModel{database: app.db, task: &db.Task{ID: 5350, PlacementTarget: "ol-agents"}, shellPaneHidden: true}
+	m.attachRemotePane(executor.RemoteTaskLocation{Host: "ol-agents"})
+
+	data, _ := os.ReadFile(calls)
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, "kill-pane") && strings.Contains(line, "%42") {
+			t.Fatalf("killed its own TUI pane: %q", line)
+		}
+	}
+}

--- a/internal/ui/detail_remote_shell_test.go
+++ b/internal/ui/detail_remote_shell_test.go
@@ -31,6 +31,7 @@ esac
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("TMUX", "test")
+	t.Setenv("TMUX_PANE", "%0")
 	m := &DetailModel{database: app.db, task: &db.Task{ID: 42, DaemonSession: "task-daemon-7", PlacementTarget: "remote"}, shellPaneHidden: true, focusExecutorOnJoin: true}
 	if id := m.attachRemotePane(executor.RemoteTaskLocation{Host: "remote"}); id != "%90" {
 		t.Fatalf("attach returned %q", id)


### PR DESCRIPTION
## The bug

Pressing Enter on a task **placed on a remote host** lands you in a different task's detail view. Reported as critical: Enter on #5350 opened #5280.

From `ui.log` at the moment it happened:

```
10:10:12.175  NewDetailModel: task 5350                              ← the Enter, correct task
10:10:12.217  setupPanesAsync: 5350 is placed on ol-agents; attaching
10:10:12.343  attachRemotePane: attached 5350 in pane %33138
10:10:12.423  killPaneWithProcess: killing process 11004 in pane %33138
10:10:12.468  NewDetailModel: task 5280  focusExecutor=true           ← lands on another task
```

Same shape earlier the same day for #5151 → #5266, also placed tasks. The board selection was never wrong; the remote attach is.

## Root cause

`attachRemotePane` asked tmux for `#{pane_id}` **with no target**. Unscoped, that returns the active pane of whichever client tmux currently considers foremost — with a second ty attached to the same server, that is *another instance's* pane.

The answer isn't merely recorded. The function then:

1. kills every other pane in that session as "left behind by the previously viewed task" (`detail.go:1084`), and
2. splits the SSH pane into it.

So a wrong answer destroys another instance's executor panes and attaches inside its session.

**This codebase already learned this lesson** — `detail.go:1751`, for `updateTmuxPaneTitle`:

> `$TMUX_PANE` is the pane this process is running in, by definition … it cannot name somebody else's pane the way asking tmux for the "current" one can.

The remote path never got the same treatment. Two unscoped `#{session_name}` lookups had the same flaw.

## The fix

- take the pane from `$TMUX_PANE` (`ownPaneID`)
- scope both session lookups to it (`ownSessionName`)
- when `$TMUX_PANE` is absent, **refuse rather than guess** — declining to attach is recoverable; killing another instance's panes is not

## Tests

The tmux stub answers unscoped queries with a *different* instance's ids, which is exactly what a second attached client produces. Without the fix the model adopts `%999` as its own pane:

```
adopted another instance's pane as its own TUI pane
```

Tests also assert no unscoped `#{pane_id}` / `#{session_name}` query is issued at all, and that the instance never kills its own TUI pane.

One pre-existing test was updated to set `TMUX_PANE` — it had been relying on the racy read. tmux always sets that variable for processes it starts.

`go test ./internal/ui/` passes.

## Caveat

This is a proven correctness bug on the exact code path the reported failure runs through, and the precondition (two ty TUIs on one tmux server) matches the reporter's setup. I have **not** proven it is the whole story for the `focusExecutor=true` navigation that follows the kill — that trigger is still unidentified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWUetsantf6kBSQEaSDS7c