### PR TITLE
fix(ui): keep dashboard banners on one row so the kanban board stays intact

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1863,51 +1863,77 @@ func (m *AppModel) viewNewTaskConfirm() string {
 	return box.Render(lipgloss.JoinVertical(lipgloss.Left, header, formView))
 }
 
+// Banner colours for the dashboard header. Every banner is the same shape — a
+// full-width bar with a coloured background — so only the palette differs.
+const (
+	bannerWarnBg    = "#FFCC00" // yellow: missing executor / notifications
+	bannerWarnFg    = "#000000"
+	bannerDangerBg  = "#E06C75" // red: global dangerous mode
+	bannerDangerFg  = "#FFFFFF"
+	bannerUpgradeBg = "#61AFEF" // blue: a newer release is available
+	bannerUpgradeFg = "#FFFFFF"
+
+	// bannerPadding is the horizontal padding inside a banner, per side.
+	bannerPadding = 2
+)
+
+// renderBanner renders one dashboard banner: a single full-width row of text on
+// a coloured background.
+//
+// Staying on one row matters. Banners sit above the kanban board, so text that
+// wraps steals rows from the board, and text wider than the terminal makes the
+// whole dashboard wider than the terminal — which the terminal then re-wraps,
+// scrambling every column of the board. Notification text is user data (task
+// titles, git and gh error output), so it is neither short nor reliably single
+// line: newlines are folded to spaces and the result is truncated to fit.
+func renderBanner(text string, bg, fg lipgloss.Color, width int) string {
+	if width <= 0 {
+		return ""
+	}
+
+	text = strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ", "\t", " ").Replace(text)
+
+	if inner := width - 2*bannerPadding; inner > 0 {
+		text = ansi.Truncate(text, inner, "…")
+	}
+
+	return lipgloss.NewStyle().
+		Background(bg).
+		Foreground(fg).
+		Bold(true).
+		Padding(0, bannerPadding).
+		Width(width).
+		MaxHeight(1).
+		Render(text)
+}
+
 func (m *AppModel) viewDashboard() string {
 	var headerParts []string
 
 	// Show warning banner if no executors are available
 	if len(m.availableExecutors) == 0 {
-		warnStyle := lipgloss.NewStyle().
-			Background(lipgloss.Color("#FFCC00")). // Yellow background
-			Foreground(lipgloss.Color("#000000")).
-			Bold(true).
-			Padding(0, 2).
-			Width(m.width)
-		headerParts = append(headerParts, warnStyle.Render(IconBlocked()+" No AI executor installed. See: https://code.claude.com/docs/en/overview"))
+		headerParts = append(headerParts, renderBanner(
+			IconBlocked()+" No AI executor installed. See: https://code.claude.com/docs/en/overview",
+			bannerWarnBg, bannerWarnFg, m.width))
 	}
 
 	// Show global dangerous mode banner if the entire system is in dangerous mode
 	if IsGlobalDangerousMode() {
-		dangerStyle := lipgloss.NewStyle().
-			Background(lipgloss.Color("#E06C75")). // Red background
-			Foreground(lipgloss.Color("#FFFFFF")).
-			Bold(true).
-			Padding(0, 2).
-			Width(m.width)
-		headerParts = append(headerParts, dangerStyle.Render(IconBlocked()+" DANGEROUS MODE ENABLED"))
+		headerParts = append(headerParts, renderBanner(
+			IconBlocked()+" DANGEROUS MODE ENABLED",
+			bannerDangerBg, bannerDangerFg, m.width))
 	}
 
 	// Show version upgrade notification
 	if m.latestRelease != nil {
-		upgradeStyle := lipgloss.NewStyle().
-			Background(lipgloss.Color("#61AFEF")). // Blue background
-			Foreground(lipgloss.Color("#FFFFFF")).
-			Bold(true).
-			Padding(0, 2).
-			Width(m.width)
-		headerParts = append(headerParts, upgradeStyle.Render(
-			fmt.Sprintf("Update available: %s → %s  (run: ty upgrade)", m.currentVersion, m.latestRelease.Version)))
+		headerParts = append(headerParts, renderBanner(
+			fmt.Sprintf("Update available: %s → %s  (run: ty upgrade)", m.currentVersion, m.latestRelease.Version),
+			bannerUpgradeBg, bannerUpgradeFg, m.width))
 	}
 
 	// Show notification banner if active
 	if m.notification != "" && time.Now().Before(m.notifyUntil) {
-		notifyStyle := lipgloss.NewStyle().
-			Background(lipgloss.Color("#FFCC00")).
-			Foreground(lipgloss.Color("#000000")).
-			Bold(true).
-			Padding(0, 2)
-		headerParts = append(headerParts, notifyStyle.Render(m.notification))
+		headerParts = append(headerParts, renderBanner(m.notification, bannerWarnBg, bannerWarnFg, m.width))
 	} else {
 		m.notification = "" // Clear expired notification
 		m.notifyTaskID = 0

--- a/internal/ui/banner_test.go
+++ b/internal/ui/banner_test.go
@@ -1,0 +1,84 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// dashboardWithNotification builds the minimum AppModel viewDashboard needs:
+// a sized kanban board and an unexpired notification.
+func dashboardWithNotification(width int, notification string) *AppModel {
+	return &AppModel{
+		width:              width,
+		height:             30,
+		kanban:             NewKanbanBoard(width, 24),
+		availableExecutors: []string{"claude"},
+		notification:       notification,
+		notifyUntil:        time.Now().Add(time.Minute),
+		keys:               LoadKeyMap(),
+	}
+}
+
+// A notification longer than the terminal used to render at its natural width,
+// which made the whole dashboard wider than the terminal: the terminal re-wrapped
+// every line and the kanban columns came apart.
+func TestNotificationBannerDoesNotWidenDashboard(t *testing.T) {
+	const width = 120
+	long := "✓ Task #12 complete: " + strings.Repeat("a very long task title ", 10) + "(g to jump)"
+
+	m := dashboardWithNotification(width, long)
+	view := m.viewDashboard()
+
+	if got := lipgloss.Width(view); got != width {
+		t.Errorf("dashboard width = %d, want %d (banner overflowed the terminal)", got, width)
+	}
+}
+
+// Notification text carries git/gh output, which is routinely multi-line. Each
+// extra row pushes the board down, so newlines are folded into the single row.
+func TestBannerFoldsNewlinesIntoOneRow(t *testing.T) {
+	banner := renderBanner("failed to push branch:\nfatal: could not read Username", bannerWarnBg, bannerWarnFg, 120)
+
+	if got := lipgloss.Height(banner); got != 1 {
+		t.Errorf("banner height = %d, want 1", got)
+	}
+	plain := stripAnsiCodes(banner)
+	if !strings.Contains(plain, "failed to push branch: fatal: could not read Username") {
+		t.Errorf("newline was not folded to a space: %q", plain)
+	}
+}
+
+func TestBannerFillsTerminalWidth(t *testing.T) {
+	for _, width := range []int{40, 80, 120} {
+		banner := renderBanner("✓ Task #12 complete", bannerWarnBg, bannerWarnFg, width)
+		if got := lipgloss.Width(banner); got != width {
+			t.Errorf("banner width at terminal %d = %d, want %d", width, got, width)
+		}
+	}
+}
+
+// Truncation keeps the banner on one row and marks that text was cut.
+func TestBannerTruncatesWithEllipsis(t *testing.T) {
+	banner := renderBanner(strings.Repeat("x", 200), bannerWarnBg, bannerWarnFg, 60)
+
+	if got := lipgloss.Width(banner); got != 60 {
+		t.Errorf("banner width = %d, want 60", got)
+	}
+	if got := lipgloss.Height(banner); got != 1 {
+		t.Errorf("banner height = %d, want 1", got)
+	}
+	if plain := stripAnsiCodes(banner); !strings.Contains(plain, "…") {
+		t.Errorf("truncated banner has no ellipsis: %q", plain)
+	}
+}
+
+// Before the first WindowSizeMsg the model has no width; a banner sized to it
+// would render as a stray fragment.
+func TestBannerEmptyBeforeFirstResize(t *testing.T) {
+	if got := renderBanner("anything", bannerWarnBg, bannerWarnFg, 0); got != "" {
+		t.Errorf("banner at width 0 = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Why the banner on the index/kanban view was wrong

The four dashboard banners were each styled inline. Three of them (no executor, dangerous mode, upgrade available) set `Width(m.width)`; the **notification** banner did not — it only had `Padding(0, 2)`.

So a notification longer than the terminal rendered at its *natural* width. `lipgloss.JoinVertical` sized the header to that widest row, and `lipgloss.Place` then emitted a dashboard wider than the terminal. The terminal re-wrapped every line, and the kanban columns underneath came apart.

Notification text is user data — task titles, and raw `git`/`gh` error output — so it is neither short nor reliably single-line. A multi-line notification also stole rows from the board.

## What changed

A single `renderBanner(text, bg, fg, width)` helper replaces the four duplicated style blocks. It:

- folds `\r\n`, `\r`, `\n`, `\t` to spaces, so a multi-line notification stays one row
- truncates to the terminal width with an ellipsis (`ansi.Truncate`, so escape sequences and wide runes are counted correctly)
- pins `Width(width)` and `MaxHeight(1)`
- returns `""` at width 0, i.e. before the first `WindowSizeMsg`, instead of a stray fragment

`viewDashboard` already measures the rendered header height to size the board, so one-row banners keep the kanban layout correct.

## Tests

New `internal/ui/banner_test.go`:

- `TestNotificationBannerDoesNotWidenDashboard` — the regression: a long notification through the real `viewDashboard`, asserting the dashboard is exactly the terminal width
- `TestBannerFoldsNewlinesIntoOneRow` — multi-line git error stays one row, newline becomes a space
- `TestBannerFillsTerminalWidth` — at 40/80/120 columns
- `TestBannerTruncatesWithEllipsis`
- `TestBannerEmptyBeforeFirstResize`

`go build ./...`, `go vet`, and the full `internal/ui` package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fXTWxfbxg95vEgujxej23