### PR TITLE
fix(tui): never ask tmux which pane is "current"

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -4350,9 +4350,13 @@ func runLocal(dangerousMode bool, debugStatePath, cpuProfilePath, memProfilePath
 	if os.Getenv("TMUX") != "" {
 		sessionName := getUISessionName()
 		// Check if we're in this instance's session
-		tmuxCmd := osexec.Command("tmux", "display-message", "-p", "#{session_name}")
+		// Scope the question to this process's own pane. Unscoped, tmux answers
+		// for the foremost client, which with a second ty attached is a different
+		// session — and the answer decides whether we kill a session.
+		pane := os.Getenv("TMUX_PANE")
+		tmuxCmd := osexec.Command("tmux", "display-message", "-t", pane, "-p", "#{session_name}")
 		out, err := tmuxCmd.Output()
-		if err == nil && strings.TrimSpace(string(out)) == sessionName {
+		if pane != "" && err == nil && strings.TrimSpace(string(out)) == sessionName {
 			osexec.Command("tmux", "kill-session", "-t", sessionName).Run()
 		}
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -720,9 +720,13 @@ func (m *AppModel) Init() tea.Cmd {
 
 	// Enable mouse support for click-to-focus on tmux panes
 	if os.Getenv("TMUX") != "" {
-		// Get actual session name to avoid prefix-matching wrong session
-		if out, err := osExec.Command("tmux", "display-message", "-p", "#{session_name}").Output(); err == nil {
-			sessionName := strings.TrimSpace(string(out))
+		// Get actual session name to avoid prefix-matching wrong session, scoped
+		// to this process's own pane so a second ty cannot have mouse mode set
+		// on its session by this one (see ownSessionName).
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		sessionName := ownSessionName(ctx)
+		cancel()
+		if sessionName != "" {
 			osExec.Command("tmux", "set-option", "-t", sessionName, "mouse", "on").Run()
 		}
 	}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -921,7 +921,7 @@ func (m *DetailModel) setupPanesAsync() tea.Cmd {
 		// Resolve the actual UI session name (avoid prefix-matching the wrong
 		// session, and avoid naming another instance's — see ownSessionName).
 		sessionCtx, cancelSession := context.WithTimeout(context.Background(), 5*time.Second)
-		m.uiSessionName = m.ownSessionName(sessionCtx)
+		m.uiSessionName = ownSessionName(sessionCtx)
 		cancelSession()
 
 		// Find the task's existing window (one tmux call).
@@ -1060,7 +1060,7 @@ func (m *DetailModel) attachRemotePane(loc executor.RemoteTaskLocation) string {
 	defer cancel()
 
 	if m.uiSessionName == "" {
-		m.uiSessionName = m.ownSessionName(ctx)
+		m.uiSessionName = ownSessionName(ctx)
 	}
 
 	tuiPaneID := ownPaneID()
@@ -1773,7 +1773,7 @@ func ownPaneID() string {
 // ownSessionName resolves the session holding this process's own pane. Scoped to
 // ownPaneID for the same reason: an unscoped query names the foremost client's
 // session, which is how one instance ends up operating inside another's.
-func (m *DetailModel) ownSessionName(ctx context.Context) string {
+func ownSessionName(ctx context.Context) string {
 	if pane := ownPaneID(); pane != "" {
 		if out, err := osExec.CommandContext(ctx, "tmux", "display-message",
 			"-t", pane, "-p", "#{session_name}").Output(); err == nil {
@@ -1904,7 +1904,8 @@ func (m *DetailModel) getCurrentDetailPaneHeight(tuiPaneID string) int {
 	}
 
 	// Get the total window height
-	cmd = osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{window_height}")
+	cmd = osExec.CommandContext(ctx, "tmux", "display-message",
+		"-t", m.titlePaneID(), "-p", "#{window_height}")
 	totalHeightOut, err := cmd.Output()
 	if err != nil {
 		return 0
@@ -2181,14 +2182,14 @@ func (m *DetailModel) joinTmuxPanes() {
 	}
 	log.Debug("joinTmuxPanes: daemonSessionID=%q", m.daemonSessionID)
 
-	// Get current pane ID before joining (so we can select it after)
-	currentPaneCmd := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}")
-	currentPaneOut, err := currentPaneCmd.Output()
-	if err != nil {
-		log.Error("joinTmuxPanes: failed to get current pane ID: %v", err)
+	// The pane to come back to after joining is this process's own — see
+	// ownPaneID. Asking tmux for "the current" one names the foremost client's
+	// pane, and the cleanup below kills everything around whatever we name here.
+	tuiPaneID := ownPaneID()
+	if tuiPaneID == "" {
+		log.Error("joinTmuxPanes: no $TMUX_PANE; refusing to guess this instance's pane")
 		return
 	}
-	tuiPaneID := strings.TrimSpace(string(currentPaneOut))
 	m.tuiPaneID = tuiPaneID
 	log.Debug("joinTmuxPanes: tuiPaneID=%q", tuiPaneID)
 
@@ -2383,19 +2384,19 @@ func (m *DetailModel) joinTmuxPanes() {
 				userShell = "/bin/zsh"
 			}
 			log.Debug("joinTmuxPanes: split-window for shell, workdir=%q, shell=%q", workdir, userShell)
-			err = osExec.CommandContext(ctx, "tmux", "split-window",
+			shellPaneOut, err := osExec.CommandContext(ctx, "tmux", "split-window",
 				"-h", "-l", shellWidth,
+				"-P", "-F", "#{pane_id}",
 				"-t", m.claudePaneID,
 				"-c", workdir,
-				userShell).Run() // user's shell to prevent immediate exit
+				userShell).Output() // user's shell to prevent immediate exit
 			if err != nil {
 				log.Error("joinTmuxPanes: split-window for shell failed: %v", err)
 				m.workdirPaneID = ""
 			} else {
-				// Get the new shell pane ID
-				workdirPaneCmd := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}")
-				workdirPaneOut, _ := workdirPaneCmd.Output()
-				m.workdirPaneID = strings.TrimSpace(string(workdirPaneOut))
+				// split-window -P -F prints the pane it just made. Asking which
+				// pane is active afterwards names the foremost client's instead.
+				m.workdirPaneID = strings.TrimSpace(string(shellPaneOut))
 				log.Debug("joinTmuxPanes: created shell pane, workdirPaneID=%q", m.workdirPaneID)
 				osExec.CommandContext(ctx, "tmux", "select-pane", "-t", m.workdirPaneID, "-T", "Shell").Run()
 				// Set environment variables in the newly created shell pane
@@ -2620,20 +2621,21 @@ func (m *DetailModel) showShellPane(ctx context.Context) {
 		if userShell == "" {
 			userShell = "/bin/zsh"
 		}
-		err := osExec.CommandContext(ctx, "tmux", "split-window",
+		shellSplitOut, err := osExec.CommandContext(ctx, "tmux", "split-window",
 			"-h", "-l", shellWidth,
+			"-P", "-F", "#{pane_id}",
 			"-t", m.claudePaneID,
 			"-c", workdir,
 			userShell,
-		).Run()
+		).Output()
 		if err != nil {
 			log.Error("showShellPane: split-window failed: %v", err)
 			return
 		}
-		// Get the new shell pane ID
-		workdirPaneCmd := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}")
-		if workdirPaneOut, err := workdirPaneCmd.Output(); err == nil {
-			m.workdirPaneID = strings.TrimSpace(string(workdirPaneOut))
+		// The pane id comes from the split that made it (-P -F above), never from
+		// asking which pane is active — that names the foremost client's.
+		if newPane := strings.TrimSpace(string(shellSplitOut)); newPane != "" {
+			m.workdirPaneID = newPane
 			osExec.CommandContext(ctx, "tmux", "select-pane", "-t", m.workdirPaneID, "-T", "Shell").Run()
 		}
 	}
@@ -3113,9 +3115,13 @@ func (m *DetailModel) focusStateCmd() tea.Cmd {
 		if inTmux && paneID != "" {
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()
-			out, err := osExec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pane_id}").Output()
+			// Ask about this pane specifically. An unscoped read returns the
+			// foremost client's active pane, so a second ty attached to the same
+			// server made this instance believe it had lost focus.
+			out, err := osExec.CommandContext(ctx, "tmux", "display-message",
+				"-t", paneID, "-p", "#{pane_active}").Output()
 			if err == nil {
-				focused = strings.TrimSpace(string(out)) == paneID
+				focused = strings.TrimSpace(string(out)) == "1"
 			}
 		}
 		return focusStateMsg{detail: m, focused: focused}

--- a/internal/ui/detail_remote_pane_id_test.go
+++ b/internal/ui/detail_remote_pane_id_test.go
@@ -20,10 +20,10 @@ func recordingTmux(t *testing.T) (logPath string) {
 	script := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$*\" >> '" + logPath + "'\n" +
 		"case \"$*\" in\n" +
+		"  *split-window*) echo '%777';; \n" + // a split reports its own new pane
+		"  *list-panes*) echo '%999'; echo '%888';; \n" +
 		"  *'#{pane_id}'*) echo '%999';; \n" + // the OTHER instance's pane
 		"  *'#{session_name}'*) echo 'task-ui-OTHER';; \n" +
-		"  *list-panes*) echo '%999'; echo '%888';; \n" +
-		"  *split-window*) echo '%777';; \n" +
 		"esac\nexit 0\n"
 	if err := os.WriteFile(filepath.Join(root, "tmux"), []byte(script), 0700); err != nil {
 		t.Fatal(err)

--- a/internal/ui/tmux_own_pane_test.go
+++ b/internal/ui/tmux_own_pane_test.go
@@ -1,0 +1,90 @@
+package ui
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// assertNoUnscopedQueries fails when tmux was asked about "the current" pane,
+// session or window without naming a target. Unscoped, tmux answers for the
+// foremost client — another ty instance when more than one is attached.
+func assertNoUnscopedQueries(t *testing.T, logPath string) {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return // no tmux calls recorded
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.Contains(line, "display-message") {
+			continue
+		}
+		if !strings.Contains(line, "#{pane_id}") &&
+			!strings.Contains(line, "#{session_name}") &&
+			!strings.Contains(line, "#{window_height}") {
+			continue
+		}
+		if !strings.Contains(line, "-t ") {
+			t.Fatalf("unscoped tmux query: %q", line)
+		}
+	}
+}
+
+// joinTmuxPanes takes the answer as its own TUI pane and then kills every other
+// pane around it. Adopting another instance's pane there destroys that
+// instance's executor panes — the same defect fixed for the remote path.
+func TestJoinTmuxPanesUsesOwnPane(t *testing.T) {
+	app, _ := refreshTestModel(t)
+	t.Setenv("TMUX", "/tmp/fake,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+	calls := recordingTmux(t)
+
+	m := &DetailModel{database: app.db, task: &db.Task{ID: 900, WorktreePath: t.TempDir()}, shellPaneHidden: true}
+	m.cachedWindowTarget = "task-daemon-1:@5"
+	m.joinTmuxPanes()
+
+	if m.tuiPaneID == "%999" {
+		t.Fatal("joinTmuxPanes adopted another instance's pane")
+	}
+	if m.tuiPaneID != "%42" {
+		t.Fatalf("tuiPaneID = %q, want %%42 from $TMUX_PANE", m.tuiPaneID)
+	}
+	assertNoUnscopedQueries(t, calls)
+}
+
+// A pane created by split-window must be identified by split-window's own
+// output, not by asking which pane is active afterwards.
+func TestShellPaneIdComesFromSplitNotActivePane(t *testing.T) {
+	app, _ := refreshTestModel(t)
+	t.Setenv("TMUX", "/tmp/fake,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+	calls := recordingTmux(t)
+
+	m := &DetailModel{database: app.db, task: &db.Task{ID: 901, WorktreePath: t.TempDir()}, tuiPaneID: "%42", claudePaneID: "%50"}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	m.showShellPane(ctx)
+
+	if m.workdirPaneID == "%999" {
+		t.Fatal("adopted the globally-active pane as the new shell pane")
+	}
+	assertNoUnscopedQueries(t, calls)
+}
+
+// Focus means "is my own pane the active one", which must be asked about this
+// pane specifically, not about whichever client tmux considers foremost.
+func TestFocusStateAsksAboutOwnPane(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/fake,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+	calls := recordingTmux(t)
+
+	m := &DetailModel{tuiPaneID: "%42"}
+	if cmd := m.focusStateCmd(); cmd != nil {
+		cmd()
+	}
+	assertNoUnscopedQueries(t, calls)
+}


### PR DESCRIPTION
Follow-up to #717, which fixed one call site. This is the audit of **every** other place with the same shape, so running multiple TUIs is actually safe rather than merely less broken.

## Why it matters

Asking tmux for `#{pane_id}` with no target answers for the **foremost client**. With two ty TUIs attached to one server, that is another instance's pane.

## The one that mattered most

`joinTmuxPanes` — the **local** twin of the remote bug, and it runs for every task *not* placed on a remote host. It took the unscoped answer as its own TUI pane and then killed "any leftover panes from previous tasks (except the TUI pane)" around it. Naming another instance's pane meant destroying that instance's executor panes.

## Every site

| Site | Was | Now |
|---|---|---|
| `detail.go` `joinTmuxPanes` | unscoped `#{pane_id}` → own pane → kills panes around it | `$TMUX_PANE`; refuses if unset |
| `detail.go` shell splits (×2) | active pane after `split-window` | `split-window -P -F '#{pane_id}'` reports its own new pane |
| `detail.go` `focusStateCmd` | compares against globally-active pane | asks `#{pane_active}` about our pane |
| `detail.go` pane height | unscoped `#{window_height}` | scoped to our pane |
| `app.go` mouse setup | unscoped session → `set-option mouse on` | `ownSessionName` |
| `cmd/task/main.go` exit | unscoped session → decides `kill-session` | scoped to `$TMUX_PANE` |

`ownSessionName` is now package-level so `app.go` shares it.

There are **no unscoped `#{pane_id}` / `#{session_name}` / `#{window_height}` queries left** outside tests.

Two of these are behaviour bugs you'd feel without any pane destruction: `focusStateCmd` made a TUI believe it had lost focus (wrong dimming) whenever another client was foremost, and the shell splits could adopt the wrong pane as the shell.

## Tests

The stub tmux answers unscoped queries with a *different* instance's ids, and the tests assert both the resulting state and that no unscoped query is issued at all. Reverting either the `joinTmuxPanes` or the focus fix fails them:

```
joinTmuxPanes adopted another instance's pane
unscoped tmux query: "display-message -p #{pane_id}"
```

`go test ./internal/ui/ ./cmd/task/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWUetsantf6kBSQEaSDS7c