### PR TITLE
feat(ty): detail-view shortcuts for copying the task id and opening a terminal

### DIFF
--- a/desktop/capabilities.json
+++ b/desktop/capabilities.json
@@ -30,6 +30,9 @@
     "CommandPalette": {
       "note": "p, f, \u2318P \u2014 cmdk palette"
     },
+    "CopyTaskID": {
+      "note": "y \u2014 copies the bare task number to the clipboard"
+    },
     "Delete": {
       "api": [
         "DELETE /api/tasks/{id}"

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -232,6 +232,8 @@ export default function App() {
                 void store.deleteTask(task.id);
               },
             });
+          case "y":
+            return void store.copyTaskId(task.id);
           case "t":
             return void store.pinTask(task.id);
           case "S":

--- a/desktop/src/store.ts
+++ b/desktop/src/store.ts
@@ -249,6 +249,20 @@ class Store {
     this.set({ theme });
   }
 
+  /** Copies the bare task number, which is what `ty` commands take as an argument. */
+  async copyTaskId(id: number) {
+    try {
+      await navigator.clipboard.writeText(String(id));
+      this.toast({ title: `Copied task #${id}`, kind: "success" });
+    } catch (err) {
+      this.toast({
+        title: "Could not copy task ID",
+        body: err instanceof Error ? err.message : String(err),
+        kind: "error",
+      });
+    }
+  }
+
   // --- Toasts (sonner) ---
 
   toast(toast: Toast) {

--- a/extensions/ty-qmd/cmd/main.go
+++ b/extensions/ty-qmd/cmd/main.go
@@ -32,11 +32,11 @@ type Config struct {
 		CLI string `yaml:"cli"`
 	} `yaml:"taskyou"`
 	Sync struct {
-		Auto         bool          `yaml:"auto"`
-		Interval     time.Duration `yaml:"interval"`
-		Statuses     []string      `yaml:"statuses"`
-		IncludeLogs  bool          `yaml:"include_logs"`
-		MaxLogLines  int           `yaml:"max_log_lines"`
+		Auto        bool          `yaml:"auto"`
+		Interval    time.Duration `yaml:"interval"`
+		Statuses    []string      `yaml:"statuses"`
+		IncludeLogs bool          `yaml:"include_logs"`
+		MaxLogLines int           `yaml:"max_log_lines"`
 	} `yaml:"sync"`
 	Collections struct {
 		Tasks    string            `yaml:"tasks"`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bborn/workflow
 go 1.25.0
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
@@ -22,7 +23,6 @@ require (
 require (
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -53,6 +53,8 @@ type KeybindingsConfig struct {
 	CollapseDone       *KeybindingConfig `yaml:"collapse_done,omitempty"`
 	OpenBrowser        *KeybindingConfig `yaml:"open_browser,omitempty"`
 	OpenPR             *KeybindingConfig `yaml:"open_pr,omitempty"`
+	CopyTaskID         *KeybindingConfig `yaml:"copy_task_id,omitempty"`
+	OpenTerminal       *KeybindingConfig `yaml:"open_terminal,omitempty"`
 }
 
 // DefaultKeybindingsConfigPath returns the default path for the keybindings config file.
@@ -258,5 +260,14 @@ open_browser:
 open_pr:
   keys: ["G"]
   help: "open PR"
+
+# Detail-view shortcuts
+copy_task_id:
+  keys: ["y"]
+  help: "copy id"
+
+open_terminal:
+  keys: ["T"]
+  help: "terminal"
 `
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -7,9 +7,11 @@ import (
 	osExec "os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -98,6 +100,9 @@ type KeyMap struct {
 	OpenBrowser key.Binding
 	// Open PR
 	OpenPR key.Binding
+	// Detail-view shortcuts
+	CopyTaskID   key.Binding
+	OpenTerminal key.Binding
 }
 
 // ShortHelp returns key bindings to show in the mini help.
@@ -270,6 +275,14 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("G"),
 			key.WithHelp("G", "open PR"),
 		),
+		CopyTaskID: key.NewBinding(
+			key.WithKeys("y"),
+			key.WithHelp("y", "copy id"),
+		),
+		OpenTerminal: key.NewBinding(
+			key.WithKeys("T"),
+			key.WithHelp("T", "terminal"),
+		),
 	}
 }
 
@@ -334,6 +347,8 @@ func ApplyKeybindingsConfig(km KeyMap, cfg *config.KeybindingsConfig) KeyMap {
 	km.CollapseDone = applyBinding(km.CollapseDone, cfg.CollapseDone)
 	km.OpenBrowser = applyBinding(km.OpenBrowser, cfg.OpenBrowser)
 	km.OpenPR = applyBinding(km.OpenPR, cfg.OpenPR)
+	km.CopyTaskID = applyBinding(km.CopyTaskID, cfg.CopyTaskID)
+	km.OpenTerminal = applyBinding(km.OpenTerminal, cfg.OpenTerminal)
 
 	return km
 }
@@ -1309,6 +1324,24 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notifyUntil = time.Now().Add(5 * time.Second)
 		} else if msg.message != "" {
 			m.notification = fmt.Sprintf("🌐 %s", msg.message)
+			m.notifyUntil = time.Now().Add(3 * time.Second)
+		}
+
+	case taskIDCopiedMsg:
+		if msg.err != nil {
+			m.notification = fmt.Sprintf("%s Failed to copy task ID: %s", IconBlocked(), msg.err.Error())
+			m.notifyUntil = time.Now().Add(5 * time.Second)
+		} else {
+			m.notification = fmt.Sprintf("📋 Copied task #%d", msg.id)
+			m.notifyUntil = time.Now().Add(3 * time.Second)
+		}
+
+	case terminalOpenedMsg:
+		if msg.err != nil {
+			m.notification = fmt.Sprintf("%s %s", IconBlocked(), msg.err.Error())
+			m.notifyUntil = time.Now().Add(5 * time.Second)
+		} else if msg.message != "" {
+			m.notification = fmt.Sprintf("🖥  %s", msg.message)
 			m.notifyUntil = time.Now().Add(3 * time.Second)
 		}
 
@@ -2584,6 +2617,12 @@ func (m *AppModel) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	if key.Matches(keyMsg, m.keys.OpenPR) && m.selectedTask != nil && m.selectedTask.PRURL != "" {
 		return m, m.openPR(m.selectedTask)
+	}
+	if key.Matches(keyMsg, m.keys.CopyTaskID) && m.selectedTask != nil {
+		return m, m.copyTaskID(m.selectedTask)
+	}
+	if key.Matches(keyMsg, m.keys.OpenTerminal) && m.selectedTask != nil {
+		return m, m.openTerminal(m.selectedTask)
 	}
 	if key.Matches(keyMsg, m.keys.ToggleShellPane) && m.detailView != nil {
 		m.detailView.ToggleShellPane()
@@ -4493,6 +4532,83 @@ func (m *AppModel) openTaskDirectory(task *db.Task) tea.Cmd {
 
 		return browserOpenedMsg{message: fmt.Sprintf("Opened %s in Finder", filepath.Base(task.WorktreePath))}
 	}
+}
+
+// taskIDCopiedMsg is returned after attempting to copy a task ID to the clipboard.
+type taskIDCopiedMsg struct {
+	id  int64
+	err error
+}
+
+// copyTaskID copies the task's numeric ID to the system clipboard. The plain
+// number (no "#") is what the `ty` CLI and MCP tools expect, so it can be pasted
+// straight into commands like `ty task <id>`.
+func (m *AppModel) copyTaskID(task *db.Task) tea.Cmd {
+	return func() tea.Msg {
+		if err := clipboard.WriteAll(strconv.FormatInt(task.ID, 10)); err != nil {
+			return taskIDCopiedMsg{id: task.ID, err: err}
+		}
+		return taskIDCopiedMsg{id: task.ID}
+	}
+}
+
+// terminalOpenedMsg is returned after attempting to open a terminal in the
+// task's working directory.
+type terminalOpenedMsg struct {
+	message string
+	err     error
+}
+
+// taskWorkdir resolves the directory a terminal should open in: the task's
+// worktree if it has one, otherwise the project directory. Returns "" when
+// neither is known.
+func (m *AppModel) taskWorkdir(task *db.Task) string {
+	if task.WorktreePath != "" {
+		return task.WorktreePath
+	}
+	if task.Project != "" && m.executor != nil {
+		if dir := m.executor.GetProjectDir(task.Project); dir != "" {
+			return dir
+		}
+	}
+	return ""
+}
+
+// openTerminal opens a new terminal tab in the task's working directory, in
+// whichever terminal application ty is being displayed in.
+func (m *AppModel) openTerminal(task *db.Task) tea.Cmd {
+	return func() tea.Msg {
+		workdir := m.taskWorkdir(task)
+		if workdir == "" {
+			return terminalOpenedMsg{err: fmt.Errorf("no working directory for task #%d", task.ID)}
+		}
+		if _, err := os.Stat(workdir); err != nil {
+			return terminalOpenedMsg{err: fmt.Errorf("directory not found: %s", workdir)}
+		}
+
+		app := detectTerminalApp()
+		cmd := buildTerminalCommand(app, workdir)
+		// Both osascript and open return once the new tab exists, so their exit
+		// status is a real answer rather than a launch acknowledgement.
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return terminalOpenedMsg{err: fmt.Errorf("failed to open terminal: %s", terminalFailure(out, err))}
+		}
+
+		name := app
+		if name == "" {
+			name = "terminal"
+		}
+		return terminalOpenedMsg{message: fmt.Sprintf("Opened %s tab in %s", name, filepath.Base(workdir))}
+	}
+}
+
+// terminalFailure prefers the message osascript printed over Go's exit-status
+// error, which on its own says nothing about what went wrong.
+func terminalFailure(out []byte, err error) string {
+	if msg := strings.TrimSpace(string(out)); msg != "" {
+		return msg
+	}
+	return err.Error()
 }
 
 // resolveEditor returns the user's configured editor: VISUAL, then EDITOR.

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -3247,6 +3247,13 @@ func (m *DetailModel) renderContent() string {
 	return content
 }
 
+// helpSeparatorWidth is the gap rendered between two help-row entries.
+const helpSeparatorWidth = 2
+
+// defaultHelpWidth is the width the help row assumes before the first
+// WindowSizeMsg tells it how wide the terminal really is.
+const defaultHelpWidth = 80
+
 func (m *DetailModel) renderHelp() string {
 	type helpKey struct {
 		key      string
@@ -3328,43 +3335,90 @@ func (m *DetailModel) renderHelp() string {
 	}
 	keys = append(keys, []helpKey{
 		{"b", browserLabel, false, false},
+		{"y", "copy id", false, false},
+		{"T", "terminal", false, false},
 		{"c", "close", false, false},
 		{"a", "archive", false, false},
 		{"d", "delete", false, false},
 		{"esc", "back", false, true},
 	}...)
 
-	var help string
 	dimmedKeyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280"))
 	dimmedDescStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#4B5563"))
-
-	rendered := 0
-	for _, k := range keys {
-		// When collapsed, only the primary keys are shown.
-		if !m.helpExpanded && !k.primary {
-			continue
-		}
-		if rendered > 0 {
-			help += "  "
-		}
-		// Disabled keys are always dimmed, regardless of focus
-		if k.disabled || !m.focused {
-			help += dimmedKeyStyle.Render(k.key) + " " + dimmedDescStyle.Render(k.desc)
-		} else {
-			help += HelpKey.Render(k.key) + " " + HelpDesc.Render(k.desc)
-		}
-		rendered++
-	}
 
 	// Trailing '?' affordance to expand/collapse the rest.
 	moreDesc := "more"
 	if m.helpExpanded {
 		moreDesc = "less"
 	}
-	if rendered > 0 {
+	moreSeg := dimmedKeyStyle.Render("?") + " " + dimmedDescStyle.Render(moreDesc)
+
+	// Render each key into its own segment first, so we can measure the row
+	// before committing to it.
+	type helpSegment struct {
+		text    string
+		width   int
+		primary bool
+	}
+	var segments []helpSegment
+	for _, k := range keys {
+		// When collapsed, only the primary keys are shown.
+		if !m.helpExpanded && !k.primary {
+			continue
+		}
+		// Disabled keys are always dimmed, regardless of focus
+		var text string
+		if k.disabled || !m.focused {
+			text = dimmedKeyStyle.Render(k.key) + " " + dimmedDescStyle.Render(k.desc)
+		} else {
+			text = HelpKey.Render(k.key) + " " + HelpDesc.Render(k.desc)
+		}
+		segments = append(segments, helpSegment{text: text, width: lipgloss.Width(text), primary: k.primary})
+	}
+
+	// The row is a single line, so anything past the terminal width is clipped
+	// mid-word — and the tail is where 'esc back' and the '?' affordance live.
+	// Budget the width instead and drop whole secondary keys that do not fit.
+	// Primary keys and '?' are always drawn: they are the ones a user needs to
+	// get back out of the view.
+	budget := m.width
+	if budget <= 0 {
+		budget = defaultHelpWidth
+	}
+	budget -= lipgloss.Width(moreSeg) + helpSeparatorWidth
+
+	// Width the primary keys still ahead of us will need, so a secondary key
+	// never eats the room reserved for them.
+	reserved := 0
+	for _, seg := range segments {
+		if seg.primary {
+			reserved += seg.width + helpSeparatorWidth
+		}
+	}
+
+	var help string
+	used := 0
+	for _, seg := range segments {
+		cost := seg.width
+		if help != "" {
+			cost += helpSeparatorWidth
+		}
+		if seg.primary {
+			reserved -= seg.width + helpSeparatorWidth
+		} else if used+cost+reserved > budget {
+			continue
+		}
+		if help != "" {
+			help += "  "
+		}
+		help += seg.text
+		used += cost
+	}
+
+	if help != "" {
 		help += "  "
 	}
-	help += dimmedKeyStyle.Render("?") + " " + dimmedDescStyle.Render(moreDesc)
+	help += moreSeg
 
 	return HelpBar.Render(help)
 }

--- a/internal/ui/detail_help_test.go
+++ b/internal/ui/detail_help_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/bborn/workflow/internal/db"
+)
+
+// helpRowTask is a task in the state that produces the widest detail help row:
+// nothing is running, so execute, retry and the rest are all offered.
+func helpRowModel(width int, expanded bool) *DetailModel {
+	return &DetailModel{
+		task:          &db.Task{ID: 4873, Title: "Apple Pay express checkout"},
+		width:         width,
+		helpExpanded:  expanded,
+		focused:       true,
+		totalInColumn: 4,
+	}
+}
+
+func TestDetailHelpRowFitsTerminalWidth(t *testing.T) {
+	// 152 is a common full-screen iTerm width; 80 is the classic terminal floor.
+	for _, width := range []int{200, 152, 100, 80} {
+		t.Run(strconv.Itoa(width), func(t *testing.T) {
+			got := lipgloss.Width(helpRowModel(width, true).renderHelp())
+			if got > width {
+				t.Errorf("expanded help row is %d columns wide, want <= %d", got, width)
+			}
+		})
+	}
+}
+
+func TestDetailHelpRowAlwaysKeepsTheWayOut(t *testing.T) {
+	// Whatever gets dropped, the keys that leave the view must survive: 'esc'
+	// closes the detail view and '?' collapses the row again.
+	for _, width := range []int{200, 152, 100, 80, 40} { //nolint:gocritic // 40 is below the floor on purpose
+		t.Run(strconv.Itoa(width), func(t *testing.T) {
+			help := helpRowModel(width, true).renderHelp()
+			for _, want := range []string{"back", "less"} {
+				if !strings.Contains(help, want) {
+					t.Errorf("width %d: help row lost %q: %s", width, want, help)
+				}
+			}
+		})
+	}
+}
+
+func TestDetailHelpRowShowsNewShortcutsAtNormalWidth(t *testing.T) {
+	help := helpRowModel(152, true).renderHelp()
+	for _, want := range []string{"copy id", "terminal"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("help row is missing %q: %s", want, help)
+		}
+	}
+}
+
+func TestDetailHelpRowCollapsedIsShort(t *testing.T) {
+	help := helpRowModel(152, false).renderHelp()
+	if strings.Contains(help, "copy id") {
+		t.Error("collapsed help row should not list secondary keys")
+	}
+	if !strings.Contains(help, "more") {
+		t.Error("collapsed help row should offer '? more'")
+	}
+}
+
+func TestDetailHelpRowFloorIsThePrimaryKeys(t *testing.T) {
+	// Primary keys are never dropped, so they set a floor the row cannot go
+	// under. Narrower than that and the terminal clips, as it always has; the
+	// detail view's bordered box is unusable at that size anyway. This test
+	// pins the floor so a future primary key is a deliberate choice.
+	help := helpRowModel(40, true).renderHelp()
+
+	if strings.Contains(help, "copy id") || strings.Contains(help, "archive") {
+		t.Errorf("secondary keys should be dropped well before 40 columns: %s", help)
+	}
+	for _, want := range []string{"execute", "edit", "status", "back", "less"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("primary key %q should survive any width: %s", want, help)
+		}
+	}
+}

--- a/internal/ui/terminal_open.go
+++ b/internal/ui/terminal_open.go
@@ -1,0 +1,228 @@
+package ui
+
+import (
+	"os"
+	osExec "os/exec"
+	"strconv"
+	"strings"
+)
+
+// terminalApps maps a fragment of $TERM_PROGRAM, or of the executable path of a
+// process that owns our tty, to the macOS application name that opens it.
+var terminalApps = []struct {
+	match string // lowercase substring to look for
+	app   string // macOS application name
+}{
+	{"iterm", "iTerm"},
+	{"apple_terminal", "Terminal"},
+	{"terminal.app", "Terminal"},
+	{"ghostty", "Ghostty"},
+	{"wezterm", "WezTerm"},
+	{"kitty", "kitty"},
+	{"alacritty", "Alacritty"},
+	{"hyper", "Hyper"},
+}
+
+// matchTerminalApp returns the application name for a $TERM_PROGRAM value or an
+// executable path, or "" when it names no terminal we recognise.
+func matchTerminalApp(s string) string {
+	s = strings.ToLower(s)
+	for _, t := range terminalApps {
+		if strings.Contains(s, t.match) {
+			return t.app
+		}
+	}
+	return ""
+}
+
+// detectTerminalApp returns the terminal application ty is displayed in.
+// $TERM_PROGRAM answers this directly, except inside tmux, where it reads
+// "tmux" and hides the real terminal; there we walk up from the tty of the tmux
+// client showing our pane until we reach the process that owns it.
+func detectTerminalApp() string {
+	if app := matchTerminalApp(os.Getenv("TERM_PROGRAM")); app != "" {
+		return app
+	}
+	if os.Getenv("TMUX") == "" {
+		return ""
+	}
+	return terminalOwningTmuxClient()
+}
+
+// tmuxClientTTY returns the tty of the tmux client displaying our own pane.
+// It asks about $TMUX_PANE rather than the "current" pane, which is racy when
+// several clients are attached to the same session.
+func tmuxClientTTY() string {
+	args := []string{"display-message", "-p"}
+	if pane := os.Getenv("TMUX_PANE"); pane != "" {
+		args = append(args, "-t", pane)
+	}
+	args = append(args, "#{client_tty}")
+	out, err := osExec.Command("tmux", args...).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// procInfo is one row of the process table: a parent pid and an executable path.
+type procInfo struct {
+	ppid int
+	comm string
+}
+
+// parseProcessTable reads `ps -axo pid=,ppid=,comm=` output into pid -> parent
+// and executable path. Executable paths contain spaces (macOS app bundles live
+// under "Application Support"), so only the first two fields are split off.
+func parseProcessTable(psOutput string) map[int]procInfo {
+	table := make(map[int]procInfo)
+	for _, line := range strings.Split(psOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pidStr, rest, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		ppidStr, comm, ok := strings.Cut(strings.TrimLeft(rest, " "), " ")
+		if !ok {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		ppid, err := strconv.Atoi(ppidStr)
+		if err != nil {
+			continue
+		}
+		table[pid] = procInfo{ppid: ppid, comm: strings.TrimLeft(comm, " ")}
+	}
+	return table
+}
+
+// parsePIDList reads a column of pids, one per line, as `ps -t <tty> -o pid=`
+// prints them.
+func parsePIDList(psOutput string) []int {
+	var pids []int
+	for _, line := range strings.Split(psOutput, "\n") {
+		pid, err := strconv.Atoi(strings.TrimSpace(line))
+		if err != nil {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// maxAncestorHops bounds the walk up the process tree so a cycle or a very deep
+// chain cannot spin.
+const maxAncestorHops = 12
+
+// terminalInAncestry walks each starting pid up through its parents and returns
+// the first terminal application named along the way.
+func terminalInAncestry(pids []int, table map[int]procInfo) string {
+	for _, start := range pids {
+		pid := start
+		for hop := 0; hop < maxAncestorHops; hop++ {
+			info, ok := table[pid]
+			if !ok {
+				break
+			}
+			if app := matchTerminalApp(info.comm); app != "" {
+				return app
+			}
+			if info.ppid <= 1 {
+				break
+			}
+			pid = info.ppid
+		}
+	}
+	return ""
+}
+
+// terminalOwningTmuxClient identifies the terminal application that is drawing
+// the tmux client we are displayed in. Our own parent chain is useless here: it
+// leads to the tmux server, which is detached from every terminal.
+func terminalOwningTmuxClient() string {
+	tty := tmuxClientTTY()
+	if tty == "" {
+		return ""
+	}
+	ttyOut, err := osExec.Command("ps", "-t", tty, "-o", "pid=").Output()
+	if err != nil {
+		return ""
+	}
+	pids := parsePIDList(string(ttyOut))
+	if len(pids) == 0 {
+		return ""
+	}
+	psOut, err := osExec.Command("ps", "-axo", "pid=,ppid=,comm=").Output()
+	if err != nil {
+		return ""
+	}
+	return terminalInAncestry(pids, parseProcessTable(string(psOut)))
+}
+
+// shellSingleQuote wraps s so a POSIX shell reads it as one literal word.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// appleScriptQuote renders s as an AppleScript string literal.
+func appleScriptQuote(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+// iTermNewTabScript opens a tab in iTerm2's front window and changes to workdir.
+// The tab keeps the user's default profile, so it runs whatever login shell they
+// normally get; we only send it a cd. iTerm2 selects a tab as it creates it, so
+// the user lands in the new tab. With no window open there is nothing to add a
+// tab to, so we create a window instead.
+func iTermNewTabScript(workdir string) string {
+	cd := appleScriptQuote("cd " + shellSingleQuote(workdir))
+	return `tell application "iTerm2"
+  activate
+  set w to current window
+  if w is missing value then
+    set w to (create window with default profile)
+    tell current session of w to write text ` + cd + `
+  else
+    tell w
+      create tab with default profile
+      tell current session to write text ` + cd + `
+    end tell
+  end if
+end tell`
+}
+
+// appleTerminalNewWindowScript opens Terminal.app at workdir. Terminal.app has
+// no scriptable "new tab", so this is a window.
+func appleTerminalNewWindowScript(workdir string) string {
+	cd := appleScriptQuote("cd " + shellSingleQuote(workdir))
+	return `tell application "Terminal"
+  activate
+  do script ` + cd + `
+end tell`
+}
+
+// buildTerminalCommand returns the command that opens a new terminal at workdir
+// in the given application. iTerm2 and Terminal.app are scripted directly so the
+// new surface is a tab in the window the user is already looking at; anything
+// else is handed to LaunchServices, which opens it at that directory.
+func buildTerminalCommand(app, workdir string) *osExec.Cmd {
+	switch app {
+	case "iTerm":
+		return osExec.Command("osascript", "-e", iTermNewTabScript(workdir))
+	case "Terminal":
+		return osExec.Command("osascript", "-e", appleTerminalNewWindowScript(workdir))
+	case "":
+		// Nothing recognised, so fall back to the terminal every Mac has.
+		return osExec.Command("open", "-a", "Terminal", workdir)
+	default:
+		return osExec.Command("open", "-a", app, workdir)
+	}
+}

--- a/internal/ui/terminal_open_test.go
+++ b/internal/ui/terminal_open_test.go
@@ -1,0 +1,201 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMatchTerminalApp(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"term_program from iTerm", "iTerm.app", "iTerm"},
+		{"iTerm restoration server path", "/Users/x/Library/Application Support/iTerm2/iTermServer-3.6.6", "iTerm"},
+		{"term_program from Terminal.app", "Apple_Terminal", "Terminal"},
+		{"Terminal.app executable path", "/System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal", "Terminal"},
+		{"ghostty", "ghostty", "Ghostty"},
+		{"tmux is not a terminal", "tmux", ""},
+		{"empty", "", ""},
+		{"unrelated process", "/usr/bin/login", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchTerminalApp(tt.input); got != tt.want {
+				t.Errorf("matchTerminalApp(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// psSample is the shape `ps -axo pid=,ppid=,comm=` prints on macOS. The iTerm
+// row matters most: its path contains spaces, so a naive field split loses it.
+const psSample = `  9684 19536 ty
+ 19536 19534 -zsh
+ 19534  2187 /usr/bin/login
+  2187     1 /Users/bruno/Library/Application Support/iTerm2/iTermServer-3.6.6
+     1     0 /sbin/launchd
+`
+
+func TestParseProcessTableKeepsPathsWithSpaces(t *testing.T) {
+	table := parseProcessTable(psSample)
+
+	if len(table) != 5 {
+		t.Fatalf("parsed %d rows, want 5", len(table))
+	}
+	got, ok := table[2187]
+	if !ok {
+		t.Fatal("pid 2187 missing from table")
+	}
+	if got.ppid != 1 {
+		t.Errorf("ppid = %d, want 1", got.ppid)
+	}
+	want := "/Users/bruno/Library/Application Support/iTerm2/iTermServer-3.6.6"
+	if got.comm != want {
+		t.Errorf("comm = %q, want %q", got.comm, want)
+	}
+}
+
+func TestParseProcessTableSkipsGarbage(t *testing.T) {
+	table := parseProcessTable("\nnot a row\n  12 nope\n  42 7 /bin/sh\n")
+	if len(table) != 1 {
+		t.Fatalf("parsed %d rows, want 1", len(table))
+	}
+	if table[42].comm != "/bin/sh" {
+		t.Errorf("comm = %q, want /bin/sh", table[42].comm)
+	}
+}
+
+func TestParsePIDList(t *testing.T) {
+	got := parsePIDList("  9684\n 19536\n\nbogus\n 19534\n")
+	want := []int{9684, 19536, 19534}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestTerminalInAncestryWalksPastShellAndLogin(t *testing.T) {
+	table := parseProcessTable(psSample)
+	// Start where ps -t <tty> starts us: the process running on the client tty.
+	if got := terminalInAncestry([]int{9684}, table); got != "iTerm" {
+		t.Errorf("terminalInAncestry = %q, want iTerm", got)
+	}
+}
+
+func TestTerminalInAncestryNoTerminal(t *testing.T) {
+	table := parseProcessTable("  42 7 /bin/sh\n   7 1 /usr/bin/login\n")
+	if got := terminalInAncestry([]int{42}, table); got != "" {
+		t.Errorf("terminalInAncestry = %q, want empty", got)
+	}
+}
+
+func TestTerminalInAncestryStopsOnCycle(t *testing.T) {
+	// A parent cycle must not spin; the hop bound ends the walk.
+	table := map[int]procInfo{
+		10: {ppid: 11, comm: "/bin/a"},
+		11: {ppid: 10, comm: "/bin/b"},
+	}
+	if got := terminalInAncestry([]int{10}, table); got != "" {
+		t.Errorf("terminalInAncestry = %q, want empty", got)
+	}
+}
+
+func TestShellSingleQuote(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"/tmp/plain", "'/tmp/plain'"},
+		{"/tmp/with space", "'/tmp/with space'"},
+		{"/tmp/it's", `'/tmp/it'\''s'`},
+	}
+	for _, tt := range tests {
+		if got := shellSingleQuote(tt.in); got != tt.want {
+			t.Errorf("shellSingleQuote(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestAppleScriptQuote(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{`plain`, `"plain"`},
+		{`say "hi"`, `"say \"hi\""`},
+		{`back\slash`, `"back\\slash"`},
+	}
+	for _, tt := range tests {
+		if got := appleScriptQuote(tt.in); got != tt.want {
+			t.Errorf("appleScriptQuote(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestITermNewTabScriptQuotesAwkwardPaths(t *testing.T) {
+	script := iTermNewTabScript(`/tmp/a dir/it's "quoted"`)
+
+	// The cd must survive both layers: a shell-safe word inside an AppleScript
+	// string literal. An unescaped quote here would end the literal early and
+	// make osascript fail to compile the script.
+	wantCd := `"cd '/tmp/a dir/it'\\''s \"quoted\"'"`
+	if !strings.Contains(script, wantCd) {
+		t.Errorf("script does not contain %s\ngot:\n%s", wantCd, script)
+	}
+	if !strings.Contains(script, "create tab with default profile") {
+		t.Error("script does not create a tab")
+	}
+}
+
+func TestBuildTerminalCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		app      string
+		wantArgv []string // nil means "check the program only"
+		wantProg string
+	}{
+		{name: "iTerm is scripted", app: "iTerm", wantProg: "osascript"},
+		{name: "Terminal is scripted", app: "Terminal", wantProg: "osascript"},
+		{
+			name:     "unknown terminal goes through open",
+			app:      "Ghostty",
+			wantProg: "open",
+			wantArgv: []string{"open", "-a", "Ghostty", "/tmp/work"},
+		},
+		{
+			name:     "undetected falls back to Terminal",
+			app:      "",
+			wantProg: "open",
+			wantArgv: []string{"open", "-a", "Terminal", "/tmp/work"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := buildTerminalCommand(tt.app, "/tmp/work")
+			if !strings.HasSuffix(cmd.Path, tt.wantProg) {
+				t.Errorf("program = %q, want %q", cmd.Path, tt.wantProg)
+			}
+			if tt.wantArgv == nil {
+				return
+			}
+			if len(cmd.Args) != len(tt.wantArgv) {
+				t.Fatalf("args = %v, want %v", cmd.Args, tt.wantArgv)
+			}
+			for i := range tt.wantArgv {
+				if cmd.Args[i] != tt.wantArgv[i] {
+					t.Fatalf("args = %v, want %v", cmd.Args, tt.wantArgv)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTerminalCommandScriptMentionsWorkdir(t *testing.T) {
+	cmd := buildTerminalCommand("iTerm", "/tmp/work")
+	if len(cmd.Args) != 3 || cmd.Args[1] != "-e" {
+		t.Fatalf("expected osascript -e <script>, got %v", cmd.Args)
+	}
+	if !strings.Contains(cmd.Args[2], "/tmp/work") {
+		t.Errorf("script does not mention the workdir: %s", cmd.Args[2])
+	}
+}

--- a/parity-ignore.json
+++ b/parity-ignore.json
@@ -1,1 +1,3 @@
-{}
+{
+  "OpenTerminal": "Opens a tab in the user's own terminal application (iTerm2, Terminal.app) at the task's worktree. The desktop GUI is not a terminal and does not script the user's terminal, so there is nothing to open a tab in."
+}


### PR DESCRIPTION
Two shortcuts in the task detail view, plus a fix for the help row they exposed.

## `y` — copy the task id

Copies the bare number (`4873`, no `#`), which is what `ty` subcommands take as
an argument, so it pastes straight into `ty task 4873` or into a prompt for
another agent.

## `T` — open a terminal at the task's directory

Opens a new tab in the terminal application you are actually looking at, at the
task's worktree, falling back to the project directory when there is no
worktree. iTerm2 and Terminal.app are scripted directly so the new surface is a
tab in the window already on screen. Other terminals are handed to
LaunchServices.

Finding the terminal is the fiddly part. Inside tmux `$TERM_PROGRAM` reads
`tmux` and hides the real one, so we walk up from the tty of the tmux client
showing our own pane until we reach the process that owns it. On a Mac running
tmux inside iTerm2 that resolves through the login shell to iTerm's restoration
server, verified live.

## Help row: budget the width instead of clipping

The detail help row is a single line with no wrapping, so anything past the
terminal width is clipped mid-word, and the tail is where `esc back` and the `?`
affordance live. Two more entries pushed the row from 149 to 172 columns, which
runs off a 152-wide terminal.

The row now measures itself and drops whole secondary keys that do not fit.
Primary keys and `?` are always drawn, so there is always a way back out of the
view. Primary keys set a floor of about 65 columns, which a test pins.

### Before, rendered pre-fix: clipped mid-word at `esc bac`

![before](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-09-12/4873-4873-before-clipped.png)

### After, at 152 columns: the whole row fits

![after](https://pub-e209f789a78e432384c9a13a5d956e7c.r2.dev/taskyou-qa/2026-09-12/4873-4873-after-fits.png)

## GUI parity

`y` is wired into the desktop app as well, so `desktop/capabilities.json` covers
it. `T` is listed in `parity-ignore.json` with a reason: the desktop app is not
a terminal and has nothing to open a tab in.

## Testing

`go test ./internal/ui/ ./internal/config/ ./internal/parity/` passes. New tests
cover terminal detection, the process-tree walk, the two layers of quoting that
carry a path into an AppleScript string, and the help row's width budget at
several terminal widths. Each was checked against a deliberately broken
implementation to confirm it fails.

Screenshots come from the isolated QA harness (`scripts/qa/ty-qa-shoot.sh`), not
the live daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrrLve4gUyq9WmuBGSkaVs