### PR TITLE
fix(tui): truncate titles by display width, not bytes

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -17,6 +17,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/fsnotify/fsnotify"
 	"github.com/muesli/termenv"
 
@@ -4394,7 +4395,7 @@ func actionResultSummary(output string) string {
 			continue
 		}
 		if len(line) > 80 {
-			return line[:79] + "…"
+			return ansi.Truncate(line, 80, "…")
 		}
 		return line
 	}
@@ -4742,7 +4743,7 @@ func (m *AppModel) createTaskWithAttachments(t *db.Task, attachmentPaths []strin
 				// Use first line of body, truncated
 				firstLine := strings.Split(strings.TrimSpace(t.Body), "\n")[0]
 				if len(firstLine) > 50 {
-					firstLine = firstLine[:50] + "..."
+					firstLine = ansi.Truncate(firstLine, 53, "...")
 				}
 				t.Title = firstLine
 			}

--- a/internal/ui/command_palette.go
+++ b/internal/ui/command_palette.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/bborn/workflow/internal/db"
 )
@@ -955,7 +956,7 @@ func (m *CommandPaletteModel) renderTaskItem(task *db.Task, isSelected bool, wid
 		maxTitleLen = 10
 	}
 	if len(title) > maxTitleLen {
-		title = title[:maxTitleLen-1] + "..."
+		title = ansi.Truncate(title, maxTitleLen, "...")
 	}
 
 	titleStyle := lipgloss.NewStyle()

--- a/internal/ui/kanban.go
+++ b/internal/ui/kanban.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/github"
@@ -1362,9 +1363,17 @@ func (k *KanbanBoard) renderTaskCard(task *db.Task, width int, isSelected bool) 
 	if maxTitleLen < 10 {
 		maxTitleLen = 10
 	}
-	if len(title) > maxTitleLen {
-		title = title[:maxTitleLen-1] + "…"
-	}
+	// ansi.Truncate measures display columns and never cuts inside a rune. The
+	// old form sliced by BYTES: a title carrying any multi-byte character (a "·"
+	// in a digest title, an accent, an emoji) could be cut mid-rune, leaving a
+	// dangling byte. The terminal and lipgloss then disagreed about the line's
+	// width, so the card's background and border stopped short of the column.
+	// ansi.Truncate measures display columns and never cuts inside a rune. The
+	// old form sliced by BYTES: a title carrying any multi-byte character (a "·"
+	// in a digest title, an accent, an emoji) could be cut mid-rune, leaving a
+	// dangling byte. The terminal and lipgloss then disagreed about the line's
+	// width, so the card's background and border stopped short of the column.
+	title = ansi.Truncate(title, maxTitleLen, "…")
 
 	leftLine := b.String()
 	indicatorText := strings.Join(indicators, " ")

--- a/internal/ui/retry.go
+++ b/internal/ui/retry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/bborn/workflow/internal/db"
 )
@@ -105,7 +106,7 @@ func (m *RetryModel) View() string {
 
 	title := m.task.Title
 	if len(title) > 60 {
-		title = title[:57] + "..."
+		title = ansi.Truncate(title, 60, "...")
 	}
 	subtitle := Dim.Render(title)
 

--- a/internal/ui/task_ref_autocomplete.go
+++ b/internal/ui/task_ref_autocomplete.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/bborn/workflow/internal/db"
 )
@@ -290,7 +291,7 @@ func (m *TaskRefAutocompleteModel) renderTaskItem(task *db.Task, isSelected bool
 	title := task.Title
 	maxTitleLen := 40
 	if len(title) > maxTitleLen {
-		title = title[:maxTitleLen-3] + "..."
+		title = ansi.Truncate(title, maxTitleLen, "...")
 	}
 
 	titleStyle := lipgloss.NewStyle()

--- a/internal/ui/truncate_runes_test.go
+++ b/internal/ui/truncate_runes_test.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// A real board title. The "·" (U+00B7) is two bytes, so a byte-indexed cut can
+// land inside it and emit a lone 0xC2. The terminal and lipgloss then disagree
+// about how wide the line is, and the card's background and border stop short of
+// the column edge.
+const middleDotTitle = "@devdoc83 Claude Code npx allow-list bug · @paolino RubyLLM 2.0 ships +1 more"
+
+func TestTaskCardTitleNeverSplitsARune(t *testing.T) {
+	k := NewKanbanBoard(200, 50)
+	card := k.renderTaskCard(&db.Task{ID: 5352, Title: middleDotTitle, Status: db.StatusBacklog, Project: "personal"}, 47, false)
+
+	if !utf8.ValidString(card) {
+		t.Fatal("rendered card holds invalid UTF-8: a multi-byte rune was cut in half")
+	}
+	if strings.ContainsRune(card, utf8.RuneError) {
+		t.Fatal("rendered card holds U+FFFD from a half-written rune")
+	}
+}
+
+// Every line of a card must occupy the same number of columns, or the column
+// border drawn around it lands in the wrong place.
+func TestTaskCardLinesShareOneWidth(t *testing.T) {
+	k := NewKanbanBoard(200, 50)
+	for _, title := range []string{
+		middleDotTitle,
+		"Plain ASCII title long enough that it certainly needs truncating",
+		"Ünïcödé áccents throughout the title, long enough to be truncated here",
+		"emoji 🚀 in a title that also runs long enough to require truncation now",
+	} {
+		card := k.renderTaskCard(&db.Task{ID: 1, Title: title, Status: db.StatusBacklog, Project: "personal"}, 47, false)
+		widths := map[int]bool{}
+		for _, line := range strings.Split(card, "\n") {
+			widths[lipgloss.Width(line)] = true
+		}
+		if len(widths) > 1 {
+			t.Fatalf("card lines have differing widths %v for title %q", widths, title)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

A backlog card rendered with its background and border stopping short of the column edge — a notch mid-card:

```
│ · #5352 [personal]                            │
│ @devdoc83 Claude Code npx allow-list bug    │      ← 2 columns short, no ellipsis
│ created 4m                                    │
```

## Root cause

`kanban.go` cut the title with a **byte** slice:

```go
if len(title) > maxTitleLen {
    title = title[:maxTitleLen-1] + "…"
}
```

`len()` counts bytes and `title[:n]` slices bytes, so any multi-byte character can be cut in half. The title was:

```
@devdoc83 Claude Code npx allow-list bug · @paolino RubyLLM 2.0 ships +1 more
```

whose `·` (U+00B7) occupies bytes 41–42. The cut landed *between* them, leaving a dangling `0xC2`. The terminal and lipgloss then disagreed about the line's width — lipgloss padded to a width the terminal didn't render — which is exactly the notch.

Pre-existing since `6357d7a9` (2026-01-08); it only surfaced now because this is the first title with a `·` in it.

## Fix

Use `ansi.Truncate`, which measures display columns and never cuts inside a rune. It's already the helper used for the detail view's meta line (`detail.go:3532`).

Rendered result:

```
│ @devdoc83 Claude Code npx allow-list bug ·…   │
```

## Same bug, five more places

Fixed in the same pass: command palette, task-ref autocomplete, retry view, and two sites in `app.go`. **`internal/ui` now has no byte-sliced truncation left** (verified by grep).

## Test

Renders the real title and asserts the card is valid UTF-8, carries no U+FFFD, and that every line of a card is the same number of columns wide — checked for ASCII, accents, a middle dot and an emoji.

Against the old code:

```
--- FAIL: TestTaskCardTitleNeverSplitsARune
    invalid UTF-8: a multi-byte rune was cut in half
```

`go test ./internal/ui/` passes.

## Not in scope

15 more byte-sliced truncations exist outside `internal/ui` (`cmd/task`, `internal/web`, `internal/mcp`, `internal/tasksummary`). Same latent bug, but they affect CLI output, HTML and model input rather than TUI layout — worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWUetsantf6kBSQEaSDS7c