### PR TITLE
feat(cli): ty open <task> and iTerm2 task variables

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/bborn/workflow/internal/mcp"
 	"github.com/bborn/workflow/internal/pipeline"
 	"github.com/bborn/workflow/internal/routine"
+	"github.com/bborn/workflow/internal/taskref"
 	"github.com/bborn/workflow/internal/tuireload"
 	"github.com/bborn/workflow/internal/ui"
 	"github.com/bborn/workflow/internal/web"
@@ -129,31 +130,38 @@ func main() {
 
 	var dangerous bool
 
+	// launchTUI runs the TUI, starting where launch says. Outside tmux it
+	// re-executes the same command line in a new tmux session, which lands back
+	// here.
+	launchTUI := func(cmd *cobra.Command, launch tuiLaunch) {
+		// TUI requires tmux for split-pane Claude interaction
+		if os.Getenv("TMUX") == "" {
+			if err := execInTmux(); err != nil {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+				os.Exit(1)
+			}
+			return
+		}
+
+		debugStatePath, _ := cmd.Flags().GetString("debug-state-file")
+		cpuProfilePath, _ := cmd.Flags().GetString("cpuprofile")
+		memProfilePath, _ := cmd.Flags().GetString("memprofile")
+
+		// Run locally
+		if err := runLocal(dangerous, debugStatePath, cpuProfilePath, memProfilePath, launch); err != nil {
+			fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+			os.Exit(1)
+		}
+	}
+
 	rootCmd := &cobra.Command{
 		Use:     "ty",
 		Short:   "Task queue manager",
 		Long:    "A beautiful terminal UI for managing your task queue.",
 		Version: version,
 		Run: func(cmd *cobra.Command, args []string) {
-			// TUI requires tmux for split-pane Claude interaction
-			if os.Getenv("TMUX") == "" {
-				if err := execInTmux(); err != nil {
-					fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
-					os.Exit(1)
-				}
-				return
-			}
-
 			focusTaskID, _ := cmd.Flags().GetInt64("task")
-			debugStatePath, _ := cmd.Flags().GetString("debug-state-file")
-			cpuProfilePath, _ := cmd.Flags().GetString("cpuprofile")
-			memProfilePath, _ := cmd.Flags().GetString("memprofile")
-
-			// Run locally
-			if err := runLocal(dangerous, debugStatePath, cpuProfilePath, memProfilePath, focusTaskID); err != nil {
-				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
-				os.Exit(1)
-			}
+			launchTUI(cmd, tuiLaunch{taskID: focusTaskID})
 		},
 	}
 
@@ -164,6 +172,45 @@ func main() {
 	// Not persistent: subcommands have their own meaning for a task argument, and
 	// this only affects the TUI's initial selection.
 	rootCmd.Flags().Int64("task", 0, "Open the TUI with this task selected")
+
+	openCmd := &cobra.Command{
+		Use:   "open <task>",
+		Short: "Open the TUI on a task",
+		Long: `Open the TUI on a task, named any way the go-to-task palette (p) accepts.
+
+A task ID, #ID, task branch or GitHub PR URL that names one task opens its
+detail view; esc goes back to the board. Anything else opens the board with
+the palette already searching for it.
+
+Examples:
+  ty open 5187
+  ty open '#5187'
+  ty open task/5187-draft-offers
+  ty open https://github.com/org/repo/pull/3482
+  ty open draft offers`,
+		ValidArgsFunction: completeTaskIDs,
+		Args:              cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ref := strings.Join(args, " ")
+			database, err := openTaskDB(db.DefaultPath())
+			if err != nil {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+				os.Exit(1)
+			}
+			task, err := taskref.Resolve(database, ref)
+			database.Close()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, errorStyle.Render("Error: "+err.Error()))
+				os.Exit(1)
+			}
+			if task == nil {
+				launchTUI(cmd, tuiLaunch{query: taskref.SearchText(ref)})
+				return
+			}
+			launchTUI(cmd, tuiLaunch{taskID: task.ID, openTask: true})
+		},
+	}
+	rootCmd.AddCommand(openCmd)
 	rootCmd.PersistentFlags().String("debug-state-file", "", "Path to write debug state JSON on update")
 	rootCmd.PersistentFlags().String("cpuprofile", "", "Write a CPU profile here while the TUI runs (analyze with: go tool pprof)")
 	rootCmd.PersistentFlags().String("memprofile", "", "Write a heap profile here when the TUI exits")
@@ -172,6 +219,7 @@ func main() {
 	// Skip for root (TUI has its own check), upgrade, daemon, mcp-server, and claude-hook.
 	skipVersionCheck := map[string]bool{
 		"ty":          true, // root command (TUI)
+		"open":        true, // also the TUI
 		"upgrade":     true,
 		"daemon":      true,
 		"mcp-server":  true,
@@ -4197,8 +4245,13 @@ func execInTmux() error {
 	sessionName := getUISessionName()
 	sessionID := getSessionID()
 
-	// Build command with all original args
+	// Build command with all original args, quoted: tmux runs it through a
+	// shell, where a bare "#5187" is a comment and "?" or "&" in a PR URL mean
+	// something else.
 	args := append([]string{executable}, os.Args[1:]...)
+	for i, a := range args {
+		args[i] = shellQuote(a)
+	}
 	cmdStr := strings.Join(args, " ")
 
 	// Set WORKTREE_SESSION_ID env var so child processes use the same session ID
@@ -4309,7 +4362,15 @@ func setupProfiling(cpuPath, memPath string) func() {
 }
 
 // runLocal runs the TUI locally with a local SQLite database.
-func runLocal(dangerousMode bool, debugStatePath, cpuProfilePath, memProfilePath string, focusTaskID int64) error {
+// tuiLaunch says where the TUI starts: a task highlighted on the board, a
+// task's detail view open, or the go-to-task palette searching for query.
+type tuiLaunch struct {
+	taskID   int64
+	openTask bool
+	query    string
+}
+
+func runLocal(dangerousMode bool, debugStatePath, cpuProfilePath, memProfilePath string, launch tuiLaunch) error {
 	// Optional performance profiling. The CPU profile captures the whole
 	// interactive session (including every render); the heap profile is written
 	// on exit. Analyze with `go tool pprof <binary> <profile>`.
@@ -4354,8 +4415,14 @@ func runLocal(dangerousMode bool, debugStatePath, cpuProfilePath, memProfilePath
 		return fmt.Errorf("read TUI reload state: %w", err)
 	}
 	model.EnableReload(token)
-	if focusTaskID > 0 {
-		model.FocusTaskOnLoad(focusTaskID)
+	model.EnableTerminalTaskReport()
+	switch {
+	case launch.query != "":
+		model.OpenPaletteOnLoad(launch.query)
+	case launch.taskID > 0 && launch.openTask:
+		model.OpenTaskOnLoad(launch.taskID)
+	case launch.taskID > 0:
+		model.FocusTaskOnLoad(launch.taskID)
 	}
 	if saved := os.Getenv("TASKYOU_TUI_RELOAD_STATE"); saved != "" {
 		os.Unsetenv("TASKYOU_TUI_RELOAD_STATE")
@@ -4396,12 +4463,15 @@ func runLocal(dangerousMode bool, debugStatePath, cpuProfilePath, memProfilePath
 		// the currently loaded build instead, acknowledging the request token.
 		fmt.Fprintln(os.Stderr, errorStyle.Render("Reload failed; resuming current TUI: "+reloadErr.Error()))
 		os.Setenv("TASKYOU_TUI_RELOAD_STATE", string(data))
-		return runLocal(dangerousMode, debugStatePath, cpuProfilePath, memProfilePath, focusTaskID)
+		return runLocal(dangerousMode, debugStatePath, cpuProfilePath, memProfilePath, launch)
 	}
 
 	// Flush profiles now, before the tmux cleanup below may kill our own session
 	// (which would SIGKILL this process and skip the deferred flush).
 	stopProfiling()
+
+	// Before the session goes away, so a tab title stops naming the last task.
+	model.ClearTerminalTask()
 
 	// Kill task-ui tmux session on exit (if we're in it)
 	// This cleans up the session that was created by execInTmux()

--- a/cmd/task/shell_quote_test.go
+++ b/cmd/task/shell_quote_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	osexec "os/exec"
+	"testing"
+)
+
+// execInTmux hands the re-executed command line to a shell; each argument must
+// come out the other side exactly as it went in.
+func TestShellQuoteSurvivesShell(t *testing.T) {
+	for _, arg := range []string{
+		"#5187",
+		"https://github.com/org/repo/pull/3482/files?w=1&a=b#r1",
+		"it's got 'quotes' and $HOME and `ticks`",
+		"draft offers",
+		"",
+	} {
+		out, err := osexec.Command("sh", "-c", "printf %s "+shellQuote(arg)).Output()
+		if err != nil {
+			t.Fatalf("sh with %q: %v", arg, err)
+		}
+		if string(out) != arg {
+			t.Errorf("shell turned %q into %q", arg, out)
+		}
+	}
+}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -32,6 +32,18 @@ The terminal UI is TaskYou's primary interface — everything ships here first. 
 [![New Task Form](screenshots/new-task-form.png)](screenshots/new-task-form.png)
 *Creating a new task with project selection, type, executor, effort, permissions, and attachments*
 
+### Show the focused task in your tab title
+
+The TUI publishes the task you are looking at (the open task in the detail view, otherwise the highlighted card) as iTerm2 user variables:
+
+| Variable | Example |
+|---|---|
+| `user.taskyouTask` | `#5202 Fix login` |
+| `user.taskyouTaskId` | `5202` |
+| `user.taskyouTaskTitle` | `Fix login` |
+
+They are session variables. Badges and status bar components can use `\(user.taskyouTask)` directly. Tab titles are evaluated in tab scope, so reach the session through `currentSession`: to keep your own tab name and append the task, choose **Edit Tab Title** and enter `ty \(currentSession.user.taskyouTask)`. Other terminals ignore the variables, so nothing changes unless you reference them.
+
 ## The CLI
 
 Everything the TUI can do, the CLI can do too — create, execute, retry, and inspect tasks, read executor output, even send keystrokes to a running executor. That makes TaskYou trivial to drive from scripts, cron jobs, and AI agents.
@@ -319,7 +331,16 @@ make build
 ```bash
 # Launch the TUI (auto-starts background daemon)
 ./bin/ty
+
+# Launch straight into a task. An ID, #ID, task branch or GitHub PR URL opens
+# its detail view (esc goes back to the board); other text opens the board
+# with the go-to-task palette searching for it.
+./bin/ty open 123
+./bin/ty open https://github.com/org/repo/pull/456
+./bin/ty open draft offers
 ```
+
+In zsh with `interactivecomments` set, quote a leading `#` (`ty open '#123'`), or the shell drops it as a comment.
 
 ### Daemon management
 

--- a/internal/taskref/taskref.go
+++ b/internal/taskref/taskref.go
@@ -1,0 +1,110 @@
+// Package taskref resolves the ways people name a task: "5187", "#5187", a
+// task branch such as "task/5187-fix-login", or a GitHub PR URL. These are the
+// references the TUI's go-to-task palette recognizes exactly. Anything looser,
+// like words from a title, is a search and belongs to the palette.
+package taskref
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+var (
+	// Matches branch names like "task/1068-description" or "task/1068".
+	branchTaskIDPattern = regexp.MustCompile(`(?:^|/)(\d+)(?:-|$)`)
+	// Matches GitHub PR URLs like "https://github.com/org/repo/pull/123".
+	prURLPattern = regexp.MustCompile(`github\.com/([^/]+/[^/]+)/pull/(\d+)`)
+)
+
+// TaskIDFromBranch returns the task ID in a branch name such as
+// "task/1068-description", or 0.
+func TaskIDFromBranch(s string) int64 {
+	if m := branchTaskIDPattern.FindStringSubmatch(s); m != nil {
+		if id, err := strconv.ParseInt(m[1], 10, 64); err == nil {
+			return id
+		}
+	}
+	return 0
+}
+
+// PRNumberFromURL returns the PR number in a GitHub PR URL, or 0.
+func PRNumberFromURL(s string) int {
+	_, n := parsePRURL(s)
+	return n
+}
+
+// parsePRURL returns the lowercased "org/repo" and number of a GitHub PR URL.
+func parsePRURL(s string) (repo string, number int) {
+	m := prURLPattern.FindStringSubmatch(s)
+	if m == nil {
+		return "", 0
+	}
+	n, err := strconv.Atoi(m[2])
+	if err != nil {
+		return "", 0
+	}
+	return strings.ToLower(m[1]), n
+}
+
+// Store is what Resolve reads; *db.DB satisfies it.
+type Store interface {
+	GetTask(id int64) (*db.Task, error)
+	SearchTasks(query string, limit int) ([]*db.Task, error)
+}
+
+// Resolve returns the one task ref names, or nil when it names none or more
+// than one: an ID with no task, a PR several tasks share, or search text.
+func Resolve(store Store, ref string) (*db.Task, error) {
+	ref = strings.TrimSpace(ref)
+	if repo, n := parsePRURL(ref); n > 0 {
+		return byPR(store, repo, n)
+	}
+	if id, err := strconv.ParseInt(strings.TrimPrefix(ref, "#"), 10, 64); err == nil {
+		return store.GetTask(id)
+	}
+	// A branch is one word; "fix 12-hour clock" is a search.
+	if !strings.ContainsAny(ref, " \t") {
+		if id := TaskIDFromBranch(ref); id > 0 {
+			return store.GetTask(id)
+		}
+	}
+	return nil, nil
+}
+
+// SearchText is what to hand the palette for ref: a PR URL cut down to
+// github.com/org/repo/pull/N, so a pasted ".../pull/N/files" still finds the
+// task, and anything else as typed.
+func SearchText(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if repo, n := parsePRURL(ref); n > 0 {
+		return canonicalPRURL(repo, n)
+	}
+	return ref
+}
+
+func canonicalPRURL(repo string, number int) string {
+	return fmt.Sprintf("github.com/%s/pull/%d", repo, number)
+}
+
+// byPR finds the task for one repo's PR. SearchTasks matches pr_url as a
+// substring, so pull/36 also finds pull/365; compare exactly here.
+func byPR(store Store, repo string, number int) (*db.Task, error) {
+	candidates, err := store.SearchTasks(canonicalPRURL(repo, number), 50)
+	if err != nil {
+		return nil, err
+	}
+	var found *db.Task
+	for _, t := range candidates {
+		if r, n := parsePRURL(t.PRURL); r == repo && n == number {
+			if found != nil {
+				return nil, nil // several tasks share this PR; the palette lists them
+			}
+			found = t
+		}
+	}
+	return found, nil
+}

--- a/internal/taskref/taskref_test.go
+++ b/internal/taskref/taskref_test.go
@@ -1,0 +1,93 @@
+package taskref
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// fakeStore mimics the real store: GetTask returns nil for a missing ID, and
+// SearchTasks matches pr_url as a case-insensitive substring.
+type fakeStore struct{ tasks []*db.Task }
+
+func (f fakeStore) GetTask(id int64) (*db.Task, error) {
+	for _, t := range f.tasks {
+		if t.ID == id {
+			return t, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f fakeStore) SearchTasks(query string, limit int) ([]*db.Task, error) {
+	var out []*db.Task
+	for _, t := range f.tasks {
+		if strings.Contains(strings.ToLower(t.PRURL), strings.ToLower(query)) {
+			out = append(out, t)
+		}
+	}
+	return out, nil
+}
+
+func TestResolve(t *testing.T) {
+	store := fakeStore{tasks: []*db.Task{
+		{ID: 5187, PRURL: "https://github.com/offerlab/offerlab/pull/3482"},
+		{ID: 7, PRURL: "https://github.com/other/repo/pull/3482"},
+		{ID: 5401, PRURL: "https://github.com/offerlab/offerlab/pull/3652"},
+		{ID: 5402, PRURL: "https://github.com/offerlab/offerlab/pull/36520"},
+		{ID: 8, PRURL: "https://github.com/offerlab/offerlab/pull/100"},
+		{ID: 9, PRURL: "https://github.com/offerlab/offerlab/pull/100"},
+	}}
+
+	for _, tt := range []struct {
+		ref  string
+		want int64 // 0: no single task
+	}{
+		{"5187", 5187},
+		{"#5187", 5187},
+		{" #5187 ", 5187},
+		{"task/5187-draft-offers", 5187},
+		{"https://github.com/offerlab/offerlab/pull/3482", 5187},
+		{"https://github.com/OfferLab/offerlab/pull/3482/files?w=1", 5187},
+		{"github.com/offerlab/offerlab/pull/3652", 5401},
+		{"https://github.com/offerlab/offerlab/pull/100", 0}, // two tasks share it
+		{"https://github.com/offerlab/offerlab/pull/4", 0},
+		{"99999", 0},
+		{"draft offers", 0},
+		{"fix 5187-thing", 0},
+	} {
+		got, err := Resolve(store, tt.ref)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", tt.ref, err)
+		}
+		var gotID int64
+		if got != nil {
+			gotID = got.ID
+		}
+		if gotID != tt.want {
+			t.Errorf("Resolve(%q) = task %d, want %d", tt.ref, gotID, tt.want)
+		}
+	}
+}
+
+func TestSearchText(t *testing.T) {
+	for in, want := range map[string]string{
+		"https://github.com/Org/Repo/pull/12/files#r1": "github.com/org/repo/pull/12",
+		"  draft offers ": "draft offers",
+		"#5187":           "#5187",
+	} {
+		if got := SearchText(in); got != want {
+			t.Errorf("SearchText(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestExtractors(t *testing.T) {
+	if got := TaskIDFromBranch("task/1068-description"); got != 1068 {
+		t.Errorf("TaskIDFromBranch = %d, want 1068", got)
+	}
+	if got := PRNumberFromURL("https://github.com/org/repo/pull/123"); got != 123 {
+		t.Errorf("PRNumberFromURL = %d, want 123", got)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -544,6 +544,9 @@ type AppModel struct {
 	// Debug state file path
 	debugStatePath string
 
+	// Publishes the focused task to the terminal (nil unless enabled)
+	terminalTask *terminalTaskReporter
+
 	// First-time experience
 	isFirstLoad bool // Track if this is the first load of tasks
 	showWelcome bool // Show welcome message when kanban is empty
@@ -555,6 +558,9 @@ type AppModel struct {
 	// pendingFocusTaskID is a task to select once the board has loaded, set by
 	// --task. Zero means no request.
 	pendingFocusTaskID int64
+	// pendingPaletteQuery opens the go-to-task palette with this search once
+	// the board has loaded (`ty open <search>`).
+	pendingPaletteQuery string
 }
 
 // taskExecutorDisplayName returns the display name for a task's executor.
@@ -752,6 +758,8 @@ func (m *AppModel) Init() tea.Cmd {
 func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	prevView := m.currentView
+	// Deferred so every early return below still publishes the new focus.
+	defer m.reportTerminalTask()
 
 	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
 		m.applyWindowSize(sizeMsg.Width, sizeMsg.Height)
@@ -905,15 +913,7 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Command palette works from any view
 		if key.Matches(msg, m.keys.CommandPalette) {
-			m.commandPaletteView = NewCommandPaletteModel(m.db, m.tasks, m.width, m.height)
-			m.commandPaletteReturnView = m.currentView
-			if m.currentView == ViewDetail && m.selectedTask != nil {
-				m.commandPaletteReturnTaskID = m.selectedTask.ID
-			} else {
-				m.commandPaletteReturnTaskID = 0
-			}
-			m.currentView = ViewCommandPalette
-			return m, m.commandPaletteView.Init()
+			return m, m.openCommandPalette("")
 		}
 
 		// First-run Welcome fork key handling.
@@ -1121,6 +1121,12 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.pendingFocusTaskID > 0 {
 			m.kanban.SelectTask(m.pendingFocusTaskID)
 			m.pendingFocusTaskID = 0
+		}
+		if query := m.pendingPaletteQuery; query != "" {
+			m.pendingPaletteQuery = ""
+			if m.currentView == ViewDashboard {
+				cmds = append(cmds, m.openCommandPalette(query))
+			}
 		}
 
 		m.kanban.SetHiddenDoneCount(msg.hiddenDoneCount)
@@ -5775,4 +5781,34 @@ func (m *AppModel) getProjects() []*db.Project {
 // rather than on whatever the board happens to sort first.
 func (m *AppModel) FocusTaskOnLoad(taskID int64) {
 	m.pendingFocusTaskID = taskID
+}
+
+// OpenTaskOnLoad opens a task's detail view once the board has loaded (`ty
+// open`). It seeds the restore path a reloaded TUI uses. When this process is
+// itself a reload, the RestoreReloadState that follows replaces it, so a restart
+// returns to where the user was, not to the task on the original command line.
+func (m *AppModel) OpenTaskOnLoad(taskID int64) {
+	m.RestoreReloadState(ReloadState{TaskID: taskID, Detail: true})
+}
+
+// OpenPaletteOnLoad opens the go-to-task palette with query typed in once the
+// board has loaded (`ty open <search>`), leaving the pick to the user.
+func (m *AppModel) OpenPaletteOnLoad(query string) {
+	m.pendingPaletteQuery = query
+}
+
+// openCommandPalette shows the go-to-task palette, pre-filled with query.
+func (m *AppModel) openCommandPalette(query string) tea.Cmd {
+	m.commandPaletteView = NewCommandPaletteModel(m.db, m.tasks, m.width, m.height)
+	if query != "" {
+		m.commandPaletteView.SetQuery(query)
+	}
+	m.commandPaletteReturnView = m.currentView
+	if m.currentView == ViewDetail && m.selectedTask != nil {
+		m.commandPaletteReturnTaskID = m.selectedTask.ID
+	} else {
+		m.commandPaletteReturnTaskID = 0
+	}
+	m.currentView = ViewCommandPalette
+	return m.commandPaletteView.Init()
 }

--- a/internal/ui/command_palette.go
+++ b/internal/ui/command_palette.go
@@ -2,9 +2,7 @@ package ui
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -13,14 +11,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/bborn/workflow/internal/db"
-)
-
-// Patterns for extracting task IDs and PR numbers from pasted input
-var (
-	// Matches branch names like "task/1068-description" or "task/1068"
-	branchTaskIDPattern = regexp.MustCompile(`(?:^|/)(\d+)(?:-|$)`)
-	// Matches GitHub PR URLs like "https://github.com/org/repo/pull/123"
-	githubPRURLPattern = regexp.MustCompile(`github\.com/[^/]+/[^/]+/pull/(\d+)`)
+	"github.com/bborn/workflow/internal/taskref"
 )
 
 // CommandPaletteModel represents the Command+P task switcher and AI command input.
@@ -122,6 +113,13 @@ func (m *CommandPaletteModel) activeLen() int {
 // Init initializes the command palette.
 func (m *CommandPaletteModel) Init() tea.Cmd {
 	return textinput.Blink
+}
+
+// SetQuery types query into the search box, as if the user had.
+func (m *CommandPaletteModel) SetQuery(query string) {
+	m.searchInput.SetValue(query)
+	m.searchInput.CursorEnd()
+	m.filter()
 }
 
 // Update handles messages.
@@ -483,28 +481,15 @@ func (m *CommandPaletteModel) scoreTask(task *db.Task, query string) int {
 
 // extractTaskID tries to extract a task ID from a branch name pattern.
 // Supports patterns like "task/1068-description", "feature/1068-foo", "1068-description".
+// Shared with `ty open` through taskref, so both accept the same references.
 func extractTaskID(input string) int64 {
-	matches := branchTaskIDPattern.FindStringSubmatch(input)
-	if len(matches) >= 2 {
-		id, err := strconv.ParseInt(matches[1], 10, 64)
-		if err == nil {
-			return id
-		}
-	}
-	return 0
+	return taskref.TaskIDFromBranch(input)
 }
 
 // extractPRNumber extracts a PR number from a GitHub PR URL.
 // Supports URLs like "https://github.com/org/repo/pull/123".
 func extractPRNumber(input string) int {
-	matches := githubPRURLPattern.FindStringSubmatch(input)
-	if len(matches) >= 2 {
-		num, err := strconv.Atoi(matches[1])
-		if err == nil {
-			return num
-		}
-	}
-	return 0
+	return taskref.PRNumberFromURL(input)
 }
 
 // matchesQuery checks if a task matches the search query.

--- a/internal/ui/open_task_test.go
+++ b/internal/ui/open_task_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func TestOpenPaletteOnLoadIsDroppedByReload(t *testing.T) {
+	m := &AppModel{}
+	m.OpenPaletteOnLoad("draft offers")
+	if m.pendingPaletteQuery != "draft offers" {
+		t.Fatalf("pendingPaletteQuery = %q", m.pendingPaletteQuery)
+	}
+	m.RestoreReloadState(ReloadState{TaskID: 7})
+	if m.pendingPaletteQuery != "" {
+		t.Errorf("a reload reopened `ty open`'s search: %q", m.pendingPaletteQuery)
+	}
+}
+
+func TestOpenCommandPaletteWithQuery(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "tasks.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	m := &AppModel{
+		db:          database,
+		width:       100,
+		height:      40,
+		currentView: ViewDashboard,
+		tasks: []*db.Task{
+			{ID: 1, Title: "Catalog sync", Status: db.StatusBacklog},
+			{ID: 2, Title: "Draft offers bundle", Status: db.StatusBacklog},
+		},
+	}
+	m.openCommandPalette("draft")
+	p := m.commandPaletteView
+	if m.currentView != ViewCommandPalette || p == nil {
+		t.Fatalf("palette not shown: view %v", m.currentView)
+	}
+	if p.searchInput.Value() != "draft" || p.resultsStale() {
+		t.Fatalf("query %q typed, stale=%v", p.searchInput.Value(), p.resultsStale())
+	}
+	if len(p.filteredTasks) == 0 || p.filteredTasks[0].ID != 2 {
+		t.Errorf("top result = %v, want task 2", p.filteredTasks)
+	}
+}
+
+func TestOpenTaskOnLoadRestoresIntoDetail(t *testing.T) {
+	m := &AppModel{}
+	m.OpenTaskOnLoad(42)
+	if m.pendingFocusTaskID != 42 {
+		t.Errorf("pendingFocusTaskID = %d, want 42", m.pendingFocusTaskID)
+	}
+	if r := m.reloadRestoring; r == nil || r.TaskID != 42 || !r.Detail {
+		t.Fatalf("reloadRestoring = %+v, want task 42 in detail", r)
+	}
+
+	// A TUI started with `ty open 42` re-runs that command line when it reloads;
+	// the reload's own state must win so the user stays where they were.
+	m.RestoreReloadState(ReloadState{TaskID: 7})
+	if m.pendingFocusTaskID != 7 {
+		t.Errorf("after reload restore, pendingFocusTaskID = %d, want 7", m.pendingFocusTaskID)
+	}
+	if r := m.reloadRestoring; r == nil || r.TaskID != 7 || r.Detail {
+		t.Errorf("after reload restore, reloadRestoring = %+v, want task 7 on the board", r)
+	}
+}

--- a/internal/ui/reload.go
+++ b/internal/ui/reload.go
@@ -26,6 +26,7 @@ func (m *AppModel) RestoreReloadState(state ReloadState) {
 	m.filterText = state.Filter
 	m.filterInput.SetValue(state.Filter)
 	m.pendingFocusTaskID = state.TaskID
+	m.pendingPaletteQuery = "" // a reload returns to where the user was, not to `ty open`'s search
 	if state.Filter != "" {
 		m.reloadSelectionID = state.TaskID
 	}

--- a/internal/ui/terminal_task.go
+++ b/internal/ui/terminal_task.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	osExec "os/exec"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// iTerm2 user variables naming the task on screen. A tab title, badge or status
+// bar can reference them as interpolated strings, e.g. a tab titled
+// `ty \(currentSession.user.taskyouTask)` reads "ty #5202 Fix login" (tab
+// titles are evaluated in tab scope, hence currentSession). Terminals that don't
+// understand OSC 1337 ignore the sequence, so publishing them changes nothing
+// unless the user opts in by referencing a variable.
+const (
+	termVarTask      = "taskyouTask"      // "#5202 Fix login"
+	termVarTaskID    = "taskyouTaskId"    // "5202"
+	termVarTaskTitle = "taskyouTaskTitle" // "Fix login"
+)
+
+// terminalTaskReporter publishes the focused task to the terminal, writing only
+// when it changes: Update runs on every key and mouse event.
+type terminalTaskReporter struct {
+	inTmux bool
+	write  func(string)
+	last   string
+	sent   bool
+}
+
+func (r *terminalTaskReporter) report(task *db.Task) {
+	var id, title, label string
+	if task != nil {
+		id = fmt.Sprint(task.ID)
+		title = strings.Join(strings.Fields(task.Title), " ")
+		label = "#" + id + " " + title
+	}
+	// The first report always goes out, clearing values left by a previous run.
+	if r.sent && label == r.last {
+		return
+	}
+	r.sent = true
+	r.last = label
+	seq := setUserVarSeq(termVarTask, label) +
+		setUserVarSeq(termVarTaskID, id) +
+		setUserVarSeq(termVarTaskTitle, title)
+	if r.inTmux {
+		seq = tmuxPassthrough(seq)
+	}
+	r.write(seq)
+}
+
+// setUserVarSeq is iTerm2's OSC 1337 SetUserVar; the value is base64 so any
+// title survives the trip.
+func setUserVarSeq(name, value string) string {
+	return "\x1b]1337;SetUserVar=" + name + "=" + base64.StdEncoding.EncodeToString([]byte(value)) + "\a"
+}
+
+// tmuxPassthrough wraps seq in tmux's DCS passthrough so it reaches the outer
+// terminal instead of being swallowed by tmux. ESCs inside are doubled.
+func tmuxPassthrough(seq string) string {
+	return "\x1bPtmux;" + strings.ReplaceAll(seq, "\x1b", "\x1b\x1b") + "\x1b\\"
+}
+
+// EnableTerminalTaskReport makes the TUI publish its focused task as iTerm2
+// user variables. Local TUI only: over SSH, /dev/tty is the server's terminal,
+// not the viewer's.
+func (m *AppModel) EnableTerminalTaskReport() {
+	inTmux := os.Getenv("TMUX") != ""
+	if pane := ownPaneID(); inTmux && pane != "" {
+		// tmux drops passthrough unless the pane allows it. Scoped to this
+		// process's own pane so no other program gains the ability.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		osExec.CommandContext(ctx, "tmux", "set-option", "-p", "-t", pane, "allow-passthrough", "on").Run()
+		cancel()
+	}
+	m.terminalTask = &terminalTaskReporter{inTmux: inTmux, write: writeTTY}
+}
+
+// ClearTerminalTask blanks the published variables so a tab title does not keep
+// naming a task after ty exits.
+func (m *AppModel) ClearTerminalTask() {
+	if m.terminalTask != nil {
+		m.terminalTask.report(nil)
+	}
+}
+
+// reportTerminalTask publishes the task the user is looking at: the open task
+// in the detail view, otherwise the highlighted card on the board.
+func (m *AppModel) reportTerminalTask() {
+	if m.terminalTask == nil {
+		return
+	}
+	var task *db.Task
+	switch {
+	case m.currentView == ViewDetail && m.selectedTask != nil:
+		task = m.selectedTask
+	case m.kanban != nil:
+		task = m.kanban.SelectedTask()
+	}
+	m.terminalTask.report(task)
+}
+
+// writeTTY writes to /dev/tty directly, like ringBellNow, so the sequence
+// reaches the terminal rather than Bubble Tea's renderer.
+func writeTTY(s string) {
+	tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		return
+	}
+	defer tty.Close()
+	tty.WriteString(s)
+}

--- a/internal/ui/terminal_task_test.go
+++ b/internal/ui/terminal_task_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+func TestSetUserVarSeqEncodesValue(t *testing.T) {
+	value := "#1 a;b=c\x07"
+	got := setUserVarSeq("taskyouTask", value)
+	want := "\x1b]1337;SetUserVar=taskyouTask=" + base64.StdEncoding.EncodeToString([]byte(value)) + "\a"
+	if got != want {
+		t.Errorf("setUserVarSeq = %q, want %q", got, want)
+	}
+}
+
+func TestTmuxPassthroughDoublesEscapes(t *testing.T) {
+	got := tmuxPassthrough("\x1b]1337;x\a\x1b]1337;y\a")
+	want := "\x1bPtmux;\x1b\x1b]1337;x\a\x1b\x1b]1337;y\a\x1b\\"
+	if got != want {
+		t.Errorf("tmuxPassthrough = %q, want %q", got, want)
+	}
+}
+
+func TestTerminalTaskReporterWritesOnlyOnChange(t *testing.T) {
+	var writes []string
+	r := &terminalTaskReporter{write: func(s string) { writes = append(writes, s) }}
+	task := &db.Task{ID: 5202, Title: "Fix\n  login"}
+
+	r.report(nil) // first report always writes, clearing a previous run's values
+	r.report(nil)
+	r.report(task)
+	r.report(task)
+	r.report(&db.Task{ID: 5202, Title: "Fix login flow"})
+	r.report(nil)
+
+	if len(writes) != 4 {
+		t.Fatalf("got %d writes, want 4: %q", len(writes), writes)
+	}
+	for i, want := range []string{
+		setUserVarSeq(termVarTask, ""),
+		setUserVarSeq(termVarTask, "#5202 Fix login") + setUserVarSeq(termVarTaskID, "5202") + setUserVarSeq(termVarTaskTitle, "Fix login"),
+		setUserVarSeq(termVarTask, "#5202 Fix login flow"),
+		setUserVarSeq(termVarTask, "") + setUserVarSeq(termVarTaskID, "") + setUserVarSeq(termVarTaskTitle, ""),
+	} {
+		if !strings.Contains(writes[i], want) {
+			t.Errorf("write %d = %q, want it to contain %q", i, writes[i], want)
+		}
+	}
+}
+
+func TestTerminalTaskReporterWrapsForTmux(t *testing.T) {
+	var got string
+	r := &terminalTaskReporter{inTmux: true, write: func(s string) { got = s }}
+	r.report(&db.Task{ID: 7, Title: "Seven"})
+	if !strings.HasPrefix(got, "\x1bPtmux;") || !strings.HasSuffix(got, "\x1b\\") {
+		t.Errorf("write = %q, want tmux passthrough", got)
+	}
+}
+
+func TestReportTerminalTaskFollowsFocus(t *testing.T) {
+	tasks := []*db.Task{
+		{ID: 1, Title: "One", Status: db.StatusBacklog},
+		{ID: 2, Title: "Two", Status: db.StatusBacklog},
+	}
+	var last string
+	m := &AppModel{
+		width:        100,
+		height:       50,
+		currentView:  ViewDashboard,
+		keys:         DefaultKeyMap(),
+		kanban:       NewKanbanBoard(100, 50),
+		terminalTask: &terminalTaskReporter{write: func(s string) { last = s }},
+	}
+	m.kanban.SetTasks(tasks)
+	before := m.kanban.SelectedTask()
+	if before == nil {
+		t.Fatal("expected a highlighted task")
+	}
+
+	// Moving the highlight through Update publishes the new card.
+	m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	after := m.kanban.SelectedTask()
+	if after == nil || after.ID == before.ID {
+		t.Fatalf("down did not move the highlight off task %d", before.ID)
+	}
+	if want := setUserVarSeq(termVarTask, fmt.Sprintf("#%d %s", after.ID, after.Title)); !strings.Contains(last, want) {
+		t.Errorf("write = %q, want it to contain %q", last, want)
+	}
+
+	// The detail view reports the open task, whatever the board highlights.
+	m.currentView = ViewDetail
+	m.selectedTask = before
+	m.reportTerminalTask()
+	if want := setUserVarSeq(termVarTask, fmt.Sprintf("#%d %s", before.ID, before.Title)); !strings.Contains(last, want) {
+		t.Errorf("in detail view, write = %q, want it to contain %q", last, want)
+	}
+}


### PR DESCRIPTION
## Summary

Two small quality-of-life features for the terminal, plus a quoting bug found along the way.

- **`ty open <task>`** launches the TUI straight into a task. It accepts what the go-to-task palette (`p`) accepts: an ID, `#ID`, task branch, or GitHub PR URL that names one task opens its detail view, and `esc` goes back to the full board. Anything else (a PR several tasks share, or plain words) opens the board with the palette already searching for it.
- **iTerm2 task variables.** The local TUI publishes the task on screen (the open task in the detail view, else the highlighted card) as iTerm2 user variables `taskyouTask` (`#5202 Fix login`), `taskyouTaskId` and `taskyouTaskTitle`. A tab title can show it with `ty \(currentSession.user.taskyouTask)`. Other terminals ignore the sequence.
- **Fix:** `execInTmux` re-executed the command line through a shell unquoted, so `#5187` became a comment and `?`/`&` in PR URLs broke.

## Changes

- `internal/taskref` (new): exact task references (ID, `#ID`, branch, PR URL, comparing repo and number exactly). The palette now uses its extractors, so the two cannot drift.
- `cmd/task`: `ty open`, a `tuiLaunch` value instead of positional `runLocal` flags, quoted re-exec.
- `internal/ui`: `OpenTaskOnLoad` / `OpenPaletteOnLoad` (a real reload still restores where the user was), palette `SetQuery`, `terminal_task.go` (OSC 1337 `SetUserVar`, wrapped in tmux passthrough; `allow-passthrough` is enabled on the TUI’s own pane only).
- Docs: `docs/reference.md`.

## Testing

- `go test ./...` passes (with `CLAUDE_CONFIG_DIR` unset; two `internal/executor` tests fail when it is set in the environment, same on `main`). golangci-lint v2.13.2: 0 issues.
- New tests: `internal/taskref` (ID/#ID/branch/PR URL incl. `pull/36` vs `pull/365`, same number in another repo, ambiguous PR), escape-sequence formatting and dedupe, focus following through `Update`, palette pre-fill, reload overriding `ty open`, and shell-quoted args surviving a real `sh`.
- End to end, launched outside tmux with a real attached client: `ty open '#<id>'` and `ty open <PR URL>/files?w=1` open the detail view and `esc` returns to the full board; `ty open <words>` opens the palette pre-filled with the matching task on top.
- iTerm2: variables read back with `it2 session get-var` on live tabs; tmux passthrough verified on an isolated tmux server.

## Screenshots

Palette opened by `ty open draft offers` (text capture):

```
╭──────────────────────────────────────────────╮
│  Go to Task                                  │
│  ╭────────────────────────────────────────╮  │
│  │ > draft offers                         │  │
│  ╰────────────────────────────────────────╯  │
│  > ⚠ #5187 [ol] Let draft offers join a …    │
│    ✓ #4934 [ol] Set existing draft offers …  │
╰──────────────────────────────────────────────╯
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
