### PR TITLE
fix(tui): escape the tmux command separator in bindPaneNavigation

### DIFF
--- a/internal/ui/bind_pane_navigation_test.go
+++ b/internal/ui/bind_pane_navigation_test.go
@@ -1,0 +1,49 @@
+package ui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// bindPaneNavigation runs on every pane setup. Its bind-key body chains two tmux
+// commands, and the separator has to survive tmux's own argv parsing: a bare ";"
+// ends the tmux command line, so tmux binds only the first half and executes the
+// second immediately. That typed C-Up / C-Down into pane 0 — the TUI — every time
+// a task was opened, and the detail view reads those as prev/next task, so
+// opening a task navigated to a different one.
+func TestBindPaneNavigationEscapesCommandSeparator(t *testing.T) {
+	dir := t.TempDir()
+	log := filepath.Join(dir, "calls")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '" + log + "'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m := &DetailModel{}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	m.bindPaneNavigation(ctx)
+
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var forwarding int
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.Contains(line, "bind-key") || !strings.Contains(line, "send-keys") {
+			continue
+		}
+		forwarding++
+		if !strings.Contains(line, `\;`) {
+			t.Fatalf("bind-key chains commands with an unescaped separator; tmux will run the send-keys at bind time instead of binding it: %q", line)
+		}
+	}
+	if forwarding != 2 {
+		t.Fatalf("expected the two key-forwarding bindings, saw %d", forwarding)
+	}
+}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -2495,6 +2495,12 @@ func (m *DetailModel) focusExecutorPane() {
 	}
 }
 
+// tmuxCmdSep separates two commands inside a single tmux command argument (e.g.
+// the body of a bind-key). It is the two characters backslash-semicolon: tmux
+// strips the backslash and treats the ";" as part of the command being defined.
+// A bare ";" would instead terminate the tmux command line itself.
+const tmuxCmdSep = `\;`
+
 // bindPaneNavigation installs the same navigation for local and SSH panes.
 func (m *DetailModel) bindPaneNavigation(ctx context.Context) {
 	// Bind Shift+Arrow keys to cycle through panes from any pane
@@ -2506,10 +2512,18 @@ func (m *DetailModel) bindPaneNavigation(ctx context.Context) {
 
 	// Forward an internal navigation key to the TUI. The task loader focuses
 	// the executor after pane setup completes, including slow SSH attachments.
+	//
+	// The separator MUST be the escaped tmuxCmdSep. A bare ";" is eaten by tmux's
+	// own argv parser as a top-level command separator, so this reads as TWO
+	// commands: it binds only the select-pane half and RUNS the send-keys
+	// immediately. bindPaneNavigation runs on every pane setup, so that typed
+	// C-Up and C-Down into pane 0 - the TUI - every time a task was opened, and
+	// the detail view acts on those as prev/next task. Opening a task therefore
+	// navigated straight to a different one.
 	osExec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "M-S-Up",
-		"select-pane", "-t", ":.0", ";", "send-keys", "-t", ":.0", "C-Up").Run()
+		"select-pane", "-t", ":.0", tmuxCmdSep, "send-keys", "-t", ":.0", "C-Up").Run()
 	osExec.CommandContext(ctx, "tmux", "bind-key", "-T", "root", "M-S-Down",
-		"select-pane", "-t", ":.0", ";", "send-keys", "-t", ":.0", "C-Down").Run()
+		"select-pane", "-t", ":.0", tmuxCmdSep, "send-keys", "-t", ":.0", "C-Down").Run()
 
 }
 


### PR DESCRIPTION
**This is the actual cause of "I press Enter on a task and get a different task's detail."** Not the palette, not pane cross-wiring — those were real bugs, but not this one.

## The bug

`bindPaneNavigation` binds Option+Shift+Up/Down to "focus the TUI, then forward C-Up/C-Down to it":

```
tmux bind-key -T root M-S-Up select-pane -t :.0 ";" send-keys -t :.0 C-Up
```

That `";"` is a **bare argument**, and tmux's own argv parser treats a bare `;` as a **top-level command separator**. So tmux read it as *two* commands:

1. `bind-key -T root M-S-Up select-pane -t :.0`
2. `send-keys -t :.0 C-Up` ← **executed immediately, at bind time**

`bindPaneNavigation` runs during **every** pane setup, local and remote. So every time a task was opened, tmux typed `C-Up` and `C-Down` into pane 0 — the TUI — and the detail view acts on those as prev/next task.

## Verified against a real tmux

Bare `;` — the text lands in the pane the moment `bind-key` runs, and only half the chain is bound:

```
$ tmux bind-key -T root M-S-Up select-pane -t p.0 ";" send-keys -t p.0 'HELLO-FROM-BIND' Enter
$ tmux capture-pane -p -t p.0
HELLO-FROM-BIND
GOT:HELLO-FROM-BIND          ← fired at bind time
$ tmux list-keys -T root | grep M-S-Up
bind-key -T root M-S-Up   select-pane -t p.0        ← send-keys missing
```

Escaped `\;` — nothing sent, whole chain stored:

```
$ tmux capture-pane -p -t p.0
[empty]
$ tmux list-keys -T root | grep M-S-Up
bind-key -T root M-S-Up   select-pane -t p.0 \; send-keys -t p.0 SHOULD-NOT-FIRE Enter
```

## Matching evidence from the field

```
13:20:07.192  NewDetailModel: task 5350        ← the Enter, correct task
13:20:07.336  attachRemotePane: attached %33156
13:20:07.404  killPaneWithProcess: %33156      ← cleanup for the navigation
13:20:07.434  NewDetailModel: task 4435  focusExecutor=true
```

`focusExecutor=true` is the signature of the ctrl+up/ctrl+down handler, and a stack trace from temporary instrumentation confirmed the caller was `updateDetail`'s navigation branch — not anything on the open path.

## Two bugs, one fix

- the spurious navigation stops
- **Option+Shift+Up/Down now actually works** — it never did, since only the `select-pane` half was ever bound

The separator is now a named constant (`tmuxCmdSep`) so the next chained `bind-key` can't repeat this.

## Test

Asserts every `bind-key` that chains a `send-keys` uses the escaped separator. Reverting the fix fails it:

```
bind-key chains commands with an unescaped separator; tmux will run the send-keys
at bind time instead of binding it:
"bind-key -T root M-S-Up select-pane -t :.0 ; send-keys -t :.0 C-Up"
```

`go test ./internal/ui/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWUetsantf6kBSQEaSDS7c