### PR TITLE
fix: rune-safe truncation everywhere, unblock reloads, fix ui.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .claude/*
 !.claude/settings.json
 .crush/
+.codex/
 
 # Archives
 *.tar.gz

--- a/cmd/task/completion.go
+++ b/cmd/task/completion.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/bborn/workflow/internal/textutil"
+
 	"github.com/spf13/cobra"
 
 	"github.com/bborn/workflow/internal/db"
@@ -181,7 +183,7 @@ func fetchTaskCompletions(toComplete string) ([]string, cobra.ShellCompDirective
 	for _, t := range tasks {
 		desc := t.Title
 		if len(desc) > 40 {
-			desc = desc[:37] + "..."
+			desc = textutil.Truncate(desc, 40, "...")
 		}
 		completions = append(completions, fmt.Sprintf("%d\t[%s] %s", t.ID, t.Status, desc))
 	}

--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -19,6 +19,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bborn/workflow/internal/textutil"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
@@ -825,7 +827,7 @@ Examples:
 				if strings.TrimSpace(title) == "" {
 					firstLine := strings.Split(strings.TrimSpace(body), "\n")[0]
 					if len(firstLine) > 50 {
-						firstLine = firstLine[:50] + "..."
+						firstLine = textutil.Truncate(firstLine, 53, "...")
 					}
 					title = firstLine
 				}
@@ -3499,7 +3501,7 @@ Examples:
 				// Show truncated instructions
 				instr := t.Instructions
 				if len(instr) > 80 {
-					instr = instr[:77] + "..."
+					instr = textutil.Truncate(instr, 80, "...")
 				}
 				instr = strings.ReplaceAll(instr, "\n", " ")
 				fmt.Printf("    Instructions: %s\n", dimStyle.Render(instr))
@@ -5320,7 +5322,7 @@ func formatToolLogMessage(input *ClaudeHookInput) string {
 				if cmd, ok := toolInput["command"].(string); ok {
 					// Truncate long commands
 					if len(cmd) > 100 {
-						cmd = cmd[:100] + "..."
+						cmd = textutil.Truncate(cmd, 103, "...")
 					}
 					return fmt.Sprintf("Bash: %s", cmd)
 				}
@@ -5433,7 +5435,7 @@ func formatPermissionDetail(input *ClaudeHookInput) string {
 
 	// Truncate to keep the approval bar compact
 	if len(detail) > 200 {
-		detail = detail[:200] + "..."
+		detail = textutil.Truncate(detail, 203, "...")
 	}
 
 	return detail
@@ -5661,7 +5663,7 @@ func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen-3] + "..."
+	return textutil.Truncate(s, maxLen, "...")
 }
 
 // execCommandRunner implements web.CommandRunner using os/exec.
@@ -5700,7 +5702,7 @@ func listSessions() {
 			// Truncate title to 40 chars
 			title := s.taskTitle
 			if len(title) > 40 {
-				title = title[:37] + "..."
+				title = textutil.Truncate(title, 40, "...")
 			}
 			titleStr = title
 		}
@@ -6070,7 +6072,7 @@ func suspendSessions(taskIDs []int, all bool) {
 
 		title := s.taskTitle
 		if len(title) > 40 {
-			title = title[:37] + "..."
+			title = textutil.Truncate(title, 40, "...")
 		}
 
 		memStr := ""

--- a/internal/hooks/placement.go
+++ b/internal/hooks/placement.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/bborn/workflow/internal/textutil"
 )
 
 // EventTaskPlacement is the one hook ty *consults* rather than merely notifies.
@@ -184,5 +186,5 @@ func truncateForLog(s string) string {
 	if len(s) <= max {
 		return s
 	}
-	return s[:max] + "…"
+	return textutil.Truncate(s, max+1, "…")
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/bborn/workflow/internal/textutil"
+
 	"github.com/bborn/workflow/internal/completion"
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/pipeline"
@@ -502,7 +504,7 @@ func (s *Server) handleToolCall(id interface{}, params *toolCallParams) {
 				ts := l.CreatedAt.Time.Format("15:04:05")
 				content := l.Content
 				if len(content) > 300 {
-					content = content[:300] + "..."
+					content = textutil.Truncate(content, 303, "...")
 				}
 				sb.WriteString(fmt.Sprintf("- `%s` [%s] %s\n", ts, l.LineType, content))
 			}

--- a/internal/tasksummary/tasksummary.go
+++ b/internal/tasksummary/tasksummary.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bborn/workflow/internal/textutil"
+
 	"github.com/bborn/workflow/internal/db"
 )
 
@@ -194,7 +196,7 @@ func buildSummaryPrompt(task *db.Task, logs []*db.TaskLog) string {
 	sb.WriteString(fmt.Sprintf("Title: %s\n", task.Title))
 	if body := strings.TrimSpace(task.Body); body != "" {
 		if len(body) > 1200 {
-			body = body[:1200] + "..."
+			body = textutil.Truncate(body, 1203, "...")
 		}
 		sb.WriteString("Body:\n")
 		sb.WriteString(body)
@@ -236,7 +238,7 @@ func formatLogs(logs []*db.TaskLog) string {
 			continue
 		}
 		if len(content) > maxLineChars {
-			content = content[:maxLineChars] + "..."
+			content = textutil.Truncate(content, maxLineChars+3, "...")
 		}
 		line := fmt.Sprintf("[%s] %s: %s", log.CreatedAt.Format("15:04"), log.LineType, content)
 		if chars+len(line)+1 > maxLogChars {

--- a/internal/textutil/truncate.go
+++ b/internal/textutil/truncate.go
@@ -1,0 +1,32 @@
+// Package textutil holds small string helpers shared across ty.
+package textutil
+
+import "unicode/utf8"
+
+// Truncate shortens s to at most limit runes, appending tail when it does.
+//
+// It exists because the obvious form, s[:limit] + tail, slices BYTES. Any
+// multi-byte character straddling the cut is split in half, leaving a dangling
+// byte and invalid UTF-8 — which corrupts terminal layout (the renderer and the
+// terminal disagree on the width), HTML, and any text handed to a model. Titles
+// routinely carry a "·", an accent or an emoji, so this is not a rare case.
+//
+// limit counts runes, not columns: callers here are bounding text size, not
+// laying out a terminal. For width-sensitive rendering use ansi.Truncate, which
+// accounts for double-width characters.
+//
+// A limit at or below the length of tail returns the leading runes alone, so the
+// result never grows past the caller's budget.
+func Truncate(s string, limit int, tail string) string {
+	if limit <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= limit {
+		return s
+	}
+	keep := limit - utf8.RuneCountInString(tail)
+	if keep <= 0 {
+		return string([]rune(s)[:limit])
+	}
+	return string([]rune(s)[:keep]) + tail
+}

--- a/internal/textutil/truncate_test.go
+++ b/internal/textutil/truncate_test.go
@@ -1,0 +1,41 @@
+package textutil
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateNeverSplitsARune(t *testing.T) {
+	// The "·" is two bytes; a byte slice at 41 lands inside it.
+	s := "@devdoc83 Claude Code npx allow-list bug · @paolino RubyLLM 2.0 ships"
+	for limit := 1; limit <= utf8.RuneCountInString(s)+2; limit++ {
+		got := Truncate(s, limit, "...")
+		if !utf8.ValidString(got) {
+			t.Fatalf("limit %d produced invalid UTF-8: %q", limit, got)
+		}
+		if strings.ContainsRune(got, utf8.RuneError) {
+			t.Fatalf("limit %d produced U+FFFD: %q", limit, got)
+		}
+		if n := utf8.RuneCountInString(got); n > limit {
+			t.Fatalf("limit %d exceeded: %d runes in %q", limit, n, got)
+		}
+	}
+}
+
+func TestTruncateKeepsShortStrings(t *testing.T) {
+	for _, s := range []string{"", "short", "Ünïcödé", "🚀🚀🚀"} {
+		if got := Truncate(s, 20, "..."); got != s {
+			t.Fatalf("Truncate(%q) = %q, want unchanged", s, got)
+		}
+	}
+}
+
+func TestTruncateAppendsTailOnlyWhenCut(t *testing.T) {
+	if got := Truncate("abcdefghij", 5, "..."); got != "ab..." {
+		t.Fatalf("got %q, want %q", got, "ab...")
+	}
+	if got := Truncate("emoji 🚀 tail here", 8, "…"); !utf8.ValidString(got) || utf8.RuneCountInString(got) > 8 {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/ui/logger.go
+++ b/internal/ui/logger.go
@@ -6,14 +6,37 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/bborn/workflow/internal/db"
 )
 
-// UILogger provides file-based logging for the UI package.
-// Logs are written to ~/.local/share/task/ui.log
+// UILogger provides file-based logging for the UI package. The TUI draws on
+// stdout, so diagnostics cannot go there; they go to ui.log beside the database.
+//
+// Three properties this file depends on, each learned the hard way:
+//
+//   - It sits next to the database, so an isolated instance (a QA harness with
+//     its own WORKTREE_DB_PATH) writes to its own log. Sharing one file made a
+//     QA run's errors look like they came from the live TUI.
+//   - Every line carries the pid. Several ty processes append concurrently —
+//     TUIs, the daemon — and without it there is no way to tell who wrote what.
+//   - It rotates. Unrotated, this file reached 205MB and eight months of history.
 type UILogger struct {
-	mu   sync.Mutex
-	file *os.File
+	mu     sync.Mutex
+	file   *os.File
+	path   string
+	pid    int
+	writes int
 }
+
+// maxLogBytes is the size at which the log is rotated to ui.log.1. One previous
+// generation is kept: enough to span a restart, bounded on disk.
+const maxLogBytes = 16 << 20
+
+// logSyncEvery flushes to disk every N lines rather than on every one. A crash
+// can now lose a few trailing lines; in exchange the UI is not paying an fsync
+// per log statement, which at debug volume is thousands per task switch.
+const logSyncEvery = 64
 
 var uiLogger *UILogger
 var loggerOnce sync.Once
@@ -29,28 +52,24 @@ func GetLogger() *UILogger {
 }
 
 func (l *UILogger) init() {
-	home, err := os.UserHomeDir()
-	if err != nil {
+	logPath := LogPath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
 		return
 	}
-
-	logDir := filepath.Join(home, ".local", "share", "task")
-	if err := os.MkdirAll(logDir, 0755); err != nil {
-		return
-	}
-
-	logPath := filepath.Join(logDir, "ui.log")
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return
 	}
 	l.file = f
+	l.path = logPath
+	l.pid = os.Getpid()
 }
 
-// LogPath returns the path to the log file.
+// LogPath returns the path to the log file: ui.log beside the database, so an
+// instance pointed at another database logs beside that one instead of into the
+// live instance's file.
 func LogPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".local", "share", "task", "ui.log")
+	return filepath.Join(filepath.Dir(db.DefaultPath()), "ui.log")
 }
 
 // CloseLogger closes the log file.
@@ -69,9 +88,36 @@ func (l *UILogger) log(level, format string, args ...interface{}) {
 
 	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
 	msg := fmt.Sprintf(format, args...)
-	line := fmt.Sprintf("[%s] %s: %s\n", timestamp, level, msg)
+	line := fmt.Sprintf("[%s] [%d] %s: %s\n", timestamp, l.pid, level, msg)
 	l.file.WriteString(line)
-	l.file.Sync()
+
+	l.writes++
+	if l.writes%logSyncEvery == 0 {
+		l.file.Sync()
+		l.rotateIfLarge()
+	}
+}
+
+// rotateIfLarge moves the log aside once it passes maxLogBytes, keeping one
+// previous generation. Caller holds the mutex.
+func (l *UILogger) rotateIfLarge() {
+	if l.path == "" {
+		return
+	}
+	info, err := l.file.Stat()
+	if err != nil || info.Size() < maxLogBytes {
+		return
+	}
+	// Other ty processes hold their own descriptor on the same inode. Renaming
+	// leaves them writing to the rotated file until they notice; reopening here
+	// is what moves this process onto the fresh one. Nothing is lost either way.
+	_ = os.Rename(l.path, l.path+".1")
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return
+	}
+	_ = l.file.Close()
+	l.file = f
 }
 
 // Info logs an info message.

--- a/internal/ui/logger_test.go
+++ b/internal/ui/logger_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An instance pointed at its own database must log beside that database. One
+// shared ui.log made an isolated QA run's errors indistinguishable from the live
+// TUI's, which sent a real debugging session down the wrong path for hours.
+func TestLogPathFollowsTheDatabase(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("WORKTREE_DB_PATH", filepath.Join(dir, "tasks.db"))
+
+	got := LogPath()
+	if want := filepath.Join(dir, "ui.log"); got != want {
+		t.Fatalf("LogPath() = %q, want %q", got, want)
+	}
+}
+
+// Several ty processes append to one file concurrently, so a line has to say
+// which one wrote it.
+func TestLogLinesCarryThePid(t *testing.T) {
+	dir := t.TempDir()
+	l := &UILogger{}
+	f, err := os.CreateTemp(dir, "ui-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	l.file, l.path, l.pid = f, f.Name(), 4242
+	l.Info("joining pane %s", "%7")
+
+	data, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "[4242]") {
+		t.Fatalf("log line does not identify the writing process: %q", data)
+	}
+	if !strings.Contains(string(data), "joining pane %7") {
+		t.Fatalf("log line lost its message: %q", data)
+	}
+}
+
+// Unrotated, this file reached 205MB and eight months of history.
+func TestLogRotatesOnceItGrowsPastTheCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ui.log")
+	if err := os.WriteFile(path, make([]byte, maxLogBytes+1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := &UILogger{file: f, path: path, pid: 1}
+
+	for i := 0; i < logSyncEvery; i++ {
+		l.Info("line %d", i)
+	}
+
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("previous generation not kept: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() >= maxLogBytes {
+		t.Fatalf("log did not start fresh after rotating: %d bytes", info.Size())
+	}
+}

--- a/internal/ui/reload.go
+++ b/internal/ui/reload.go
@@ -41,7 +41,12 @@ func (m *AppModel) checkReload() tea.Cmd {
 }
 
 func (m *AppModel) beginReload() tea.Cmd {
-	if m.reloadWrites.Load() > 0 || !m.reloadPending || m.reloadReady || m.detailCleanupInFlight || m.taskTransitionInProgress {
+	// transitionInProgress(), not the bare field: a task switch holds that guard
+	// until its panes report back, and if that report is ever lost only the
+	// deadline reopens it. Reading the field directly let one stuck switch block
+	// every future reload, so a TUI left in a detail view silently never picked
+	// up a new binary no matter how often the reload was requested.
+	if m.reloadWrites.Load() > 0 || !m.reloadPending || m.reloadReady || m.detailCleanupInFlight || m.transitionInProgress() {
 		return nil
 	}
 	if m.currentView != ViewDashboard && m.currentView != ViewDetail {

--- a/internal/ui/reload_blocked_test.go
+++ b/internal/ui/reload_blocked_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// A task switch holds the navigation guard until its panes report back. If that
+// report is lost the guard expires by deadline — but only through
+// transitionInProgress(). beginReload read the bare field, so a stuck guard
+// silently blocked every future reload: a TUI left in a detail view never picked
+// up a new binary, and no amount of re-requesting helped.
+func TestReloadIsNotBlockedByAnExpiredTransition(t *testing.T) {
+	app, _ := refreshTestModel(t)
+	app.reloadEnabled = true
+	app.reloadPending = true
+	app.currentView = ViewDashboard
+
+	app.beginTaskTransition()
+	app.taskTransitionDeadline = time.Now().Add(-2 * taskTransitionTimeout) // report never arrived
+
+	if app.transitionInProgress() {
+		t.Fatal("guard should have expired")
+	}
+	if cmd := app.beginReload(); cmd == nil {
+		t.Fatal("reload still blocked by a transition that has already expired")
+	}
+}
+
+// While a switch really is in flight, the reload must wait rather than tear the
+// panes out from under it.
+func TestReloadWaitsForAnActiveTransition(t *testing.T) {
+	app, _ := refreshTestModel(t)
+	app.reloadEnabled = true
+	app.reloadPending = true
+	app.currentView = ViewDashboard
+	app.beginTaskTransition()
+
+	if cmd := app.beginReload(); cmd != nil {
+		t.Fatal("reload ran while a task switch was genuinely in flight")
+	}
+}
+
+// A TUI sitting in a detail view must still reload: beginReload hands the panes
+// back first, and the cleanup result drives the second pass.
+func TestReloadProceedsFromDetailView(t *testing.T) {
+	app, _ := refreshTestModel(t)
+	app.reloadEnabled = true
+	app.reloadPending = true
+	app.currentView = ViewDetail
+	app.detailView = &DetailModel{task: &db.Task{ID: 7}}
+	app.selectedTask = &db.Task{ID: 7}
+
+	cmd := app.beginReload()
+	if cmd == nil {
+		t.Fatal("reload refused while the detail view was open")
+	}
+	if app.currentView != ViewDashboard || app.detailView != nil {
+		t.Fatal("reload did not release the detail view before quitting")
+	}
+	if !app.reloadPrepared || app.reloadSnapshot.TaskID != 7 || !app.reloadSnapshot.Detail {
+		t.Fatalf("reload snapshot did not capture the open task: %+v", app.reloadSnapshot)
+	}
+}

--- a/internal/web/board.go
+++ b/internal/web/board.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bborn/workflow/internal/textutil"
+
 	"github.com/bborn/workflow/internal/db"
 )
 
@@ -180,5 +182,5 @@ func truncateTitle(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen-3] + "..."
+	return textutil.Truncate(s, maxLen, "...")
 }

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/bborn/workflow/internal/textutil"
+
 	"github.com/bborn/workflow/internal/db"
 	"github.com/bborn/workflow/internal/github"
 	"github.com/bborn/workflow/internal/tasksummary"
@@ -159,7 +161,7 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	if title == "" && req.Body != "" {
 		title = req.Body
 		if len(title) > 50 {
-			title = title[:50] + "..."
+			title = textutil.Truncate(title, 53, "...")
 		}
 	}
 


### PR DESCRIPTION
Three parked items, one commit each.

## 1. Truncate by runes outside the TUI too (`710924de`)

#720 fixed the six byte-sliced truncations in `internal/ui`. The same `s[:limit] + "..."` form was in **fourteen** more places, and the consequences there are just as real: invalid UTF-8 in served HTML, in CLI output, and in text handed to a model.

New `internal/textutil.Truncate` does it by runes. It's its own package because the callers span `web`, `mcp`, `hooks`, `tasksummary` and `cmd/task` — pulling a terminal-rendering dependency into the MCP server to shorten a string would be the wrong trade. Where display **width** matters, `ansi.Truncate` is still right and `internal/ui` keeps using it.

The one byte slice left is the API-key mask, which takes a prefix and suffix of a key that is ASCII by construction.

Tested across every limit from 1 to past the string's length: valid UTF-8, no U+FFFD, rune budget never exceeded.

## 2. A stuck task switch no longer blocks reloads forever (`a87e1970`)

**A regression I introduced in #713.** A TUI sitting in a detail view silently ignored every reload request — the binary changed underneath it and it kept running the old one, no error, no retry that helped. It bit us twice while shipping today.

`beginReload` already handles the detail view. Its guard was the problem:

```go
if ... || m.detailCleanupInFlight || m.taskTransitionInProgress {
```

That reads the **bare field**. Since #713 the navigation guard is held from the start of a task switch until its panes report back, and if that report is lost only `taskTransitionTimeout` reopens it — through `transitionInProgress()`, which `beginReload` bypassed. One switch with a missing pane message blocked every reload for the life of the process. Before #713 the guard cleared as soon as the row loaded, so it was never held long enough to matter.

A switch genuinely in flight still defers the reload rather than pulling panes out from under it.

## 3. ui.log: beside the database, pid-stamped, rotated (`13e30f4d`)

Three problems that together made the log actively misleading:

| | Was | Now |
|---|---|---|
| Path | hardcoded `$HOME` — an isolated QA instance appended to the **live** log | beside the database (`WORKTREE_DB_PATH`-aware), matching what the executor lock already does |
| Attribution | no writer id; two TUIs + daemon append concurrently | every line carries its pid |
| Size | never rotated — reached **205MB / 2.36M lines / 8 months** | rotates at 16MB, one previous generation |
| Durability | `fsync` **per line**, thousands per task switch, on the UI goroutine | flush every 64 lines |

With no override the path is unchanged, so existing installs keep `~/.local/share/task/ui.log`.

The path problem is not hypothetical: while debugging the TUI today, `breakTmuxPanes: could not find or create task window` was attributed to the live TUI when it came from a QA run.

`go test ./internal/ui/ ./internal/textutil/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWUetsantf6kBSQEaSDS7c